### PR TITLE
Update kernel version to v4.19.157-cip38

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -36,8 +36,8 @@ LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
 #
 # LINUX_GIT_SRCREV = "${LINUX_GIT_BRANCH}"
 #
-LINUX_GIT_SRCREV ?= "946cd6c834661fa97c8dc914c95fc8a90a111676"
-LINUX_CVE_VERSION ?= "${@bb.utils.contains('LINUX_GIT_SRCREV', '946cd6c834661fa97c8dc914c95fc8a90a111676', '4.19.150', '${PV}', d)}"
+LINUX_GIT_SRCREV ?= "d0a2919cfb81bc30f7def0b39f5cb1e370051f7a"
+LINUX_CVE_VERSION ?= "${@bb.utils.contains('LINUX_GIT_SRCREV', 'd0a2919cfb81bc30f7def0b39f5cb1e370051f7a', '4.19.157', '${PV}', d)}"
 
 # use toolchain mode for Debian instead of the default
 TCMODE ?= "emlinux"


### PR DESCRIPTION
# Purpose of pull request

Update kernel version to v4.19.157-cip38

# Test
## How to test

Run following command from console

```
$ echo 'MACHINE = "qemuarm64"' >> conf/local.conf
$ bitbake core-image-minimal
$ runqemu qemuarm64
```

## Test result

```
$ echo 'MACHINE = "qemuarm64"' >> conf/local.conf
$ bitbake core-image-minimal
$ cd tmp-glibc/work-shared/qemuarm64/kernel-source
$ git log
d0a2919cfb81 (HEAD -> linux-4.19.y-cip, tag: v4.19.157-cip38, origin/linux-4.19.y-cip) CIP: Bump version suffix to -cip38 after merge from stable
...
$ runqemu nographic
...
EMLinux 2.2 qemuarm64 /dev/ttyAMA0

qemuarm64 login: root
root@qemuarm64:~# uname -a
Linux qemuarm64 4.19.157-cip38 #1 SMP PREEMPT Wed Nov 18 05:05:53 UTC 2020 aarch64 GNU/Linux
```



