### PR TITLE
init-ifupdown: Wait network device is initialized before run ifup

### DIFF
--- a/recipes-core/init-ifupdown/init-ifupdown-1.0/raspberrypi3-64/interfaces
+++ b/recipes-core/init-ifupdown/init-ifupdown-1.0/raspberrypi3-64/interfaces
@@ -1,0 +1,18 @@
+# /etc/network/interfaces -- configuration file for ifup(8), ifdown(8)
+ 
+# The loopback interface
+auto lo
+iface lo inet loopback
+
+# Wireless interfaces
+iface wlan0 inet dhcp
+        wireless_mode managed
+        wireless_essid any
+        wpa-driver wext
+        wpa-conf /etc/wpa_supplicant.conf
+
+# Wired or wireless interfaces
+auto eth0
+iface eth0 inet dhcp
+  pre-up /etc/network/if-up.d/wait-iface.sh $IFACE
+

--- a/recipes-core/init-ifupdown/init-ifupdown-1.0/wait-iface.sh
+++ b/recipes-core/init-ifupdown/init-ifupdown-1.0/wait-iface.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if [ $# -ne 1 ]; then
+  echo "usage $0 [interface]"
+  exit 1
+fi
+
+IFACE=$1
+echo "checking ${IFACE}"
+
+for i in $(seq 10);
+do
+  if [ -d /sys/class/net/${IFACE} ]; then
+    exit 0
+  fi
+  sleep 1
+done
+
+exit 1

--- a/recipes-core/init-ifupdown/init-ifupdown_1.0.bbappend
+++ b/recipes-core/init-ifupdown/init-ifupdown_1.0.bbappend
@@ -1,0 +1,8 @@
+# interfaces file is based on commit 733ae41f20983a7e6f1c147188aa6b4db951d05b.
+FILESEXTRAPATHS_append := "${THISDIR}/${PN}-${PV}"
+
+SRC_URI += "file://wait-iface.sh"
+
+do_install_append_raspberrypi3-64() {
+    install -m 0755 ${WORKDIR}/wait-iface.sh ${D}${sysconfdir}/network/if-up.d/wait-iface.sh
+}


### PR DESCRIPTION
# Purpose of pull request

Raspberry Pi takes time to initialize ethernet device, because ethernet device initializes after usb device's initialize process
has done. Therefore sometimes ehternet device is not available when run /etc/init.d/networking script. It causes ehternet device haven't initialized correctly. So use pre-up feature to wait device is initalized.

this log is device was initialized after runs ifup script.
```
raspberrypi3-64 login: [    3.935083] random: crng init done
[    4.094340] lan78xx 1-1.1.1:1.0 (unnamed net_device) (uninitialized): No External EEPROM. Setting MAC Speed
[    4.122405] libphy: lan78xx-mdiobus: probed
```

# Test

## How to test

Build raspberry pi image(core-image-minimal) and boot/reboot sometimes.


## Test result

Check /var/log/boot log file to dhcp log which contains ip address.

Most case, it takes 1 second to wait device(Thu Aug 27 05:07:17 2020 to Thu Aug 27 05:07:18 2020).

```
root@raspberrypi3-64:~# cat /var/log/boot
Thu Aug 27 05:07:17 2020: hwclock: can't open '/dev/misc/rtc': No such file or directory
Thu Aug 27 05:07:17 2020: Thu Aug 27 05:07:17 UTC 2020
Thu Aug 27 05:07:17 2020: hwclock: can't open '/dev/misc/rtc': No such file or directory
Thu Aug 27 05:07:17 2020: INIT: Entering runlevel: 5
Thu Aug 27 05:07:17 2020: Configuring network interfaces... checking eth0
Thu Aug 27 05:07:18 2020: udhcpc: started, v1.30.1
Thu Aug 27 05:07:18 2020: udhcpc: sending discover
Thu Aug 27 05:07:21 2020: udhcpc: sending discover
Thu Aug 27 05:07:21 2020: udhcpc: sending select for 192.168.11.15
Thu Aug 27 05:07:21 2020: udhcpc: lease of 192.168.11.15 obtained, lease time 172800
Thu Aug 27 05:07:21 2020: /etc/udhcpc.d/50default: Adding DNS 192.168.11.1
Thu Aug 27 05:07:21 2020: done.
Thu Aug 27 05:07:21 2020: hwclock: can't open '/dev/misc/rtc': No such file or directory
Thu Aug 27 05:07:21 2020: Starting syslogd/klogd: done
```

Best case is less than 1 second to wait device(Thu Aug 27 05:25:16 2020 to Thu Aug 27 05:25:16 2020).

```
root@raspberrypi3-64:~# cat /var/log/boot
Thu Aug 27 05:25:16 2020: hwclock: can't open '/dev/misc/rtc': No such file or directory
Thu Aug 27 05:25:16 2020: Thu Aug 27 05:25:16 UTC 2020
Thu Aug 27 05:25:16 2020: hwclock: can't open '/dev/misc/rtc': No such file or directory
Thu Aug 27 05:25:16 2020: INIT: Entering runlevel: 5
Thu Aug 27 05:25:16 2020: Configuring network interfaces... checking eth0
Thu Aug 27 05:25:16 2020: udhcpc: started, v1.30.1
Thu Aug 27 05:25:16 2020: udhcpc: sending discover
Thu Aug 27 05:25:19 2020: udhcpc: sending discover
Thu Aug 27 05:25:19 2020: udhcpc: sending select for 192.168.11.15
Thu Aug 27 05:25:19 2020: udhcpc: lease of 192.168.11.15 obtained, lease time 172800
Thu Aug 27 05:25:19 2020: /etc/udhcpc.d/50default: Adding DNS 192.168.11.1
Thu Aug 27 05:25:19 2020: done.
Thu Aug 27 05:25:19 2020: hwclock: can't open '/dev/misc/rtc': No such file or directory
Thu Aug 27 05:25:19 2020: Starting syslogd/klogd: done
```

If LAN cable is not plugged, dhcp process give up to get ip address, and run process in background.

```
root@raspberrypi3-64:~# cat /var/log/boot
Thu Aug 27 05:29:05 2020: hwclock: can't open '/dev/misc/rtc': No such file or directory
Thu Aug 27 05:29:05 2020: Thu Aug 27 05:29:05 UTC 2020
Thu Aug 27 05:29:05 2020: hwclock: can't open '/dev/misc/rtc': No such file or directory
Thu Aug 27 05:29:05 2020: INIT: Entering runlevel: 5
Thu Aug 27 05:29:05 2020: Configuring network interfaces... checking eth0
Thu Aug 27 05:29:06 2020: udhcpc: started, v1.30.1
Thu Aug 27 05:29:06 2020: udhcpc: sending discover
Thu Aug 27 05:29:09 2020: udhcpc: sending discover
Thu Aug 27 05:29:12 2020: udhcpc: sending discover
Thu Aug 27 05:29:15 2020: udhcpc: no lease, forking to background
Thu Aug 27 05:29:15 2020: done.
Thu Aug 27 05:29:15 2020: hwclock: can't open '/dev/misc/rtc': No such file or directory
Thu Aug 27 05:29:15 2020: Starting syslogd/klogd: done
```

ps shows udhcp process.

```
 1628 root      3236 S    udhcpc -R -b -p /var/run/udhcpc.eth0.pid -i eth0
```

When plug a LAN cable, it get ip address from dhcp server.
