### PR TITLE
images: remove clutter-1.0-examples from core-image-weston

### DIFF
--- a/recipes-images/images/core-image-weston-sdk.bb
+++ b/recipes-images/images/core-image-weston-sdk.bb
@@ -1,3 +1,3 @@
 require recipes-graphics/images/core-image-weston.bb
+require core-image-weston.inc
 require core-image-sdk.inc
-

--- a/recipes-images/images/core-image-weston.bbappend
+++ b/recipes-images/images/core-image-weston.bbappend
@@ -1,0 +1,1 @@
+require core-image-weston.inc

--- a/recipes-images/images/core-image-weston.inc
+++ b/recipes-images/images/core-image-weston.inc
@@ -1,0 +1,1 @@
+CORE_IMAGE_BASE_INSTALL_remove = "clutter-1.0-examples"


### PR DESCRIPTION
Clutter is in deep maintenance mode now and will be replaced by GTK4
in the future. So we stop using it by default.

Reference: https://gitlab.gnome.org/GNOME/clutter/blob/master/README.md#notice