### PR TITLE
Support genericx86-64 machine type

### DIFF
--- a/recipes-graphics/weston/weston-conf.bbappend
+++ b/recipes-graphics/weston/weston-conf.bbappend
@@ -2,6 +2,7 @@ DEFAULTBACKEND ??= ""
 DEFAULTBACKEND_qemuall ?= "fbdev"
 DEFAULTBACKEND_raspberrypi3-64 ?= "fbdev"
 DEFAULTBACKEND_beaglebone ?= "fbdev"
+DEFAULTBACKEND_genericx86-64 ?= "fbdev"
 
 do_install() {
         if [ -n "${DEFAULTBACKEND}" ]; then

--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -14,4 +14,6 @@ KERNEL_DEVICETREE_raspberrypi3-64 = "broadcom/bcm2837-rpi-3-b-plus.dtb \
 
 SRC_URI_append_beaglebone += "file://beaglebone.config"
 
+LINUX_DEFCONFIG_genericx86-64 = "x86_64_defconfig"
+
 CVE_VERSION = "${LINUX_CVE_VERSION}"

--- a/scripts/bbmask.conf
+++ b/scripts/bbmask.conf
@@ -2,8 +2,6 @@ BBMASK += "meta-debian/recipes-core"
 # nsswitch.conf is not provided by debian base-file package but systemd requires it.
 # use poky's base-files package temporary.
 BBMASK += "meta-debian/recipes-debian/base-files/base-files_debian.bb"
-BBMASK += "poky/meta/recipes-bsp/grub/grub_2.02.bb \
-           poky/meta/recipes-bsp/grub/grub-efi_2.02.bb \
-           poky/meta/recipes-sato/webkit/webkitgtk_2.22.7.bb \
+BBMASK += "poky/meta/recipes-sato/webkit/webkitgtk_2.22.7.bb \
            poky/meta/recipes-graphics/xorg-lib/libxxf86misc_1.0.4.bb \
            meta-debian/recipes-debian/fcode-utils/fcode-utils_debian.bb"

--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -45,6 +45,7 @@ if [ -z "$TEMPLATECONF" ] && [ "${EML_BUILDDIR_SETUP_DONE}" = "false" ]; then
 
     # add layer
     echo "BBLAYERS += \"\${TOPDIR}/../repos/poky/meta\"" >> conf/bblayers.conf
+    echo "BBLAYERS += \"\${TOPDIR}/../repos/poky/meta-yocto-bsp\"" >> conf/bblayers.conf
     echo "BBLAYERS += \"\${TOPDIR}/../repos/meta-debian\"" >> conf/bblayers.conf
     echo "BBLAYERS += \"\${TOPDIR}/../repos/meta-debian-extended\"" >> conf/bblayers.conf
     echo "BBLAYERS += \"\${TOPDIR}/../repos/meta-emlinux\"" >> conf/bblayers.conf


### PR DESCRIPTION
# Purpose of pull request

This PR support genericx86-64 machine.

# Test
## How to test

Add meta-yocto-bsp layer.
Set following lines in your local.conf then build core-image-minimal or core-image-weston.

```
MACHINE = "genericx86-64"
PREFERRED_PROVIDER_virtual/kernel = "linux-base"
``` 
## Test result

Build success.

