### PR TITLE
Fix bash scripting error when SYNC_POKY is not set

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -28,7 +28,7 @@ if [ ! -d ${REPOS}/meta-debian-extended ]; then
 	${REPOS}/meta-debian-extended
 fi
 
-if [ "$SYNC_POKY" -eq "1" ]; then
+if [[ "$SYNC_POKY" -eq "1" ]]; then
     POKY_REV=$(grep "^POKY_REV :=" ${REPOS}/meta-debian/docker/Makefile \
 		      | sed -r 's/^POKY_REV := (\S*)$/\1/')
     cd $REPOS/poky


### PR DESCRIPTION
If SYNC_POKY is not set, -eq operator compares emptry string and numric.
Then got following error.

+ REPOS=/home/masami/fix-bash-comp/repos
+ '[' '!' -d /home/masami/fix-bash-comp/repos/poky ']'
+ '[' '!' -d /home/masami/fix-bash-comp/repos/meta-debian ']'
+ '[' '!' -d /home/masami/fix-bash-comp/repos/meta-debian-extended ']'
+ '[' '' -eq 1 ']'
./repos/meta-emlinux/scripts/setup-emlinux: line 31: [: : integer expression expected

So, use [[ instead of [ to compare values would be good.