### PR TITLE
Update kernel version to v4.19.128-cip28

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -36,7 +36,7 @@ LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
 #
 # LINUX_GIT_SRCREV = "${LINUX_GIT_BRANCH}"
 #
-LINUX_GIT_SRCREV ?= "21bb1b8ab7b78799a21ce39525d1d95fb8a6b5bf"
+LINUX_GIT_SRCREV ?= "775b010f64a43fe825f22c8784b6589ac4295956"
 
 # use toolchain mode for Debian instead of the default
 TCMODE ?= "emlinux"


### PR DESCRIPTION
# Purpose of pull request

Updates kernel version to v4.19.128-cip28 to take bug-fixes in EMLinux.

# Test
## How to test

Build and boot image with qemuarm64. For example:

```
$ echo 'MACHINE = "qemuarm64"' >> conf/local.conf
$ bitbake core-image-minimal
$ runqemu qemuarm64
```