### PR TITLE
layer.conf: ignore empty collection of bbfiles

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -6,7 +6,8 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "emlinux"
-BBFILE_PATTERN_emlinux = ""
+BBFILE_PATTERN_emlinux = "^${LAYERDIR}/"
+BBFILE_PATTERN_IGNORE_EMPTY_emlinux = "1"
 BBFILE_PRIORITY_emlinux = "12"
 
 LAYERSERIES_COMPAT_emlinux = "warrior"


### PR DESCRIPTION
This suppress the following warning.

    WARNING: No bb files matched BBFILE_PATTERN_emlinux