### PR TITLE
Fix sdk issue.

### DIFF
--- a/recipes-images/images/core-image-sdk.inc
+++ b/recipes-images/images/core-image-sdk.inc
@@ -5,6 +5,9 @@ sdk_post_process () {
         # Set up kernel for building kernel module now
         echo "configuring scripts of kernel source for building .ko file..."
         $SUDO_EXEC bash -c 'source "$0" && cd "${OECORE_TARGET_SYSROOT}/usr/src/kernel" && make scripts' $target_sdk_dir/environment-setup-@REAL_MULTIMACH_TARGET_SYS@
+
+        # Set up kernel headers for building user application
+        $SUDO_EXEC bash -c 'source "$0" && cd "${OECORE_TARGET_SYSROOT}/usr/src/kernel" && make mrproper; make headers_check; make INSTALL_HDR_PATH=${OECORE_TARGET_SYSROOT}/usr headers_install' $target_sdk_dir/environment-setup-@REAL_MULTIMACH_TARGET_SYS@
 }
 SDK_POST_INSTALL_COMMAND_append = " ${sdk_post_process}"
 


### PR DESCRIPTION
We get file not found error when building application which uses kernel header.
Because kernel header files are not installed properly in /usr/include.
This commit fix it.