### PR TITLE
doc: Update how to clone rpi firmware

### DIFF
--- a/doc/raspberrypi3.md
+++ b/doc/raspberrypi3.md
@@ -76,7 +76,7 @@ $ sudo mount /dev/sde2 /mnt/rootfs
 1. Clone firmware repository
 
 ```
-$ git clone git@github.com:raspberrypi/firmware.git -b 1.20190709
+$ git clone https://github.com/raspberrypi/firmware.git -b 1.20190709
 ```
 
 2. Copy files to fat32 partition


### PR DESCRIPTION
Use https protocol instead of ssh. It easy to access git repository via https.

