### PR TITLE
Raspberrypi wic

### DIFF
--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -6,3 +6,22 @@ SERIAL_CONSOLES ?= "115200;ttyS1"
 
 UBOOT_MACHINE ?= "rpi_3_defconfig"
 IMAGE_INSTALL_append += " u-boot linux-firmware-bcm43455"
+
+IMAGE_FSTYPES = "tar.gz wic wic.gz"
+
+WKS_FILE ?=  "raspberrypi3-64.wks"
+IMAGE_BOOT_FILES ?= "Image \
+                     bcm2837-rpi-3-b-plus.dtb \
+                     u-boot.bin \
+                     rpi-bootfiles/start* \
+                     rpi-bootfiles/fixup* \
+                     rpi-bootfiles/bootcode.bin;bootcode.bin \
+                     rpi-bootfiles/overlays/*;overlays/ \
+                     boot.scr \
+                     config.txt \
+"
+
+do_image_wic[depends] += " \
+    rpi-bootfiles:do_deploy \
+    rpi-u-boot-scr:do_deploy \
+"

--- a/doc/raspberrypi3.md
+++ b/doc/raspberrypi3.md
@@ -39,6 +39,16 @@ $ bitbake core-image-minimal
 
 This document uses parted to create partitions and /dev/sde as sdcard device.
 
+## Using SD card image
+
+Write the following image to the SD card with the dd command.
+tmp-glibc/deploy/images/raspberrypi3-64/core-image-minimal-raspberrypi3-64.wic
+```
+$ sudo dd if=core-image-minimal-raspberrypi3-64.wic of=/dev/sde bs=1G
+```
+
+## Write kernel image and rootfs manually
+
 1. Create fat32 partition for boot.
 
 ```
@@ -72,7 +82,7 @@ $ sudo mount /dev/sde1 /mnt/rpi
 $ sudo mount /dev/sde2 /mnt/rootfs
 ```
 
-## Copy Raspberry Pi firmwares
+### Copy Raspberry Pi firmwares
 
 1. Clone firmware repository
 
@@ -90,7 +100,7 @@ $ sudo cp -r boot/overlays /mnt/rpi/.
 $ sudo cp boot/bootcode.bin /mnt/rpi/.
 ```
 
-## Copy kernel, dtb and u-boot
+### Copy kernel, dtb and u-boot
 
 Go to your build directory. Then,
 
@@ -100,7 +110,7 @@ $ sudo cp tmp-glibc/deploy/images/raspberrypi3-64/bcm2837-rpi-3-b-plus.dtb /mnt/
 $ sudo cp tmp-glibc/deploy/images/raspberrypi3-64/u-boot.bin /mnt/rpi/.
 ```
 
-##  Create config.txt
+###  Create config.txt
 
 1. Create config.txt on /mnt/rpi
 
@@ -122,7 +132,7 @@ gpu_mem=16
 mask_gpu_interrupt1=0x100
 ```
 
-## Setup u-boot
+### Setup u-boot
 
 1. Create boot.cmd file on any directory.
 
@@ -156,7 +166,7 @@ If you want see u-boot's message by uart, you needs to run following command.
 $ sudo sed -i -e "s/BOOT_UART=0/BOOT_UART=1/" /mnt/rpi/bootcode.bin
 ```
 
-## Setup root file system
+### Setup root file system
 
 1. Extract root file system files to sdcard
 

--- a/recipes-bsp/bootfiles/rpi-bootfiles.bb
+++ b/recipes-bsp/bootfiles/rpi-bootfiles.bb
@@ -1,0 +1,41 @@
+# base recipe: meta-raspberrypi/recipes-bsp/bootfiles/rpi-bootfiles.bb
+# base branch: master
+# base commit: 68976061c5c130ce68430a59c23afb8044975d41
+
+DESCRIPTION = "Closed source binary files to help boot the ARM on the BCM2835."
+LICENSE = "Proprietary"
+
+LIC_FILES_CHKSUM = "file://boot/LICENCE.broadcom;md5=4a4d169737c0786fb9482bb6d30401d1"
+
+inherit deploy nopackages
+
+include recipes-bsp/common/raspberrypi-firmware.inc
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+COMPATIBLE_MACHINE = "^ras"
+
+PR = "r1"
+
+S = "${WORKDIR}/firmware-${SRCREV}"
+
+do_deploy() {
+    install -d ${DEPLOYDIR}/${PN}
+
+    for i in ${S}/boot/start* ; do
+        cp $i ${DEPLOYDIR}/${PN}
+    done
+    for i in ${S}/boot/fixup* ; do
+        cp $i ${DEPLOYDIR}/${PN}
+    done
+    cp -r ${S}/boot/overlays ${DEPLOYDIR}/${PN}
+    cp ${S}/boot/bootcode.bin ${DEPLOYDIR}/${PN}
+
+    # Add stamp in deploy directory
+    touch ${DEPLOYDIR}/${PN}/${PN}-${PV}.stamp
+}
+
+addtask deploy before do_build after do_install
+do_deploy[dirs] += "${DEPLOYDIR}/${PN}"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/common/raspberrypi-firmware.inc
+++ b/recipes-bsp/common/raspberrypi-firmware.inc
@@ -1,0 +1,10 @@
+RPIFW_DATE ?= "20190709"
+SRCREV ?= "356f5c2880a3c7e8774025aa6fc934a617553e7b"
+RPIFW_SRC_URI ?= "https://github.com/raspberrypi/firmware/archive/${SRCREV}.tar.gz"
+RPIFW_S ?= "${WORKDIR}/firmware-${SRCREV}"
+
+SRC_URI = "${RPIFW_SRC_URI}"
+SRC_URI[md5sum] = "5962784e7963f0116cd1519e47749b25"
+SRC_URI[sha256sum] = "6e07d98e4229ba7a1970a4c475fc6b8631823d200d3b8734a508e7ff5ea4c120"
+
+PV = "${RPIFW_DATE}"

--- a/recipes-bsp/rpi-u-boot-scr/files/boot.cmd
+++ b/recipes-bsp/rpi-u-boot-scr/files/boot.cmd
@@ -1,0 +1,4 @@
+fatload mmc 0 ${kernel_addr_r} Image
+fatload mmc 0 ${fdt_addr_r} bcm2837-rpi-3-b-plus.dtb
+setenv bootargs dwc_otg.lpm_enable=0 earlyprintk root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
+booti ${kernel_addr_r} - ${fdt_addr_r}

--- a/recipes-bsp/rpi-u-boot-scr/files/config.txt
+++ b/recipes-bsp/rpi-u-boot-scr/files/config.txt
@@ -1,0 +1,15 @@
+[all]
+boot_delay=1
+kernel=u-boot.bin
+
+# Put the RPi3 into 64 bit mode
+arm_control=0x200
+
+upstream_kernel=1
+audio_pwm_mode=0
+
+# Enable UART
+enable_uart=1
+
+gpu_mem=16
+mask_gpu_interrupt1=0x100

--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -1,0 +1,32 @@
+# base recipe: meta-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb            
+# base branch: master 
+# base commit: 68976061c5c130ce68430a59c23afb8044975d41
+
+SUMMARY = "U-boot boot scripts for Raspberry Pi"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+COMPATIBLE_MACHINE = "^ras"
+
+DEPENDS = "u-boot-mkimage-native"
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+PR = "r1"
+
+SRC_URI = "file://boot.cmd \ 
+           file://config.txt \
+"
+
+do_compile() {
+    mkimage -A arm64 -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" boot.scr
+}
+
+inherit deploy nopackages
+
+do_deploy() {
+    cp ${WORKDIR}/config.txt ${DEPLOYDIR}
+    install -d ${DEPLOYDIR}
+    install -m 0644 boot.scr ${DEPLOYDIR}
+}
+
+addtask do_deploy after do_compile before do_build

--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -1,0 +1,71 @@
+# base recipe: meta-raspberrypi/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+# base branch: master 
+# base commit: 68976061c5c130ce68430a59c23afb8044975d41
+
+SUMMARY = "Linux kernel firmware files from Raspbian distribution"
+DESCRIPTION = "Updated firmware files for RaspberryPi hardware. \
+RPi-Distro obtains these directly from Cypress; they are not submitted \
+to linux-firmware for general use."
+HOMEPAGE = "https://github.com/RPi-Distro/firmware-nonfree"
+SECTION = "kernel"
+
+# In maintained upstream linux-firmware:
+# * brcmfmac43430-sdio falls under LICENCE.cypress
+# * brcmfmac43455-sdio falls under LICENCE.broadcom_bcm43xx
+# * brcmfmac43456-sdio falls under LICENCE.broadcom_bcm43xx
+#
+# It is likely[^1] that both of these should be under LICENCE.cypress.
+# Further, at this time the text of LICENCE.broadcom_bcm43xx is the same
+# in linux-firmware and RPi-Distro/firmware-nonfree, but this may
+# change.
+#
+# Rather than make assumptions about what's supposed to be what, we'll
+# use the license implied by the source of these files, named to avoid
+# conflicts with linux-firmware.
+#
+# [^1]: https://github.com/RPi-Distro/bluez-firmware/issues/1
+LICENSE = "\
+    Firmware-broadcom_bcm43xx-rpidistro \
+    & WHENCE \
+"
+LIC_FILES_CHKSUM = "\
+    file://LICENCE.broadcom_bcm43xx;md5=3160c14df7228891b868060e1951dfbc \
+    file://WHENCE;md5=7b12b2224438186e4c97c4c7f3a5cc28 \
+"
+
+# These are not common licenses, set NO_GENERIC_LICENSE for them
+# so that the license files will be copied from fetched source
+NO_GENERIC_LICENSE[Firmware-broadcom_bcm43xx-rpidistro] = "LICENCE.broadcom_bcm43xx"
+NO_GENERIC_LICENSE[WHENCE] = "WHENCE"
+
+SRC_URI = "git://github.com/RPi-Distro/firmware-nonfree"
+
+SRCREV = "b66ab26cebff689d0d3257f56912b9bb03c20567"
+PV = "20190114-1+rpt10"
+
+S = "${WORKDIR}/git"
+
+inherit allarch
+
+CLEANBROKEN = "1"
+
+do_compile() {
+    :
+}
+
+do_install() {
+    install -d ${D}${nonarch_base_libdir}/firmware
+
+    cp ./LICENCE.broadcom_bcm43xx ${D}${nonarch_base_libdir}/firmware/LICENCE.broadcom_bcm43xx-rpidistro
+}
+
+
+LICENSE_${PN}-bcm43430 = "Firmware-broadcom_bcm43xx-rpidistro"
+LICENSE_${PN}-bcm43455 = "Firmware-broadcom_bcm43xx-rpidistro"
+LICENSE_${PN}-bcm43456 = "Firmware-broadcom_bcm43xx-rpidistro"
+LICENSE_${PN}-broadcom-license = "Firmware-broadcom_bcm43xx-rpidistro"
+FILES_${PN}-broadcom-license = "${nonarch_base_libdir}/firmware/LICENCE.broadcom_bcm43xx-rpidistro"
+
+# Firmware files are generally not run on the CPU, so they can be
+# allarch despite being architecture specific
+INSANE_SKIP = "arch"

--- a/wic/raspberrypi3-64.wks
+++ b/wic/raspberrypi3-64.wks
@@ -1,0 +1,8 @@
+# short-description: Create SD card image for Raspberry Pi.
+# long-description: Creates a partitioned SD card image for Raspberry Pi.
+# SD card is partitioned as follows,
+#  1st partition: fat32, 65MB for u-boot and kernel image, dtb, firmware.
+#  2nd partition: ext4, 1GB for rootfs.
+
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 1024 --fixed-size 65
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 1024 --fixed-size 1024


### PR DESCRIPTION
# Purpose of pull request

For wic support of raspberry pi3

# Test
## How to test
Build core-image-minimal by following the steps in doc / raspberrypi3.md.
```
# bitbake core-image-minimal
```
After the construction is completed, write the wic image to the SD card and start it with raspberry pi3.
```
$ sudo dd if=core-image-minimal-raspberrypi3-64.wic of=/dev/sde bs=1G
```
## Test result
I was able to confirm the startup.
```
root@raspberrypi3-64:~# uname -a                                                
Linux raspberrypi3-64 4.19.175-cip43 #1 SMP PREEMPT Fri Mar 5 02:02:36 UTC 2021x
```


