### PR TITLE
kernel-cve-check.bbclass: add new class

### DIFF
--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -1,0 +1,198 @@
+#
+# kernel-cve-check.bbclass
+#
+# This class checks fixed CVEs in kernel by using cip-kernel-sec
+# and adds them to the CVE_CHECK_WHITELIST before the cve_check runs.
+#
+# This class reads cip version from 'LINUX_CIP_VERSION' variable.
+# Set the version of cip kernel to be used in the variable.
+#
+# Example:
+#   LINUX_CIP_VERSION = 'v4.19.165-cip41'
+#
+# In order to use this class inherit this class in the local.conf
+# and run cve_check task.
+
+inherit cve-check
+
+KERNEL_CVE_CHECK_DIR ?= "${CVE_CHECK_DB_DIR}/KERNEL"
+
+# Consider ignore information.
+# If value is "0", add CVEs that are registered as negligible to whitelist.
+KERNEL_CVE_CHECK_INCLUDE_IGNORE ?= "1"
+
+# Add ignore information to cve manifest.
+KERNEL_CVE_CHECK_SHOW_IGNORE_INFO ?= "0"
+
+python() {
+    if d.getVar("PN") == "linux-base":
+        d.appendVar("DEPENDS", " python3-html5lib-native python3-pyyaml-native ")
+}
+
+###############################################################################
+# update_cip_kernel_sec
+###############################################################################
+
+def remove_remote(workdir):
+    """
+    Remove needless remotes from remotes.yml.
+    """
+    import yaml
+
+    remotes_path = os.path.join(workdir, "remotes.yml")
+
+    with open(remotes_path) as f:
+        content = yaml.safe_load(f)
+
+    with open(remotes_path, "w") as f:
+        yaml.dump({"cip": content["cip"]}, f, default_flow_style=False)
+
+python update_cip_kernel_sec () {
+    """
+    Update cip-kernel-sec repository.
+    """
+    from bb.fetch2 import runfetchcmd
+
+    kernel_cve_check_dir = d.getVar("KERNEL_CVE_CHECK_DIR")
+    cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
+    git_uri = "https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec.git"
+
+    if not os.path.isdir(kernel_cve_check_dir):
+        os.mkdir(kernel_cve_check_dir)
+
+    if not os.path.isdir(cip_kernel_sec_path):
+        # first run
+        runfetchcmd("git clone %s cip-kernel-sec" % git_uri, d,  workdir=kernel_cve_check_dir)
+        remove_remote(os.path.join(cip_kernel_sec_path, "conf"))
+        runfetchcmd("git update-index --skip-worktree conf/remotes.yml", d, workdir=cip_kernel_sec_path)
+    else:
+        runfetchcmd("git pull", d, workdir=cip_kernel_sec_path)
+}
+
+do_populate_cve_db[postfuncs] += "update_cip_kernel_sec"
+
+###############################################################################
+# kernel_cve_check
+###############################################################################
+
+def get_issue_list(cip_kernel_sec_path):
+    """
+    Get issue list registered to cip-kernel-sec.
+    """
+    import glob
+    glob_param = cip_kernel_sec_path + "/issues/CVE-*.yml"
+
+    return [os.path.basename(name)[:-4] for name in glob.glob(glob_param)]
+
+python kernel_cve_check () {
+    """
+    Check cves by cip-kernel-sec
+    """
+    from bb.fetch2 import runfetchcmd
+    import requests
+
+    kernel_path = d.getVar("S")
+    linux_cip_ver = d.getVar("LINUX_CIP_VERSION")
+    kernel_cve_check_dir = d.getVar("KERNEL_CVE_CHECK_DIR")
+    cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
+    include_ignore = d.getVar("KERNEL_CVE_CHECK_INCLUDE_IGNORE")
+    python_path = d.getVar("STAGING_BINDIR_NATIVE") + "/python3-native/python3"
+
+    if linux_cip_ver is None:
+        bb.error("LINUX_CIP_VERSION is not set. Please set version")
+        return
+
+    opt_ignore = "--include-ignored" if include_ignore == "1" else ""
+
+    cert_path = requests.certs.where()
+    cmd = "SSL_CERT_FILE='%s' %s scripts/report_affected.py %s --remote-name cip:origin --git-repo %s %s" % (cert_path, python_path, opt_ignore, kernel_path, linux_cip_ver)
+    output = runfetchcmd(cmd, d, workdir=cip_kernel_sec_path)
+
+    affect_cves = output.split(":")[2].strip().split()
+
+    whitelist = []
+    for cve in get_issue_list(cip_kernel_sec_path):
+        if cve not in affect_cves:
+            whitelist.append(cve)
+
+    bb.debug(2, "Whitelisted by cip-kernel-sec:\n    %s" % "\n    ".join(whitelist))
+    d.appendVar("CVE_CHECK_WHITELIST", ' ' + ' '.join(whitelist))
+}
+
+do_cve_check[prefuncs] += "${@bb.utils.contains('PN', 'linux-base', 'kernel_cve_check', '', d)}"
+do_cve_check[depends] += "${@bb.utils.contains('PN', 'linux-base', 'linux-base:do_unpack linux-base:do_prepare_recipe_sysroot', '', d)}"
+
+###############################################################################
+# write_ignore_info
+###############################################################################
+
+def get_ignore_info(cip_kernel_sec_path, cve_id, d):
+    """
+    Get ignore reason for the cve_id.
+    """
+    import sys
+
+    sys.path.append(cip_kernel_sec_path + "/scripts")
+    import kernel_sec.issue
+
+    cwd = os.getcwd()
+    os.chdir(cip_kernel_sec_path)
+    issue = kernel_sec.issue.load(cve_id)
+    os.chdir(cwd)
+
+    ignore = issue.get('ignore', {})
+    for branch_name in ignore:
+        if branch_name == "all" or branch_name == "cip/4.19":
+            return ignore[branch_name].replace('\n', ' ')
+    return None
+
+def insert_ignore_info(file_name, d):
+    """
+    Insert IGNORE INFO attribute.
+    """
+    if not os.path.isfile(file_name):
+        bb.error("%s is not found." % file_name)
+        return
+
+    kernel_cve_check_dir =d.getVar("KERNEL_CVE_CHECK_DIR")
+    cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
+    issue_list = get_issue_list(cip_kernel_sec_path)
+
+    with open(file_name, "r") as f:
+        content = f.readlines()
+
+    for index,line in enumerate(content):
+        ignore_info = None
+        if line.startswith("PACKAGE NAME:"):
+            pkg_name = line.split()[2]
+        if line.startswith("CVE:") and pkg_name == "linux-base":
+            cve_id = line.split()[1]
+            if cve_id in issue_list:
+                ignore_info = get_ignore_info(cip_kernel_sec_path, cve_id, d)
+                if ignore_info:
+                    content.insert(index+6, "IGNORE INFO: %s\n" % ignore_info)
+
+    with open(file_name, "w") as f:
+        for line in content:
+            f.write(line)
+
+python write_ignore_info () {
+    """
+    Write ignore information to CVE manifest
+    """
+
+    cve_file = d.getVar("CVE_CHECK_LOG")
+
+    insert_ignore_info(cve_file, d)
+
+    if d.getVar("CVE_CHECK_COPY_FILES") == "1":
+        cve_dir = d.getVar("CVE_CHECK_DIR")
+        deploy_file = os.path.join(cve_dir, d.getVar("PN"))
+        insert_ignore_info(deploy_file, d)
+
+    if d.getVar("CVE_CHECK_CREATE_MANIFEST") == "1":
+        tmp_file = d.getVar("CVE_CHECK_TMP_FILE")
+        insert_ignore_info(tmp_file, d)
+}
+
+do_cve_check[postfuncs] += "${@bb.utils.contains('PN', 'linux-base', 'write_ignore_info', '', d) if d.getVar('KERNEL_CVE_CHECK_SHOW_IGNORE_INFO') == '1' else ''}"

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -38,6 +38,7 @@ LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
 #
 LINUX_GIT_SRCREV ?= "e48c182113555669a03ec13050eed01d1dc66e9f"
 LINUX_CVE_VERSION ?= "${@bb.utils.contains('LINUX_GIT_SRCREV', 'e48c182113555669a03ec13050eed01d1dc66e9f', '4.19.177', '${PV}', d)}"
+LINUX_CIP_VERSION ?= "${@bb.utils.contains('LINUX_GIT_SRCREV', 'e48c182113555669a03ec13050eed01d1dc66e9f', 'v4.19.177-cip44', '${PV}', d)}"
 
 # use toolchain mode for Debian instead of the default
 TCMODE ?= "emlinux"


### PR DESCRIPTION
# Purpose of pull request

This PR adds new class kernel-cve-check.
cve-check task only looks at NVD databse, but NVD dosen't have the fix information in cip.
In order to reduce false positives, 
this class checks kernel CVEs with cip-kernel-sec and pass the fixed CVEs to cve-check as whitelist.

# Test
## How to test
Inherit kernel-cve-check in conf/local.conf
 
```
$ echo 'INHERIT += "kernel-cve-check"' >> conf/local.conf
```

To output IGNORE information in cip-kernel-sec,
set `KERNEL_CVE=CHECK_SHOW_IGNORE_INFO` to "1".

```
$ echo 'KERNEL_CVE_CHECK_SHOW_IGNORE_INFO = "1"' >> conf/local.conf
```

Run linux-base cve-check.

```
$ bitbake -c cve_check linux-base
```

## Test result

```
$ bitbake -c cve_check lnux-base
WARNING: linux-base-gitAUTOINC+e48c182113-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2015-0569 CVE-2015-0570 CVE-2015-0571 CVE-2015-2877 CVE-2015-7312 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-15213 CVE-2019-16089 CVE-2019-19036 CVE-2019-19083 CVE-2019-19338 CVE-2019-20794 CVE-2019-9003 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-27170 CVE-2020-27171 CVE-2020-29374 CVE-2021-26934 CVE-2021-27363 CVE-2021-27364 CVE-2021-27365 CVE-2021-28038 CVE-2021-28660 CVE-2021-28964 CVE-2021-28971 CVE-2021-28972 CVE-2021-3444), for more information check /home/ubuntu/emlinux/build/tmp-glibc/work/qemuarm-emlinux-linux-gnueabi/linux-base/gitAUTOINC+e48c182113-r0/temp/cve.log
```

detailed information is generated in `<build-dir>/tmp-glibc/deploy/cve/linux-base`.


