### PR TITLE
Fix if condition

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 BUILDDIR="build"
-if [ -z $1 ]; then
+if [ -n "$1" ]; then
     BUILDDIR=$1
 fi
 


### PR DESCRIPTION
The -z option returns true if string length is 0 so that use -n
option to check $1's length is more than 0. Then set $1 to BUILDDIR.