### PR TITLE
distro: use default value assignment for preferred crypt

### DIFF
--- a/conf/distro/include/emlinux-preferred-provider.inc
+++ b/conf/distro/include/emlinux-preferred-provider.inc
@@ -2,5 +2,5 @@
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-base"
 PREFERRED_PROVIDER_linux-libc-headers ?= "linux-libc-headers-base"
 PREFERRED_PROVIDER_nativesdk-linux-libc-headers ?= "nativesdk-linux-libc-headers-base"
-PREFERRED_PROVIDER_virtual/crypt = "glibc"
-PREFERRED_PROVIDER_virtual/nativesdk-crypt = "nativesdk-glibc"
+PREFERRED_PROVIDER_virtual/crypt ?= "glibc"
+PREFERRED_PROVIDER_virtual/nativesdk-crypt ?= "nativesdk-glibc"


### PR DESCRIPTION
We use ?= instead of = for PREFERRED_PROVIDER_virtual/crypt so that users
who want to use alternatives (e.g. libxcrypt) can override it in local.conf.