### PR TITLE
Fix cache problem.

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -85,4 +85,6 @@ WARN_TO_ERROR_QA = "already-stripped compile-host-path install-host-path \
 WARN_QA_remove = "${WARN_TO_ERROR_QA}"
 ERROR_QA_append = " ${WARN_TO_ERROR_QA}"
 
+BB_HASHBASE_WHITELIST_append = " DEBIAN_UNPACK_DIR"
+
 require conf/distro/include/no-static-libs.inc


### PR DESCRIPTION
Task hash value shall not contain absolute path in it.
The recipes on meta-debian layer use DEBIAN_UNPACK_DIR as a working directory and it may include absolute path.
So this variable has to excluded when calculating task hash.

# Purpose of pull request

meta-debian uses DEBIAN_UNPACK_DIR as a working directory.
In Poky's manner, working directory should be listed in the variable "BB_HASHBASE_WHITELIST".
The variable listed in "BB_HASHBASE_WHITELIST" doesn't be included when generating the signatures.

See also
https://www.yoctoproject.org/docs/3.1.2/bitbake-user-manual/bitbake-user-manual.html#checksums
