### PR TITLE
layer.conf: change layer priority to 12

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "emlinux"
 BBFILE_PATTERN_emlinux = ""
-BBFILE_PRIORITY_emlinux = "10"
+BBFILE_PRIORITY_emlinux = "12"
 
 LAYERSERIES_COMPAT_emlinux = "warrior"
 


### PR DESCRIPTION
The meta-debian-extended has priority 11, so we use higher priority for
meta-emlinux.