### PR TITLE
pam: Add emlinux specific patch

### DIFF
--- a/recipes-debian/pam/files/override-uservariables.patch
+++ b/recipes-debian/pam/files/override-uservariables.patch
@@ -1,0 +1,15 @@
+--- a/doc/specs/Makefile.am
++++ b/doc/specs/Makefile.am
+@@ -12,9 +12,9 @@ draft-morgan-pam-current.txt: padout dra
+ AM_YFLAGS = -d
+ 
+ CC = @CC_FOR_BUILD@
+-AM_CPPFLAGS = @BUILD_CPPFLAGS@
+-AM_CFLAGS = @BUILD_CFLAGS@
+-AM_LDFLAGS = @BUILD_LDFLAGS@
++CPPFLAGS = @BUILD_CPPFLAGS@
++CFLAGS = @BUILD_CFLAGS@
++LDFLAGS = @BUILD_LDFLAGS@
+ 
+ BUILT_SOURCES = parse_y.h
+ 

--- a/recipes-debian/pam/libpam_debian.bbappend
+++ b/recipes-debian/pam/libpam_debian.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+# Fix build issue on ubuntu 18.04
+SRC_URI += "file://override-uservariables.patch"
+


### PR DESCRIPTION
# Purpose of pull request

Add override-uservariables.patch that came from meta-debian-extended
repository. This patch is required to build libpam on ubuntu 18.04 build host.
EMLinux currently only support ubuntu 18.04 as supported distribution so this patch is required.

This PR is related to https://github.com/miraclelinux/meta-debian-extended/pull/285
# Test
## How to test

1. Add ```DISTRO_FEATURES += "pam" ``` in your local.conf
2. Build core-image-minimal


## Test result

The core-image-minimal image should be created.




