### PR TITLE
Add systemd to EMLINUX_DEFAULT_DISTRO_FEATURES

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -15,7 +15,7 @@ DISTRO_VERSION[vardepsexclude] = "DATE"
 SDK_VERSION[vardepsexclude] = "DATE"
 
 # Override these in poky based distros
-EMLINUX_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan"
+EMLINUX_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan systemd"
 EMLINUX_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
 
 DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${EMLINUX_DEFAULT_DISTRO_FEATURES}"


### PR DESCRIPTION
In EMLinux, eudev is used as the default udev, but we prefer to use systemd-udev
for ease of maintenance.

This commit sets the systemd-udev as default.