### PR TITLE
busybox: Add du -l test fix patch

### DIFF
--- a/recipes-debian/busybox/busybox_debian.bbappend
+++ b/recipes-debian/busybox/busybox_debian.bbappend
@@ -1,4 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI += "file://runtest-setup-resolve-conf.patch"
+SRC_URI += "file://runtest-setup-resolve-conf.patch \
+            file://0001-du-l-works-fix-to-use-145-instead-of-144.patch"
 


### PR DESCRIPTION
The emlinux use 1k block device for rootfs so it's able to adopt
0001-du-l-works-fix-to-use-145-instead-of-144.patch from poky.

The du -l test case's expectation result depends on test environment.
For example,  this patch doesn't work in meta-debian.
see https://github.com/meta-debian/meta-debian/pull/160