### PR TITLE
glibc: remove empty /usr/share

### DIFF
--- a/recipes-debian/glibc/glibc_debian.bbappend
+++ b/recipes-debian/glibc/glibc_debian.bbappend
@@ -1,0 +1,10 @@
+stash_locale_sysroot_cleanup() {
+        stash_locale_cleanup ${SYSROOT_DESTDIR}
+        # We don't want to ship an empty /usr/share
+        rmdir --ignore-fail-on-non-empty ${SYSROOT_DESTDIR}${datadir}
+}
+stash_locale_package_cleanup() {
+        stash_locale_cleanup ${PKGD}
+        # We don't want to ship an empty /usr/share
+        rmdir --ignore-fail-on-non-empty ${PKGD}${datadir}
+}


### PR DESCRIPTION
Follow-up for poky's b174d936e91902c3e2ab800856bb7bc492d096a0.