### PR TITLE
conf: temporary disable base-files package in meta-debain

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -52,6 +52,9 @@ if [ -z "$TEMPLATECONF" ] && [ "${BUILDDIR_SETUP_DONE}" = "false" ]; then
     echo "PACKAGE_CLASSES = \"package_deb\"" >> conf/local.conf
     echo "BBMASK = \"meta-debian/recipes-core\"" >> conf/local.conf
     echo "BBMASK .= \"|meta-debian-extended/recipes-debian/base-files/base-files_debian.bb\"" >> conf/local.conf
+    # nsswitch.conf is not provided by debian base-file package but systemd requires it.
+    # use poky's base-files package temporary.
+    echo "BBMASK .= \"|meta-debian/recipes-debian/base-files/base-files_debian.bb\"" >> conf/local.conf
     echo "DL_DIR = \"\${TOPDIR}/../downloads\"" >> conf/local.conf
 
     if [ -d "$HOOKS" ]; then


### PR DESCRIPTION
Since meta-debian has base-files recipes, no one provides /etc/nsswitch.conf.
However, systemd requires /etc/nsswitch.conf if use meta-debian's base-files,
building image is failed.

```
WARNING: core-image-minimal-1.0-r0 do_rootfs: Postinstall for package systemd failed with 2:
sed: can't read /home/masami/emlinux/build/tmp-glibc/work/qemuarm64-emlinux-linux/core-image-minimal/1.0-r0/rootfs/etc/nsswitch.conf: No such file or directory

ERROR: core-image-minimal-1.0-r0 do_rootfs: Postinstall scriptlets of ['systemd'] have failed. If the intention is to defer them to first boot,
then please place them into pkg_postinst_ontarget_${PN} ().
Deferring to first boot via 'exit 1' is no longer supported.

Details of the failure are in /home/masami/emlinux/build/tmp-glibc/work/qemuarm64-emlinux-linux/core-image-minimal/1.0-r0/temp/log.do_rootfs.
ERROR: core-image-minimal-1.0-r0 do_rootfs:
ERROR: core-image-minimal-1.0-r0 do_rootfs: Function failed: do_rootfs
ERROR: Logfile of failure stored in: /home/masami/emlinux/build/tmp-glibc/work/qemuarm64-emlinux-linux/core-image-minimal/1.0-r0/temp/log.do_rootfs.23800
ERROR: Task (/home/masami/emlinux/repos/poky/meta/recipes-core/images/core-image-minimal.bb:do_rootfs) failed with exit code '1'
```

This patch temporary disables base-files package.