### PR TITLE
weston-conf: use fbdev-backend for qemuarm{64}

### DIFF
--- a/recipes-graphics/weston/weston-conf.bbappend
+++ b/recipes-graphics/weston/weston-conf.bbappend
@@ -1,0 +1,15 @@
+do_install_qemuarm() {
+        mkdir -p ${D}/${sysconfdir}/xdg/weston
+        cat << EOF > ${D}/${sysconfdir}/xdg/weston/weston.ini
+[core]
+backend=fbdev-backend.so
+EOF
+}
+
+do_install_qemuarm64() {
+        mkdir -p ${D}/${sysconfdir}/xdg/weston
+        cat << EOF > ${D}/${sysconfdir}/xdg/weston/weston.ini
+[core]
+backend=fbdev-backend.so
+EOF
+}


### PR DESCRIPTION
This should go to the poky upstream in the future.