### PR TITLE
Update kernel version to v4.19.138-cip32

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -36,8 +36,8 @@ LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
 #
 # LINUX_GIT_SRCREV = "${LINUX_GIT_BRANCH}"
 #
-LINUX_GIT_SRCREV ?= "4da95b68eb2b04de4ec212c17db4863d0301e7f9"
-LINUX_CVE_VERSION ?= "${@bb.utils.contains('LINUX_GIT_SRCREV', '4da95b68eb2b04de4ec212c17db4863d0301e7f9', '4.19.132', '${PV}', d)}"
+LINUX_GIT_SRCREV ?= "87e30ad380b2da89b8fb27e61a38c467a628b102"
+LINUX_CVE_VERSION ?= "${@bb.utils.contains('LINUX_GIT_SRCREV', '87e30ad380b2da89b8fb27e61a38c467a628b102', '4.19.138', '${PV}', d)}"
 
 # use toolchain mode for Debian instead of the default
 TCMODE ?= "emlinux"


### PR DESCRIPTION
# Purpose of pull request

Update kernel version to v4.19.138-cip32

# Test
## How to test

Build kernel

```
$ echo "MACHINE='qemuarm64'" >> conf/local.conf
$ bitbake linux-base
```
succesed

## Test result

```
$ cd tmp-glibc/work-shared/qemuarm64/kernel-source
$ git log
linux-4.19.y-cip, tag: v4.19.138-cip32
```

Kernel revision has been updated.


