### PR TITLE
conf: prefer libcrypt provided by glibc

### DIFF
--- a/conf/distro/include/emlinux-preferred-provider.inc
+++ b/conf/distro/include/emlinux-preferred-provider.inc
@@ -2,3 +2,5 @@
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-base"
 PREFERRED_PROVIDER_linux-libc-headers ?= "linux-libc-headers-base"
 PREFERRED_PROVIDER_nativesdk-linux-libc-headers ?= "nativesdk-linux-libc-headers-base"
+PREFERRED_PROVIDER_virtual/crypt = "glibc"
+PREFERRED_PROVIDER_virtual/nativesdk-crypt = "nativesdk-glibc"


### PR DESCRIPTION
After the following commit, https://github.com/meta-debian/meta-debian/commit/768f82146786382cf4ed288442001efb07b86ebc, now both libxcrypt and glibc provides virtual/crypt. So, it is necessary to set `PREFERRED_PROVIDER` for `virtual/crypt`.