### PR TITLE
follow poky's LAYERSERIES_COMPAT update

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,7 +5,7 @@ BBFILE_COLLECTIONS += "emlinux"
 BBFILE_PATTERN_emlinux = ""
 BBFILE_PRIORITY_emlinux = "10"
 
-LAYERSERIES_COMPAT_emlinux = "thud"
+LAYERSERIES_COMPAT_emlinux = "warrior"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers


### PR DESCRIPTION
You can build core-image-minimal as follows:

```
mkdir emlinux
cd emlinux/
mkdir repos

git clone -b pr-follow-warrior-1 https://github.com/hiraku-wfs/meta-emlinux repos/meta-emlinux
cd repos/meta-emlinux
git checkout 92d401fdf88b45d004bdd370a7bc9754517dcd82
cd -

git clone -b pr-follow-warrior-1 https://github.com/hiraku-wfs/meta-debian-extended repos/meta-debian-extended
cd repos/meta-debian-extended
git checkout 2bd1b9911bce2927bb687f7783dcb0cacc78dc31
cd -

git clone -b master https://github.com/meta-debian/meta-debian repos/meta-debian
cd repos/meta-debian
git checkout 2f874f33eeeda07c2ca467d263cf0fc740bb46c2
cd -

git clone -b master https://git.yoctoproject.org/git/poky repos/poky
cd repos/poky
git checkout ffac131f1f03dd26ff65dd32918e940350e5e305
cd -

SYNC_POKY=0 source repos/meta-emlinux/scripts/setup-emlinux build
echo "MACHINE = \"qemuarm64\"" >> conf/local.conf
bitbake core-image-minimal
```
