### PR TITLE
Add util linux patches

### DIFF
--- a/recipes-debian/util-linux/files/0001-tests-check-kernel-btrfs-support.patch
+++ b/recipes-debian/util-linux/files/0001-tests-check-kernel-btrfs-support.patch
@@ -1,0 +1,32 @@
+From 26cd9bcbc3e6b8a19930bf4560ba2b5cad0ddfa4 Mon Sep 17 00:00:00 2001
+From: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+Date: Tue, 2 Jul 2019 14:43:39 +0900
+Subject: [PATCH] tests: check kernel btrfs support
+
+Check kernel supports btrfs or not before run tests.
+
+Signed-off-by: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+---
+ tests/ts/mount/fstab-btrfs | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/tests/ts/mount/fstab-btrfs b/tests/ts/mount/fstab-btrfs
+index 54c6bb8..aa419ca 100755
+--- a/tests/ts/mount/fstab-btrfs
++++ b/tests/ts/mount/fstab-btrfs
+@@ -21,6 +21,12 @@ TS_DESC="btrfs (fstab)"
+ . $TS_TOPDIR/functions.sh
+ ts_init "$*"
+ 
++# btrfs kernel support check
++grep btrfs /proc/filesystems &>/dev/null
++if [ $? -ne 0 ]; then
++    ts_skip "kernel does not support btrfs"
++fi
++
+ ts_check_test_command "$TS_CMD_MOUNT"
+ ts_check_test_command "$TS_CMD_UMOUNT"
+ 
+-- 
+2.20.1
+

--- a/recipes-debian/util-linux/files/0001-tests-check-kernel-raid-support.patch
+++ b/recipes-debian/util-linux/files/0001-tests-check-kernel-raid-support.patch
@@ -1,0 +1,48 @@
+From 873f903e7fbd74b4c955eab8d10199a5077dab61 Mon Sep 17 00:00:00 2001
+From: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+Date: Wed, 3 Jul 2019 17:12:26 +0900
+Subject: [PATCH] tests: check kernel raid support
+
+To check kernel raid support for ignore test error when kernel doesn't
+support raid.
+
+Signed-off-by: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+---
+ tests/ts/blkid/md-raid0-whole | 4 ++++
+ tests/ts/blkid/md-raid1-whole | 5 +++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/tests/ts/blkid/md-raid0-whole b/tests/ts/blkid/md-raid0-whole
+index 45c6ee5..f873be4 100755
+--- a/tests/ts/blkid/md-raid0-whole
++++ b/tests/ts/blkid/md-raid0-whole
+@@ -48,6 +48,10 @@ ts_log "Create RAID device"
+ mdadm -q --create ${MD_DEVICE} --metadata=0.90 --chunk=64 --level=0 \
+ 	    --raid-devices=2 ${DEVICE1} ${DEVICE2} >> $TS_OUTPUT 2>&1
+ 
++if [ ! -d "/sys/module/md_mod/parameters/new_array" ]; then
++  ts_skip "kernel doesn't support raid"
++fi
++
+ ts_log "Create partitions on RAID device"
+ $TS_CMD_FDISK ${MD_DEVICE} >> $TS_OUTPUT 2>&1 <<EOF
+ n
+diff --git a/tests/ts/blkid/md-raid1-whole b/tests/ts/blkid/md-raid1-whole
+index ddf4a69..a4f3364 100755
+--- a/tests/ts/blkid/md-raid1-whole
++++ b/tests/ts/blkid/md-raid1-whole
+@@ -49,6 +49,11 @@ udevadm settle
+ ts_log "Create RAID device"
+ mdadm -q --create ${MD_DEVICE} --metadata=0.90 --chunk=64 --level=1 \
+ 	    --raid-devices=2 ${DEVICE1} ${DEVICE2} >> $TS_OUTPUT 2>&1
++
++if [ ! -d "/sys/module/md_mod/parameters/new_array" ]; then
++  ts_skip "kernel doesn't support raid"
++fi
++
+ udevadm settle
+ 
+ ts_log "Create partitions on RAID device"
+-- 
+2.20.1
+

--- a/recipes-debian/util-linux/files/0001-tests-fix-test-failed-on-busybox-environment.patch
+++ b/recipes-debian/util-linux/files/0001-tests-fix-test-failed-on-busybox-environment.patch
@@ -1,0 +1,46 @@
+From 6be5850858be91d750d4a7830607212f1c10cb76 Mon Sep 17 00:00:00 2001
+From: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+Date: Wed, 3 Jul 2019 10:12:17 +0900
+Subject: [PATCH] tests: fix test failed on busybox environment
+
+Remove \r from expected file to ignore newline code difference error.
+Add -B option to diff to ignore empty lines.
+
+Signed-off-by: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+---
+ tests/expected/script/options-size | 4 ++--
+ tests/functions.sh                 | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tests/expected/script/options-size b/tests/expected/script/options-size
+index c984dfa..dcea580 100644
+--- a/tests/expected/script/options-size
++++ b/tests/expected/script/options-size
+@@ -1,9 +1,9 @@
+ Script started on 2015-05-24 17:43:18+00:00 [<not executed on terminal>]
+-1:1234567890
++1:1234567890
+ 
+ Script done on 2015-05-24 17:43:18+00:00 [<max output size exceeded>]
+ Script started on 2015-05-24 17:43:18+00:00 [<not executed on terminal>]
+-2:1234567890
++2:1234567890
+ 
+ Script done on 2015-05-24 17:43:18+00:00 [<max output size exceeded>]
+ 0
+diff --git a/tests/functions.sh b/tests/functions.sh
+index 2fb0ddb..e3b5f3b 100644
+--- a/tests/functions.sh
++++ b/tests/functions.sh
+@@ -421,7 +421,7 @@ function ts_gen_diff {
+ 	sed --in-place 's/^lt\-\(.*\: \)/\1/g' $TS_OUTPUT
+ 
+ 	[ -d "$TS_DIFFDIR" ] || mkdir -p "$TS_DIFFDIR"
+-	diff -u $TS_EXPECTED $TS_OUTPUT > $TS_DIFF
++	diff -uB $TS_EXPECTED $TS_OUTPUT > $TS_DIFF
+ 
+ 	if [ $? -ne 0 ] || [ -s $TS_DIFF ]; then
+ 		res=1
+-- 
+2.20.1
+

--- a/recipes-debian/util-linux/files/fix-mkfs-endianness-test.patch
+++ b/recipes-debian/util-linux/files/fix-mkfs-endianness-test.patch
@@ -1,0 +1,258 @@
+diff --git a/tests/ts/cramfs/mkfs-endianness b/tests/ts/cramfs/mkfs-endianness
+index c5110867e..5c5c7ab8b 100755
+--- a/tests/ts/cramfs/mkfs-endianness
++++ b/tests/ts/cramfs/mkfs-endianness
+@@ -44,10 +44,10 @@ test_image() {
+ #generate test data, must be owner root
+ rm -rf "$IMAGE_DATA"
+ mkdir -p $IMAGE_DATA/dirA/dirB
+-yes "Testing cramfs 1234567890 Endianness check 1234567890 Endianness check" \
+-	| dd of=$IMAGE_DATA/dirA/dirB/a bs=512 count=1 &> /dev/null
+-yes "Testing cramfs 1234567890 Endianness check 1234567890 Endianness check" \
+-	| dd of=$IMAGE_DATA/dirA/dirB/b bs=512 count=30 &> /dev/null
++
++cp $TS_SELF/mkfs-endianness_testdata_a $IMAGE_DATA/dirA/dirB/a
++cp $TS_SELF/mkfs-endianness_testdata_b $IMAGE_DATA/dirA/dirB/b
++
+ # sudo may use whatever group
+ chgrp -R 0 $IMAGE_DATA
+ 
+diff --git a/tests/ts/cramfs/mkfs-endianness_testdata_a b/tests/ts/cramfs/mkfs-endianness_testdata_a
+new file mode 100644
+index 000000000..d6c57b768
+--- /dev/null
++++ b/tests/ts/cramfs/mkfs-endianness_testdata_a
+@@ -0,0 +1,8 @@
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 
+\ No newline at end of file
+diff --git a/tests/ts/cramfs/mkfs-endianness_testdata_b b/tests/ts/cramfs/mkfs-endianness_testdata_b
+new file mode 100644
+index 000000000..30f9faf0a
+--- /dev/null
++++ b/tests/ts/cramfs/mkfs-endianness_testdata_b
+@@ -0,0 +1,217 @@
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 1234567890 Endianness check 1234567890 Endianness check
++Testing cramfs 123456789
+\ No newline at end of file

--- a/recipes-debian/util-linux/files/run-ptest
+++ b/recipes-debian/util-linux/files/run-ptest
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+
+# When udevd (from eudev) is running most eject/mount tests will fail because
+# of automount. We need to stop udevd before executing util-linux's tests.
+# The systemd-udevd daemon doesn't change the outcome of util-linux's tests.
+if [ -f /etc/init.d/udev ]; then
+    UDEV_PID="`pidof "@base_sbindir@/udevd"`"
+fi
+if [ "x$UDEV_PID" != "x" ]; then
+    /etc/init.d/udev stop
+fi
+
+current_path=$(readlink -f $0)
+export bindir=$(dirname $current_path)
+export PATH=$bindir/bin:$PATH
+
+cd tests || exit 1                                                          
+
+comps=$(find ts/ -type f -perm -111 -regex ".*/[^\.~]*" |  sort)
+
+
+echo
+echo "-------------------- util-linux regression tests --------------------"
+echo
+echo "                    For development purpose only.                    "
+echo "                 Don't execute on production system!                 "
+echo
+
+res=0
+count=0
+for ts in $comps; 
+do 
+   $ts | sed -u '{        
+      s/^\(.*\):\(.*\) \.\.\. OK$/PASS: \1:\2/                              
+      s/^\(.*\):\(.*\) \.\.\. FAILED \(.*\)$/FAIL: \1:\2 \3/                
+      s/^\(.*\):\(.*\) \.\.\. SKIPPED \(.*\)$/SKIP: \1:\2 \3/               
+   }' 
+done
+
+
+if [ "x$UDEV_PID" != "x" ]; then
+    /etc/init.d/udev start
+fi
+

--- a/recipes-debian/util-linux/util-linux_debian.bbappend
+++ b/recipes-debian/util-linux/util-linux_debian.bbappend
@@ -1,2 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI += "file://0001-tests-skip-ul-command-test.patch"
+SRC_URI += "file://0001-tests-skip-ul-command-test.patch \
+            file://0001-tests-check-kernel-btrfs-support.patch \
+            file://0001-tests-check-kernel-raid-support.patch \
+            file://0001-tests-fix-test-failed-on-busybox-environment.patch \
+            file://run-ptest"

--- a/recipes-debian/util-linux/util-linux_debian.bbappend
+++ b/recipes-debian/util-linux/util-linux_debian.bbappend
@@ -4,3 +4,5 @@ SRC_URI += "file://0001-tests-skip-ul-command-test.patch \
             file://0001-tests-check-kernel-raid-support.patch \
             file://0001-tests-fix-test-failed-on-busybox-environment.patch \
             file://run-ptest"
+
+RDEPENDS_${PN}-ptest += "tar"

--- a/recipes-debian/util-linux/util-linux_debian.bbappend
+++ b/recipes-debian/util-linux/util-linux_debian.bbappend
@@ -3,6 +3,7 @@ SRC_URI += "file://0001-tests-skip-ul-command-test.patch \
             file://0001-tests-check-kernel-btrfs-support.patch \
             file://0001-tests-check-kernel-raid-support.patch \
             file://0001-tests-fix-test-failed-on-busybox-environment.patch \
-            file://run-ptest"
+            file://run-ptest \
+			file://fix-mkfs-endianness-test.patch"
 
 RDEPENDS_${PN}-ptest += "tar"


### PR DESCRIPTION
# Purpose of pull request

## patches from meta-debian-extended

util-linux is removed by [meta-debian-extended/pull/278](https://github.com/miraclelinux/meta-debian-extended/pull/278). However, there are some patches which need emlinux distribution. This includes these patches.

## add tar package dependency

ptest needs tar command which support ``` xz ``` option.  busybox's tar command doesn't support this option, so it needs to add tar package.
This fix has been send to [meta-debain](https://github.com/meta-debian/meta-debian/pull/237) so that it can be remove when pr has merged.

## backport mkfs-endianness test fix

Backport mkfs-endianness test fix patch from util-linux master branch.

# Test
## How to test

1. Run ptest
2. Run mkfs-endianness test

## Test result

ptest 
```
root@qemuarm64:~# ptest-runner util-linux
START: ptest-runner
2020-09-11T01:59
BEGIN: /usr/lib/util-linux/ptest

-------------------- util-linux regression tests --------------------

                    For development purpose only.                    
                 Don't execute on production system!                 

PASS:        bitops: swap bytes                    
PASS:    blkdiscard: offsets                       
SKIP:         blkid: DM error                       (missing in PATH: dmsetup)
        blkid: superblocks probing            ...
PASS:         blkid: adaptec-raid                  
PASS:         blkid: bcache-B                      
PASS:         blkid: bcache-C                      
PASS:         blkid: befs                          
PASS:         blkid: bfs                           
PASS:         blkid: cramfs                        
PASS:         blkid: ddf-raid                      
PASS:         blkid: drbdmanage-control-volume     
PASS:         blkid: exfat                         
PASS:         blkid: ext2                          
PASS:         blkid: ext3                          
PASS:         blkid: f2fs                          
PASS:         blkid: fat                           
PASS:         blkid: fat16_noheads                 
PASS:         blkid: fat32_cp850_O_tilde           
PASS:         blkid: fat32_label_64MB              
PASS:         blkid: fat32_mkdosfs_label1          
PASS:         blkid: fat32_mkdosfs_label1_dosfslabel_NO_NAME
PASS:         blkid: fat32_mkdosfs_label1_dosfslabel_empty
PASS:         blkid: fat32_mkdosfs_label1_dosfslabel_label2
PASS:         blkid: fat32_mkdosfs_label1_mlabel_NO_NAME
PASS:         blkid: fat32_mkdosfs_label1_mlabel_erase
PASS:         blkid: fat32_mkdosfs_label1_xp_erase 
PASS:         blkid: fat32_mkdosfs_label1_xp_label2
PASS:         blkid: fat32_mkdosfs_none            
PASS:         blkid: fat32_mkdosfs_none_dosfslabel_NO_NAME
PASS:         blkid: fat32_mkdosfs_none_dosfslabel_label1
PASS:         blkid: fat32_mkdosfs_none_dosfslabel_label1_xp_label2
PASS:         blkid: fat32_mkdosfs_none_xp_label1  
PASS:         blkid: fat32_mkdosfs_none_xp_label1_dosfslabel_label2
PASS:         blkid: fat32_xp_label1               
PASS:         blkid: fat32_xp_none                 
PASS:         blkid: fat32_xp_none_dosfslabel_label1
PASS:         blkid: fat32_xp_none_mlabel_label1   
PASS:         blkid: gfs2                          
PASS:         blkid: hfs                           
PASS:         blkid: hfsplus                       
PASS:         blkid: hpfs                          
PASS:         blkid: hpt37x-raid                   
PASS:         blkid: hpt45x-raid                   
PASS:         blkid: iso-joliet                    
PASS:         blkid: iso-rr-joliet                 
PASS:         blkid: iso                           
PASS:         blkid: isw-raid                      
PASS:         blkid: jbd                           
PASS:         blkid: jfs                           
PASS:         blkid: jmicron-raid                  
PASS:         blkid: lsi-raid                      
PASS:         blkid: luks1                         
PASS:         blkid: luks2                         
PASS:         blkid: lvm2                          
PASS:         blkid: mdraid                        
PASS:         blkid: minix-BE                      
PASS:         blkid: minix-LE                      
PASS:         blkid: mpool                         
PASS:         blkid: netware                       
PASS:         blkid: nilfs2                        
PASS:         blkid: ntfs                          
PASS:         blkid: nvidia-raid                   
PASS:         blkid: ocfs2                         
PASS:         blkid: promise-raid                  
PASS:         blkid: reiser3                       
PASS:         blkid: reiser4                       
PASS:         blkid: romfs                         
PASS:         blkid: silicon-raid                  
PASS:         blkid: small-fat32                   
PASS:         blkid: swap0                         
PASS:         blkid: swap1                         
PASS:         blkid: tuxonice                      
PASS:         blkid: ubi                           
PASS:         blkid: ubifs                         
PASS:         blkid: udf-bdr-2.60-nero             
PASS:         blkid: udf-cd-mkudfiso-20100208      
PASS:         blkid: udf-cd-nero-6                 
PASS:         blkid: udf-hdd-mkudffs-1.0.0-1       
PASS:         blkid: udf-hdd-mkudffs-1.0.0-2       
PASS:         blkid: udf-hdd-mkudffs-1.3-1         
PASS:         blkid: udf-hdd-mkudffs-1.3-2         
PASS:         blkid: udf-hdd-mkudffs-1.3-3         
PASS:         blkid: udf-hdd-mkudffs-1.3-4         
PASS:         blkid: udf-hdd-mkudffs-1.3-5         
PASS:         blkid: udf-hdd-mkudffs-1.3-6         
PASS:         blkid: udf-hdd-mkudffs-1.3-7         
PASS:         blkid: udf-hdd-mkudffs-1.3-8         
PASS:         blkid: udf-hdd-udfclient-0.7.5       
PASS:         blkid: udf-hdd-udfclient-0.7.7       
PASS:         blkid: udf-hdd-win7                  
PASS:         blkid: udf                           
PASS:         blkid: ufs                           
PASS:         blkid: vdo                           
PASS:         blkid: via-raid                      
PASS:         blkid: vmfs                          
PASS:         blkid: vmfs_volume                   
PASS:         blkid: xfs-log                       
PASS:         blkid: xfs                           
PASS:         blkid: zfs                           
           ... OK (all 96 sub-tests PASSED)
        blkid: partitions probing             ...
PASS:         blkid: atari-icd                     
PASS:         blkid: atari-xgm                     
PASS:         blkid: bsd                           
PASS:         blkid: dos+bsd                       
PASS:         blkid: gpt                           
PASS:         blkid: sgi                           
PASS:         blkid: sun                           
           ... OK (all 7 sub-tests PASSED)
SKIP:         blkid: mbr-wholedisk                  (missing scsi_debug module (dry-run))
SKIP:         blkid: MD raid0 (whole-disks)         (kernel doesn't support raid)
SKIP:         blkid: MD raid1 (last partition)      (missing scsi_debug module (dry-run))
SKIP:         blkid: MD raid1 (whole-disks)         (kernel doesn't support raid)
SKIP:     build-sys: config                         (optional)
          cal: Year 2147483646                ...
PASS:           cal: 1m-month                      
PASS:           cal: 1s-month                      
PASS:           cal: 1mj-month                     
PASS:           cal: 1sj-month                     
PASS:           cal: 3m-month                      
PASS:           cal: 3s-month                      
PASS:           cal: 3mj-month                     
PASS:           cal: 3sj-month                     
PASS:           cal: 1m-year                       
PASS:           cal: 1s-year                       
PASS:           cal: 1mj-year                      
PASS:           cal: 1sj-year                      
PASS:           cal: 1mw-month                     
PASS:           cal: 1sw-month                     
PASS:           cal: 1mjw-month                    
PASS:           cal: 1sjw-month                    
PASS:           cal: 3mw-month                     
PASS:           cal: 3sw-month                     
PASS:           cal: 3mjw-month                    
PASS:           cal: 3sjw-month                    
PASS:           cal: 1mw-year                      
PASS:           cal: 1sw-year                      
PASS:           cal: 1mjw-year                     
PASS:           cal: 1sjw-year                     
           ... OK (all 24 sub-tests PASSED)
PASS:           cal: color                         
PASS:           cal: color with week numbers       
          cal: January 1753                   ...
PASS:           cal: m3w                           
PASS:           cal: 3w                            
           ... OK (all 2 sub-tests PASSED)
          cal: month                          ...
PASS:           cal: 1m                            
PASS:           cal: 1s                            
PASS:           cal: 1mj                           
PASS:           cal: 1sj                           
PASS:           cal: 1mw                           
PASS:           cal: 1sw                           
PASS:           cal: 1mjw                          
PASS:           cal: 1sjw                          
PASS:           cal: 3m                            
PASS:           cal: 3s                            
PASS:           cal: 3mj                           
PASS:           cal: 3sj                           
PASS:           cal: 3mw                           
PASS:           cal: 3sw                           
PASS:           cal: 3mjw                          
PASS:           cal: 3sjw                          
PASS:           cal: Sn3                           
PASS:           cal: Sn21                          
PASS:           cal: Sn51                          
PASS:           cal: Sn201                         
           ... OK (all 20 sub-tests PASSED)
          cal: September 1752                 ...
PASS:           cal: 1mw-month                     
PASS:           cal: 1sw-month                     
PASS:           cal: 1mjw-month                    
PASS:           cal: 1sjw-month                    
PASS:           cal: 3mw-month                     
PASS:           cal: 3sw-month                     
PASS:           cal: 3mjw-month                    
PASS:           cal: 3sjw-month                    
PASS:           cal: 1mw-year                      
PASS:           cal: 1sw-year                      
PASS:           cal: 1mjw-year                     
PASS:           cal: 1sjw-year                     
PASS:           cal: week-iso                      
PASS:           cal: 1m-month                      
PASS:           cal: 1s-month                      
PASS:           cal: 1mj-month                     
PASS:           cal: 1sj-month                     
PASS:           cal: 3m-month                      
PASS:           cal: 3s-month                      
PASS:           cal: 3mj-month                     
PASS:           cal: 3sj-month                     
PASS:           cal: 1m-year                       
PASS:           cal: 1s-year                       
PASS:           cal: 1mj-year                      
PASS:           cal: 1sj-year                      
           ... OK (all 25 sub-tests PASSED)
          cal: week number given as argument  ...
PASS:           cal: 3m-week40                     
PASS:           cal: 3s-week40                     
PASS:           cal: 3mj-week40                    
PASS:           cal: 3sj-week40                    
PASS:           cal: m-week40                      
PASS:           cal: s-week40                      
PASS:           cal: mj-week40                     
PASS:           cal: sj-week40                     
PASS:           cal: 3m-week40-color               
PASS:           cal: 3mj-week40-color              
PASS:           cal: 1m-week53                     
PASS:           cal: 1mj-week53                    
PASS:           cal: 3m-week53-color               
PASS:           cal: 1m-week53-color               
PASS:           cal: 1mj-week53-color              
PASS:           cal: 3s-week54-color               
PASS:           cal: 3m-week52-color               
           ... OK (all 17 sub-tests PASSED)
          cal: week number corner cases       ...
PASS:           cal: ymw                           
PASS:           cal: ysw                           
PASS:           cal: ymjw                          
PASS:           cal: ysjw                          
PASS:           cal: 3mw                           
PASS:           cal: 3sw                           
PASS:           cal: 3mjw                          
PASS:           cal: 3sjw                          
           ... OK (all 8 sub-tests PASSED)
          cal: year                           ...
PASS:           cal: ym                            
PASS:           cal: ys                            
PASS:           cal: ymj                           
PASS:           cal: ysj                           
PASS:           cal: ymw                           
PASS:           cal: ysw                           
PASS:           cal: ymjw                          
PASS:           cal: ysjw                          
           ... OK (all 8 sub-tests PASSED)
PASS:           col: multibyte input               
       colcrt: functional                     ...
PASS:        colcrt: no-options                    
PASS:        colcrt: no-underlining                
PASS:        colcrt: half-lines                    
PASS:        colcrt: short-options                 
           ... OK (all 4 sub-tests PASSED)
       colcrt: regressions                    ...
PASS:        colcrt: crash1                        
PASS:        colcrt: crash2                        
PASS:        colcrt: hang1                         
           ... OK (all 3 sub-tests PASSED)
PASS:         colrm: basic check                   
       column: columnate                      ...
PASS:        column: fill-cols-80                  
PASS:        column: fill-cols-50                  
PASS:        column: fill-cols-250                 
PASS:        column: fill-rows-80                  
PASS:        column: fill-rows-50                  
PASS:        column: fill-rows-250                 
           ... OK (all 6 sub-tests PASSED)
PASS:        column: invalid multibyte             
PASS:        column: multiple files                
       column: table                          ...
PASS:        column: default                       
PASS:        column: output-separator              
PASS:        column: input-separator               
PASS:        column: input-separator-space         
PASS:        column: empty-lines                   
PASS:        column: noempty-lines                 
PASS:        column: long                          
PASS:        column: hide                          
PASS:        column: headers                       
PASS:        column: truncate                      
PASS:        column: right                         
PASS:        column: wrap                          
PASS:        column: order                         
PASS:        column: tree                          
PASS:        column: empty-column                  
           ... OK (all 15 sub-tests PASSED)
SKIP:        cramfs: mkfs doubles                   (mount: /usr/lib/util-linux/ptest/tests/output/cramfs/doubles-mnt: unknown filesystem type 'cramfs'.)
       cramfs: fsck bad header                ...
PASS:        cramfs: nopad-4K-be                   
PASS:        cramfs: nopad-4K-le                   
PASS:        cramfs: pad-4K-be                     
PASS:        cramfs: pad-4K-le                     
PASS:        cramfs: pad-64K-be                    
PASS:        cramfs: pad-64K-le                    
           ... OK (all 6 sub-tests PASSED)
PASS:        cramfs: fsck endianness               
SKIP:        cramfs: mkfs checksums                 (mount: /usr/lib/util-linux/ptest/tests/output/cramfs/mkfs-mnt: unknown filesystem type 'cramfs'.)
PASS:        cramfs: mkfs endianness               
PASS:         dmesg: colors                        
PASS:         dmesg: levels                        
PASS:         dmesg: decode                        
PASS:         dmesg: delta                         
PASS:         dmesg: facilities                    
PASS:         dmesg: indentation                   
        eject: umount                         ...
SKIP:         eject: by-disk                        (missing scsi_debug module (dry-run))
SKIP:         fdisk: align 512/4K                   (missing scsi_debug module (dry-run))
SKIP:         fdisk: align 512/4K +alignment_offset (missing scsi_debug module (dry-run))
SKIP:         fdisk: align 512/4K +MD               (missing scsi_debug module (dry-run))
PASS:         fdisk: align 512/512                 
SKIP:         fdisk: align 512/512 +topology        (missing scsi_debug module (dry-run))
PASS:         fdisk: nested BSD                    
PASS:         fdisk: GPT                           
[  299.507826] random: crng init done
PASS:         fdisk: gpt-resize                    
PASS:         fdisk: MBR - id                      
PASS:         fdisk: MBR - dos mode                
PASS:         fdisk: MBR - non-dos mode            
PASS:         fdisk: MBR - sort                    
PASS:         fdisk: invalid input tests           
PASS:         fdisk: sunlabel tests                
PASS:       fincore: count file contents in core   
      findmnt: filter                         ...
PASS:       findmnt: types                         
PASS:       findmnt: types-multi                   
PASS:       findmnt: types-neg                     
PASS:       findmnt: options                       
PASS:       findmnt: options-name                  
PASS:       findmnt: options-nameval               
PASS:       findmnt: options-nameval-neg           
PASS:       findmnt: options-nameval-multi         
PASS:       findmnt: options-neg                   
PASS:       findmnt: options-no                    
PASS:       findmnt: options-no-multi              
           ... OK (all 11 sub-tests PASSED)
      findmnt: outputs                        ...
PASS:       findmnt: default                       
PASS:       findmnt: kernel                        
PASS:       findmnt: force-tree                    
PASS:       findmnt: submounts                     
PASS:       findmnt: messy-mountinfo               
           ... OK (all 5 sub-tests PASSED)
      findmnt: target                         ...
PASS:       findmnt: root                          
PASS:       findmnt: non-root                      
           ... OK (all 2 sub-tests PASSED)
[  347.377120] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  347.428304] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:          fsck: is mounted                    
PASS:        getopt: basic                         
       getopt: options                        ...
PASS:        getopt: alternative_option_clash      
PASS:        getopt: alternative_option_long       
PASS:        getopt: alternative_option_short      
PASS:        getopt: invalid_getopt_option         
PASS:        getopt: invocation_model_one          
PASS:        getopt: invocation_model_three_as_one 
PASS:        getopt: invocation_model_two_as_one   
PASS:        getopt: invocation_without_parameters 
PASS:        getopt: long_option_ambiguous_1       
PASS:        getopt: longopts                      
PASS:        getopt: name_option_long              
PASS:        getopt: name_option_short             
PASS:        getopt: quiet_option_long             
PASS:        getopt: quiet_option_short            
PASS:        getopt: quiet_output_option_long      
PASS:        getopt: quiet_output_option_short     
PASS:        getopt: same_long_short_options       
PASS:        getopt: test_for_enhanced_getopt      
PASS:        getopt: unknown_options               
PASS:        getopt: unquoted_option_bash          
PASS:        getopt: unquoted_option_tcsh          
PASS:        getopt: weird_quoting_bash            
PASS:        getopt: weird_quoting_tcsh            
PASS:        getopt: compatible                    
PASS:        getopt: sh                            
PASS:        getopt: csh                           
PASS:        getopt: no-arguments                  
PASS:        getopt: posix_correctly               
PASS:        getopt: non-option                    
           ... OK (all 29 sub-tests PASSED)
      hexdump: format-strings                 ...
PASS:       hexdump: empty-format                  
PASS:       hexdump: 1b_octal                      
PASS:       hexdump: 1b_char                       
PASS:       hexdump: canon                         
PASS:       hexdump: 2b_dec                        
PASS:       hexdump: 2b_octal                      
PASS:       hexdump: 2b_hex                        
           ... OK (all 7 sub-tests PASSED)
      hexdump: highlighting                   ...
PASS:       hexdump: 1b_octal-1                    
PASS:       hexdump: 1b_octal-2                    
PASS:       hexdump: 1b_octal-3                    
PASS:       hexdump: 1b_octal-4                    
PASS:       hexdump: 1b_octal-5                    
PASS:       hexdump: 1b_octal-6                    
PASS:       hexdump: 1b_octal-7                    
PASS:       hexdump: 1b_octal-8                    
PASS:       hexdump: 1b_octal-9                    
PASS:       hexdump: 1b_char-1                     
PASS:       hexdump: 1b_char-2                     
PASS:       hexdump: 1b_char-3                     
PASS:       hexdump: canon-1                       
PASS:       hexdump: canon-2                       
PASS:       hexdump: 2b_dec-1                      
PASS:       hexdump: 2b_dec-2                      
PASS:       hexdump: 2b_dec-3                      
PASS:       hexdump: 2b_dec-4                      
PASS:       hexdump: 2b_dec-5                      
PASS:       hexdump: 2b_dec-6                      
PASS:       hexdump: 2b_dec-7                      
PASS:       hexdump: 2b_dec-8                      
PASS:       hexdump: 4b_dec-1                      
PASS:       hexdump: 4b_dec-2                      
PASS:       hexdump: 4b_dec-3                      
PASS:       hexdump: 4b_dec-4                      
PASS:       hexdump: 4b_dec-5                      
PASS:       hexdump: 4b_dec-6                      
PASS:       hexdump: 4b_dec-7                      
           ... OK (all 29 sub-tests PASSED)
SKIP:       hwclock: system to hw                   (missing in PATH: sntp)
PASS:          ipcs: headers                       
PASS:          ipcs: limits overflow               
PASS:          ipcs: basic limits                  
PASS:          ipcs: mk-rm-msg                     
PASS:          ipcs: mk-rm-sem                     
PASS:          ipcs: mk-rm-shm                     
      isosize: print-size                     ...
PASS:       isosize: default_output                
PASS:       isosize: sector_output                 
PASS:       isosize: divisor_output                
           ... OK (all 3 sub-tests PASSED)
PASS:          kill: all_processes                 
PASS:          kill: name_to_number                
PASS:          kill: options                       
PASS:          kill: print_pid                     
PASS:          kill: queue                         
SKIP:      libfdisk: GPT                            (test_fdisk_gpt not found)
     libfdisk: mkpart                         ...
PASS:      libfdisk: mbr                           
PASS:      libfdisk: mbr-logic                     
PASS:      libfdisk: mbr-nopartno                  
PASS:      libfdisk: gpt                           
           ... OK (all 4 sub-tests PASSED)
     libfdisk: mkpart-full                    ...
PASS:      libfdisk: mbr-primary                   
PASS:      libfdisk: mbr-primary-nopartno          
PASS:      libfdisk: mbr-err-primary               
PASS:      libfdisk: mbr-err-nospace               
PASS:      libfdisk: mbr-logical                   
PASS:      libfdisk: mbr-nopartno                  
PASS:      libfdisk: mbr-err-logical               
PASS:      libfdisk: mbr-space-gap                 
PASS:      libfdisk: gpt                           
PASS:      libfdisk: gpt-nopartno                  
PASS:      libfdisk: gpt-err-overlap               
PASS:      libfdisk: gpt-partno-gap                
PASS:      libfdisk: gpt-space-gap                 
           ... OK (all 13 sub-tests PASSED)
SKIP:      libmount: context                        (test not compiled)
SKIP:      libmount: context-py                     (pylibmount not compiled)
SKIP:      libmount: context (utab)                 (test not compiled)
SKIP:      libmount: context-py (utab)              (pylibmount not compiled)
SKIP:      libmount: debugging                      (test not compiled)
SKIP:      libmount: lock                           (optional)
     libmount: losetup-loop                   ...
[  422.649372] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  422.717112] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:      libmount: file                          
[  423.622405] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  423.671424] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:      libmount: file-o-loop                   
[  424.310051] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  424.349762] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:      libmount: dev-loop                      
[  425.001931] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  425.031520] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:      libmount: o-loop-val                    
[  425.746048] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  425.776050] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:      libmount: reuse                         
PASS:      libmount: conflict                      
PASS:      libmount: o-loop-val-initialized        
PASS:      libmount: o-loop-val-conflict           
           ... OK (all 8 sub-tests PASSED)
[  430.931115] loop_set_status: loop0 () has still dirty pages (nrpages=1)
FAIL:      libmount: loop overlay                   (libmount/loop-overlay)
SKIP:      libmount: options string                 (test not compiled)
SKIP:      libmount: table diffs                    (test not compiled)
SKIP:      libmount: tab files                      (test not compiled)
SKIP:      libmount: tab files-py                   (pylibmount not compiled)
SKIP:      libmount: tags                           (test not compiled)
SKIP:      libmount: tags-py                        (pylibmount not compiled)
SKIP:      libmount: tab update                     (test not compiled)
SKIP:      libmount: tab update-py                  (pylibmount not compiled)
SKIP:      libmount: utils                          (test not compiled)
 libsmartcols: fromfile                       ...
PASS:  libsmartcols: tree                          
PASS:  libsmartcols: tree-json                     
PASS:  libsmartcols: tree-middle                   
PASS:  libsmartcols: tree-end                      
PASS:  libsmartcols: trunc                         
PASS:  libsmartcols: right                         
PASS:  libsmartcols: right-maxout                  
PASS:  libsmartcols: strictwidth                   
PASS:  libsmartcols: noextremes                    
PASS:  libsmartcols: hidden                        
PASS:  libsmartcols: wrap                          
PASS:  libsmartcols: wrap-tree                     
PASS:  libsmartcols: wrapnl                        
PASS:  libsmartcols: wrapnl-tree                   
PASS:  libsmartcols: raw                           
PASS:  libsmartcols: export                        
PASS:  libsmartcols: column-separator              
           ... OK (all 17 sub-tests PASSED)
PASS:  libsmartcols: title                         
       logger: errors                         ...
PASS:        logger: kern_priority                 
PASS:        logger: kern_priority_numeric         
PASS:        logger: invalid_prio                  
PASS:        logger: rfc5424_exceed_size           
PASS:        logger: id_with_space                 
PASS:        logger: tag_with_space                
PASS:        logger: tcp                           
PASS:        logger: multi-line                    
PASS:        logger: rfc5424_msgid_with_space      
PASS:        logger: invalid_socket                
PASS:        logger: check_socket                  
           ... OK (all 11 sub-tests PASSED)
       logger: formats                        ...
PASS:        logger: rfc3164                       
PASS:        logger: rfc5424_simple                
PASS:        logger: rfc5424_notime                
PASS:        logger: rfc5424_nohost                
PASS:        logger: rfc5424_msgid                 
PASS:        logger: octet_counting                
PASS:        logger: priorities                    
PASS:        logger: check_socket                  
           ... OK (all 8 sub-tests PASSED)
SKIP:        logger: journald                       (unsupported)
       logger: options                        ...
PASS:        logger: simple                        
PASS:        logger: log_pid                       
PASS:        logger: log_pid_long                  
PASS:        logger: log_pid_define                
PASS:        logger: log_pid_no_arg                
PASS:        logger: input_file_simple             
PASS:        logger: input_file_empty_line         
PASS:        logger: input_file_skip_empty         
PASS:        logger: input_file_prio_prefix        
PASS:        logger: check_socket                  
           ... OK (all 10 sub-tests PASSED)
PASS:         login: islocal                       
PASS:         login: defs                          
PASS:          look: separator                     
      losetup: losetup                        ...
PASS:       losetup: file-show                     
PASS:       losetup: file-offset                   
PASS:       losetup: file-sizelimit                
PASS:       losetup: file-section                  
           ... OK (all 4 sub-tests PASSED)
SKIP:       losetup: losetup-blkdev                 (missing scsi_debug module (dry-run))
SKIP:       losetup: losetup-loop                   (missing scsi_debug module (dry-run))
        lsblk: lsblk                          ...
PASS:         lsblk: simple-lvm-basic              
PASS:         lsblk: simple-lvm-discard            
PASS:         lsblk: simple-lvm-rw                 
PASS:         lsblk: simple-lvm-state              
PASS:         lsblk: simple-lvm-topo               
PASS:         lsblk: simple-lvm-vendor             
PASS:         lsblk: simple-lvm-zone               
PASS:         lsblk: simple-nvme-basic             
PASS:         lsblk: simple-nvme-discard           
PASS:         lsblk: simple-nvme-rw                
PASS:         lsblk: simple-nvme-state             
PASS:         lsblk: simple-nvme-topo              
PASS:         lsblk: simple-nvme-vendor            
PASS:         lsblk: simple-nvme-zone              
           ... OK (all 14 sub-tests PASSED)
        lscpu: lscpu                          ...
PASS:         lscpu: armv7                         
PASS:         lscpu: ppc-qemu                      
PASS:         lscpu: ppc64-POWER7-64cpu            
PASS:         lscpu: ppc64-POWER7                  
PASS:         lscpu: s390-kvm                      
PASS:         lscpu: s390-lpar-drawer              
PASS:         lscpu: s390-lpar                     
PASS:         lscpu: s390-zvm                      
PASS:         lscpu: sparc64                       
PASS:         lscpu: vbox-win                      
PASS:         lscpu: x86_64-64cpu                  
PASS:         lscpu: x86_64-dell_e4310             
           ... OK (all 12 sub-tests PASSED)
        lsmem: lsmem                          ...
PASS:         lsmem: s390-zvm-6g                   
PASS:         lsmem: x86_64-16g                    
           ... OK (all 2 sub-tests PASSED)
RTNETLINK answers: Operation not supported
SKIP:          lsns: NETNSID compare to ip-link     (failed to initialize)
PASS:          lsns: NSFS for ip-netns-add         
PASS:           md5: md5                           
SKIP:         minix: mkfs fsck                      (mkfs.minix not found)
SKIP:         minix: fsck images                    (fsck.minix not found)
SKIP:         minix: mkfs mount                     (mkfs.minix not found)
PASS:          misc: fallocate                     
         misc: flock                          ...
PASS:          misc: non-block                     
PASS:          misc: no-fork                       
PASS:          misc: shared                        
PASS:          misc: exclusive                     
PASS:          misc: timeout                       
         misc: time-check                     ... OK (diff 4 sec)
           ... OK (all 6 sub-tests PASSED)
PASS:          misc: ionice                        
SKIP:          misc: line                           (line not found)
         misc: mbsencode                      ...
PASS:          misc: safe-ascii                    
PASS:          misc: invalid-ascii                 
         misc: safe-utf8                      ... KNOWN FAILED (misc/mbsencode-safe-utf8)
         misc: invalid-utf8                   ... KNOWN FAILED (misc/mbsencode-invalid-utf8)
           ... KNOWN FAILED (2 from 4 sub-tests)
PASS:          misc: mcookie                       
PASS:          misc: rev                           
         misc: setarch                        ...
PASS:          misc: options                       
PASS:          misc: uname26                       
PASS:          misc: uname26-version               
           ... OK (all 3 sub-tests PASSED)
PASS:          misc: setsid                        
PASS:          misc: strtosize                     
PASS:          misc: swaplabel                     
SKIP:          misc: ul                             (testing ul command not supported yet.)
PASS:          misc: whereis                       
PASS:          more: regexp                        
PASS:          more: squeeze                       
[  571.332997] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  571.378999] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by devname                    
        mount: fs lists                       ...
[  574.146308] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  574.196062] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: one-type                      
[  574.754376] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  574.782414] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: more-types                    
[  575.495467] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  575.523975] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: more-types-fstab              
[  576.117007] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  576.192570] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: type-pattern                  
PASS:         mount: type-pattern-neg              
           ... OK (all 5 sub-tests PASSED)
        mount: broken fstab                   ...
PASS:         mount: mount                         
PASS:         mount: mount-all                     
           ... OK (all 2 sub-tests PASSED)
SKIP:         mount: btrfs (fstab)                  (kernel does not support btrfs)
[  582.956264] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  583.004716] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  583.337070] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  583.367575] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by devname (fstab)            
[  586.130758] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  586.161912] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by devname (fstab label)      
[  589.079205] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  589.132132] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by devname (fstab uuid)       
[  591.844897] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  591.875938] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  592.189063] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  592.220335] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  592.528898] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  592.560489] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by label (fstab)              
[  595.604181] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  595.664148] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  595.996933] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  596.038323] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by label (fstab devname)      
[  598.957098] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  599.009664] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  599.355335] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  599.387289] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by label (fstab uuid)         
[  601.758052] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  601.796602] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: loop (fstab)                  
PASS:         mount: none                          
[  606.454503] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  606.499768] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by devname (fstab symlink)    
[  609.492917] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  609.543357] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  609.912827] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  609.949547] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  610.285192] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  610.316288] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by uuid (fstab)               
[  613.156650] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  613.191327] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  613.516730] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  613.544286] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by uuid (fstab devname)       
[  616.675516] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  616.724424] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  617.059253] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  617.094242] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by uuid (fstab label)         
[  619.669032] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  619.704327] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  620.185132] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  620.241005] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by label                      
PASS:         mount: move                          
[  625.503197] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  625.560288] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: regular file                  
PASS:         mount: remount                       
SKIP:         mount: rlimit-fsize                   (mtab unsupported)
        mount: shared-subtree                 ...
PASS:         mount: make-shared                   
PASS:         mount: make-private                  
PASS:         mount: make-unbindable               
PASS:         mount: bind-shared                   
[  633.463145] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  633.522260] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: mount-private                 
[  634.064119] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  634.107513] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: mount-private-ro              
           ... OK (all 6 sub-tests PASSED)
PASS:         mount: call mount.<type>             
SKIP:         mount: umount-all-targets             (missing scsi_debug module (dry-run))
SKIP:         mount: umount-recursive               (missing scsi_debug module (dry-run))
[  642.327463] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  642.401372] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
[  642.853930] EXT4-fs (loop0): mounting ext3 file system using the ext4 subsystem
[  642.887993] EXT4-fs (loop0): mounted filesystem with ordered data mode. Opts: (null)
PASS:         mount: by uuid                       
PASS:         namei: basic functionality           
SKIP:         partx: partitions probing             (missing scsi_debug module (dry-run))
        partx: show images                    ...
PASS:         partx: atari-icd                     
PASS:         partx: atari-xgm                     
PASS:         partx: bsd                           
PASS:         partx: dos+bsd                       
PASS:         partx: gpt                           
PASS:         partx: sgi                           
PASS:         partx: sun                           
           ... OK (all 7 sub-tests PASSED)
SKIP:         paths: built-in                       (optional)
PASS:        rename: basic check                   
PASS:        rename: exit codes                    
PASS:        rename: overwrite                     
PASS:        rename: subdir check                  
PASS:        rename: symlink check                 
   schedutils: chrt                           ...
PASS:    schedutils: fifo                          
PASS:    schedutils: batch                         
PASS:    schedutils: other                         
PASS:    schedutils: rr                            
PASS:    schedutils: idle                          
chrt: failed to set pid 0's policy: Device or resource busy
[  669.366879] sched: DL replenish lagged too much
   schedutils: deadline                       ... KNOWN FAILED (schedutils/chrt-deadline)
Supported policies:
SCHED_OTHER min/max priority    : 0/0
SCHED_FIFO min/max priority     : 1/99
SCHED_RR min/max priority       : 1/99
SCHED_BATCH min/max priority    : 0/0
SCHED_IDLE min/max priority     : 0/0
SCHED_DEADLINE min/max priority : 0/0
PASS:    schedutils: batch-vs-nice                 
           ... OK (all 1 sub-tests PASSED)
PASS:    schedutils: cpuset                        
PASS:        script: buffering race                
       script: options                        ...
PASS:        script: append                        
PASS:        script: force                         
PASS:        script: quiet                         
PASS:        script: return                        
PASS:        script: size                          
           ... OK (all 5 sub-tests PASSED)
PASS:        script: race conditions               
PASS:        script: replay                        
SKIP:        sfdisk: MBR                            (missing scsi_debug module (dry-run))
SKIP:        sfdisk: GPT                            (missing scsi_debug module (dry-run))
SKIP:        sfdisk: movedata                       (missing scsi_debug module (dry-run))
SKIP:        sfdisk: resize                         (missing scsi_debug module (dry-run))
SKIP:        sfdisk: GPT                            (missing scsi_debug module (dry-run))
SKIP:        sfdisk: wipe                           (missing scsi_debug module (dry-run))
PASS:          sha1: sha1                          
[  807.812787] Adding 5116k swap on /dev/loop0.  Priority:-2 extents:1 across:5116k 
PASS:        swapon: by devname                    
[  810.348120] Adding 5116k swap on /dev/loop0.  Priority:-2 extents:1 across:5116k 
PASS:        swapon: fix page size                 
[  812.992450] Adding 5116k swap on /dev/loop0.  Priority:-2 extents:1 across:5116k 
PASS:        swapon: fix signature                 
[  815.135268] Adding 5116k swap on /dev/loop0.  Priority:-2 extents:1 across:5116k 
PASS:        swapon: by label                      
[  817.252462] Adding 5116k swap on /dev/loop0.  Priority:-2 extents:1 across:5116k 
PASS:        swapon: by uuid                       
         utmp: last                           ...
PASS:          utmp: nodns                         
           ... OK (all 1 sub-tests PASSED)
         utmp: last ipv6                      ...
PASS:          utmp: nodns                         
           ... OK (all 1 sub-tests PASSED)
PASS:          utmp: circle                        
PASS:          utmp: subsecond                     
SKIP:          utmp: to binary                      (utmp struct size 400)
SKIP:          utmp: IPv6 to binary                 (utmp struct size 400)
SKIP:          utmp: to text                        (utmp struct size 400)
SKIP:          utmp: IPv6 to text                   (utmp struct size 400)
PASS:          uuid: namespace                     
PASS:          uuid: oids                          
PASS:          uuid: uuid_parser                   
PASS:          uuid: uuidd                         
PASS:          uuid: uuidgen                       
PASS:          uuid: uuidparse                     
SKIP:        wipefs: wipefs                         (missing scsi_debug module (dry-run))
DURATION: 820
END: /usr/lib/util-linux/ptest
2020-09-11T02:13
STOP: ptest-runner

```

libmount's loop-overlay test success when run it.
```
root@qemuarm64:/usr/lib/util-linux/ptest/tests# ./ts/libmount/loop-overlay 
     libmount: loop overlay                   ... OK
```

mkfs-endianness test

```
root@qemuarm64:/usr/lib/util-linux/ptest/tests# for i in $(seq 1 100); do ./ts/cramfs/mkfs-endianness ; done | grep FAILED | wc -l
0
```


