### PR TITLE
kernel: Fix graphic doesn't work on qemuarm

### DIFF
--- a/recipes-kernel/linux/files/qemuarm.config
+++ b/recipes-kernel/linux/files/qemuarm.config
@@ -1,0 +1,2 @@
+# Graphical environment requires this option.
+CONFIG_ARM_LPAE=y

--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -4,6 +4,7 @@ SRC_URI_append = " \
 "
 
 SRC_URI_append_qemuall += "file://qemu-emlinux.config"
+SRC_URI_append_qemuarm += "file://qemuarm.config"
 
 SRC_URI_append_raspberrypi3-64 += "file://raspberrypi3-64.config"
 LINUX_DEFCONFIG_raspberrypi3-64 = "defconfig"


### PR DESCRIPTION
The qemuarm machine requires CONFIG_ARM_LPAE option to graphic work correctly.
Without this option, qemu's gui shows "Guest has not initialized the display (yet).".
Even display is not initialized, linux is booted so it is able to login to system via ssh.
If drm is initialized correctly, you can see following logs but in that case, these logs aren't found.

```
[    0.435606] bochs-drm 0000:00:01.0: enabling device (0100 -> 0102)
[    0.437289] [drm] Found bochs VGA, ID 0xb0c5.
[    0.437568] [drm] Framebuffer size 16384 kB @ 0x10000000, mmio @ 0x11040000.
[    0.477088] bochs-drm 0000:00:01.0: fb0: bochsdrmfb frame buffer device
[    0.478078] [drm] Initialized bochs-drm 1.0.0 20130925 for 0000:00:01.0 on minor 0
```
Without patch, failed to start graphical environment.
![qemuarm_weston-boot-test](https://user-images.githubusercontent.com/165052/66196422-6fd18200-e6d3-11e9-9555-b15ebf19db8b.png)

With patch, graphical login succeeded.
![qemuarm-weston](https://user-images.githubusercontent.com/165052/66196443-7e1f9e00-e6d3-11e9-8f2c-11b13face74f.png)
