### PR TITLE
systemd: set default locale to en_US.utf8

### DIFF
--- a/recipes-debian/systemd/systemd_debian.bbappend
+++ b/recipes-debian/systemd/systemd_debian.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OEMESON += "-Ddefault-locale=en_US.utf8"


### PR DESCRIPTION
As it seems that C.UTF-8 is broken.