### PR TITLE
Beaglebone: Add support for wic image format

### DIFF
--- a/conf/machine/beaglebone.conf
+++ b/conf/machine/beaglebone.conf
@@ -20,6 +20,8 @@ KERNEL_DEVICETREE ?= " \
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
 PREFERRED_PROVIDER_u-boot = "u-boot"
 
+SPL_BINARY = "MLO"
+UBOOT_SUFFIX = "img"
 UBOOT_ENTRYPOINT ?= "0x80008000"
 UBOOT_LOADADDRESS ?= "0x80008000"
 UBOOT_MACHINE ?= "am335x_boneblack_config"
@@ -29,9 +31,11 @@ EXTRA_IMAGEDEPENDS += "u-boot"
 
 SERIAL_CONSOLES ?= "115200;ttyO0"
 
-IMAGE_FSTYPES = "tar.gz"
+IMAGE_FSTYPES = "tar.gz wic wic.bmap"
+WKS_FILE ?= "beaglebone.wks"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "kernel-image kernel-devicetree"
 
 MACHINE_FEATURES = "ext2 serial usbhost vfat"
 
+IMAGE_BOOT_FILES ?= "${KERNEL_IMAGETYPE} ${KERNEL_DEVICETREE}"

--- a/conf/machine/beaglebone.conf
+++ b/conf/machine/beaglebone.conf
@@ -12,6 +12,10 @@ require conf/machine/include/tune-cortexa8.inc
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-base"
 KERNEL_IMAGETYPE = "zImage"
+KERNEL_DEVICETREE ?= " \
+    am335x-boneblack.dtb \
+    am335x-boneblack-wireless.dtb \
+"
 
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
 PREFERRED_PROVIDER_u-boot = "u-boot"

--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -13,9 +13,5 @@ KERNEL_DEVICETREE_raspberrypi3-64 = "broadcom/bcm2837-rpi-3-b-plus.dtb \
                                      broadcom/bcm2837-rpi-3-b.dtb"
 
 SRC_URI_append_beaglebone += "file://beaglebone.config"
-KERNEL_DEVICETREE_beaglebone ?= " \
-    am335x-boneblack.dtb \
-    am335x-boneblack-wireless.dtb \
-"
 
 CVE_VERSION = "${LINUX_CVE_VERSION}"

--- a/wic/beaglebone.wks
+++ b/wic/beaglebone.wks
@@ -1,0 +1,8 @@
+# short-description: Create SD card image for Beaglebone Black
+# long-description: Create SD card image for Beaglebone Black that the user
+# can directory dd to sd card.
+
+part SPL --source rawcopy --sourceparams="file=MLO" --ondisk mmcblk --no-table --align 128
+part u-boot --source rawcopy --sourceparams="file=u-boot.img" --ondisk mmcblk --no-table --align 384
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4 --size 32 --use-uuid
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4 --use-uuid


### PR DESCRIPTION
Hi, EMLinux team.

First of all I'd like to thank you for accepting my PR#84.

In this PR, I added support for WIC image format of BeagleBone Black.
After applying this, user will be able to create bootable SD card image using dd.
I believe this patches improves usability of BeagleBone.

thank you.

## How To build

Add MACHINE ?= "beaglebone" to local.conf, and

```
$: bitbake core-image-weston
```

## How to Test

Flash the wic in ${DEPLOYDIR} to SD card.

```
$: dd if=core-image-weston-beaglebone.wic of=/dev/sdX
```

Insert the SD card into the BeagleBone Black with the power off.

Press and hold the 'boot button' then power up the board by plugging in the mini USB cable.