### PR TITLE
Update kernel version to v4.19.150-cip36

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -36,8 +36,8 @@ LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
 #
 # LINUX_GIT_SRCREV = "${LINUX_GIT_BRANCH}"
 #
-LINUX_GIT_SRCREV ?= "1d9c4c7e291d5f49ab07402ef739f98fac6e7adb"
-LINUX_CVE_VERSION ?= "${@bb.utils.contains('LINUX_GIT_SRCREV', '1d9c4c7e291d5f49ab07402ef739f98fac6e7adb', '4.19.144', '${PV}', d)}"
+LINUX_GIT_SRCREV ?= "946cd6c834661fa97c8dc914c95fc8a90a111676"
+LINUX_CVE_VERSION ?= "${@bb.utils.contains('LINUX_GIT_SRCREV', '946cd6c834661fa97c8dc914c95fc8a90a111676', '4.19.150', '${PV}', d)}"
 
 # use toolchain mode for Debian instead of the default
 TCMODE ?= "emlinux"


### PR DESCRIPTION
# Test
## How to test
Build kernel

$ echo "MACHINE='qemuarm64'" >> conf/local.conf
$ bitbake linux-base
succesed

## Test result
$ cd tmp-glibc/work-shared/qemuarm64/kernel-source
$ git log
linux-4.19.y-cip, tag: v4.19.150-cip36
Kernel revision has been updated.