### PR TITLE
rpi3: doc: Use tag to checkout raspberry pi firmware

### DIFF
--- a/doc/raspberrypi3.md
+++ b/doc/raspberrypi3.md
@@ -76,7 +76,7 @@ $ sudo mount /dev/sde2 /mnt/rootfs
 1. Clone firmware repository
 
 ```
-$ git clone git@github.com:raspberrypi/firmware.git
+$ git clone git@github.com:raspberrypi/firmware.git -b 1.20190709
 ```
 
 2. Copy files to fat32 partition


### PR DESCRIPTION
# Purpose of pull request

Newer raspberry pi's firmware and kernel 4.19.x's dtb files
doesn't work well on u-boot if user wants to use u-boot console.
So, use old firmware to u-boot work well.

# Test
## How to test

Setup SD card by following new raspberrypi3.md.

## Test result

Can enter u-boot console without errors. 
```
Raspberry Pi Bootcode

Found SD card, config.txt = 1, start.elf = 1, recovery.elf = 0, timeout = 0
Read File: config.txt, 191 (bytes)




Raspberry Pi Bootcode
Read File: config.txt, 191
Read File: start_cd.elf, 685412 (bytes)
Read File: fixup_cd.dat, 2649 (bytes)


U-Boot 2019.01 (Jun 11 2020 - 01:06:55 +0000)

DRAM:  998 MiB
RPI 3 Model B+ (0xa020d3)
MMC:   mmc@7e202000: 0, sdhci@7e300000: 1
Loading Environment from FAT... *** Warning - bad CRC, using default environment

In:    serial
Out:   vidconsole
Err:   vidconsole
Net:   No ethernet found.
starting USB...
USB0:   scanning bus 0 for devices... 4 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  0 
U-Boot> 

```

and, can root login via uart.

```
EMLinux 2.1 raspberrypi3-64 ttyS1

raspberrypi3-64 login: root
                                                   
root@raspberrypi3-64:~# 
```




