### PR TITLE
Update kernel version to v4.19.132-cip30

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -36,7 +36,7 @@ LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
 #
 # LINUX_GIT_SRCREV = "${LINUX_GIT_BRANCH}"
 #
-LINUX_GIT_SRCREV ?= "775b010f64a43fe825f22c8784b6589ac4295956"
+LINUX_GIT_SRCREV ?= "4da95b68eb2b04de4ec212c17db4863d0301e7f9"
 
 # use toolchain mode for Debian instead of the default
 TCMODE ?= "emlinux"


### PR DESCRIPTION
# Purpose of pull request

Updates kernel version to v4.19.132-cip30 to take bug-fixes in EMLinux.

# Test
## How to test

Build and boot image with qemuarm64. For example:

```
$ echo 'MACHINE = "qemuarm64"' >> conf/local.conf
$ bitbake core-image-minimal
$ runqemu qemuarm64
```


