### PR TITLE
build target: add new build target

### DIFF
--- a/recipes-core/packagegroups/packagegroup-smoketest.bb
+++ b/recipes-core/packagegroups/packagegroup-smoketest.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Package group for smoke test"
+PR = "r1"
+
+inherit packagegroup
+
+# following packages are installed by default
+# - sysvinit
+# - systemd-udev
+
+# they are required packages to run test script
+RDEPENDS_${PN} = "\
+    bash \
+    coreutils \
+"
+
+# test target packages
+# sort by package name
+RDEPENDS_${PN} += "\
+    acl \
+    attr \
+    adduser \
+    openssl \
+"

--- a/recipes-testing/images/core-image-smoketest.bb
+++ b/recipes-testing/images/core-image-smoketest.bb
@@ -1,0 +1,17 @@
+# This target use default emlinux setting
+# e.g. sysvinit as default init program, systemd-udev as udev component.
+
+SUMMARY = "Smoke test target for default emlinux setting"
+
+IMAGE_INSTALL = "packagegroup-core-boot packagegroup-smoketest ${CORE_IMAGE_EXTRA_INSTALL}"
+
+IMAGE_FEATURES += "ssh-server-dropbear"
+
+IMAGE_LINGUAS = " "
+
+LICENSE = "MIT"
+
+inherit core-image
+
+IMAGE_ROOTFS_SIZE ?= "8192"
+


### PR DESCRIPTION
Add a new build target to support run smoke test easy.
This build target includes all packages which needs to test on
non-graphic environment. Also this target is basic test target.
It will test EMLinux's default setting, such as use sysvinit as
default init system, systemd-udev as udev component.

This patch hasn't include all test targets yet. This patch's purpose
is add a new build target.

Test targets are listed in packagegroup-smoketest.bb.