### PR TITLE
setup: Disable alias when run ls

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -55,7 +55,7 @@ if [ -z "$TEMPLATECONF" ] && [ "${BUILDDIR_SETUP_DONE}" = "false" ]; then
     echo "DL_DIR = \"\${TOPDIR}/../downloads\"" >> conf/local.conf
 
     if [ -d "$HOOKS" ]; then
-	for hook in $(ls $HOOKS); do
+	for hook in $(\ls $HOOKS); do
 	    source $HOOKS/$hook
 	done
     fi


### PR DESCRIPTION
Add '\' with ls command to ignore user defined alias because if
user defines ls as "ls -a", ls command result contains . and ..
then user will see following error.

-bash: source: /home/masami/release-test/setup-hooks/./: is a directory
-bash: source: /home/masami/release-test/setup-hooks/../: is a directory

In this case ignore user defined alias is quite safe.