### PR TITLE
kernel: update to 4.19.58-cip6

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -40,7 +40,7 @@ LINUX_GIT_BRANCH = "linux-4.19.y-cip"
 #
 # LINUX_GIT_SRCREV = "${LINUX_GIT_BRANCH}"
 #
-LINUX_GIT_SRCREV ??= "5b7dee96a2b4fffe481be81edc72fd104ed047ab"
+LINUX_GIT_SRCREV ??= "2be2d3f02499e9d3a68f9e2ad1b1c4a0c42189b2"
 
 BOOTLOADER_GIT_URI ??= "git://github.com/ystk"
 BOOTLOADER_GIT_PROTOCOL ??= "https"


### PR DESCRIPTION
Regular kernel update.

arm and arm64 work fine.

arm
----------------
EMLinux 2.0 qemuarm /dev/ttyAMA0

qemuarm login: root
root@qemuarm:~# uname -a
Linux qemuarm 4.19.58-cip6 #1 SMP Mon Jul 22 07:37:37 UTC 2019 armv7l GNU/Linux

arm64
----------------
EMLinux 2.0 qemuarm64 /dev/ttyAMA0

qemuarm64 login: root
root@qemuarm64:~# uname -a
Linux qemuarm64 4.19.58-cip6 #1 SMP PREEMPT Mon Jul 22 07:02:51 UTC 2019 aarch64 GNU/Linux