### PR TITLE
Support linux-cip 5.10

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -1,0 +1,16 @@
+require include/linux.inc
+
+DISTRO = "emlinux-k510"
+
+LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
+LINUX_GIT_SRCREV ?= "3ddbe9bf6a006b50d35887b00f96c5768a32b7f3"
+LINUX_CVE_VERSION ??= "5.10.8"
+
+#
+# If you want to use latest revision of the kernel, append the following line
+# to local.conf
+#
+#LINUX_GIT_SRCREV = "${LINUX_GIT_BRANCH}"
+
+# preferred providers and versions
+require conf/distro/include/emlinux-k510-preferred-provider.inc

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -1,91 +1,14 @@
+require include/linux.inc
+
 DISTRO = "emlinux"
-DISTRO_NAME = "EMLinux"
-DISTRO_VERSION = "2.3"
-DISTRO_CODENAME = "buster"
-SDK_VENDOR = "-emlinuxsdk"
-SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
-
-MAINTAINER = "Cybertrust Japan"
-
-TARGET_VENDOR = "-emlinux"
-
-LOCALCONF_VERSION = "1"
-
-DISTRO_VERSION[vardepsexclude] = "DATE"
-SDK_VERSION[vardepsexclude] = "DATE"
-
-# Override these in poky based distros
-EMLINUX_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan systemd"
-EMLINUX_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
-
-DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${EMLINUX_DEFAULT_DISTRO_FEATURES}"
-
-SDK_NAME = "${DISTRO}-${TCLIBC}-${SDK_ARCH}-${IMAGE_BASENAME}-${TUNE_PKGARCH}"
-SDKPATH = "/opt/${DISTRO}/${SDK_VERSION}"
-
-DISTRO_EXTRA_RDEPENDS += " ${EMLINUX_DEFAULT_EXTRA_RDEPENDS}"
-
-LINUX_GIT_URI ?= "git://git.kernel.org/pub/scm/linux/kernel/git/cip"
-LINUX_GIT_PROTOCOL ?= "https"
-LINUX_GIT_PREFIX ?= ""
-LINUX_GIT_REPO ?= "linux-cip.git"
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
+LINUX_GIT_SRCREV ?= "e48c182113555669a03ec13050eed01d1dc66e9f"
+LINUX_CVE_VERSION ??= "4.19.177"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf
 #
-# LINUX_GIT_SRCREV = "${LINUX_GIT_BRANCH}"
-#
-LINUX_GIT_SRCREV ?= "e48c182113555669a03ec13050eed01d1dc66e9f"
-LINUX_CVE_VERSION ?= "${@bb.utils.contains('LINUX_GIT_SRCREV', 'e48c182113555669a03ec13050eed01d1dc66e9f', '4.19.177', '${PV}', d)}"
-LINUX_CIP_VERSION ?= "${@bb.utils.contains('LINUX_GIT_SRCREV', 'e48c182113555669a03ec13050eed01d1dc66e9f', 'v4.19.177-cip44', '${PV}', d)}"
-
-# use toolchain mode for Debian instead of the default
-TCMODE ?= "emlinux"
-
-# Add an eventhandler that generates DEBIAN_SRC_URI information
-# from Debian apt repository.
-INHERIT += "debian-source"
-
-QEMU_TARGETS ?= "arm aarch64 i386 x86_64"
-
-PREMIRRORS ??= "\
-bzr://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
-cvs://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
-git://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
-gitsm://.*/.* http://downloads.yoctoproject.org/mirror/sources/ \n \
-hg://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
-osc://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
-p4://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
-svn://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n"
-
-MIRRORS =+ "\
-ftp://.*/.*      http://downloads.yoctoproject.org/mirror/sources/ \n \
-http://.*/.*     http://downloads.yoctoproject.org/mirror/sources/ \n \
-https://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n"
-
-SANITY_TESTED_DISTROS ?= " \
-            ubuntu-18.04 \n \
-            "
+#LINUX_GIT_SRCREV = "${LINUX_GIT_BRANCH}"
 
 # preferred providers and versions
 require conf/distro/include/emlinux-preferred-provider.inc
-
-#
-# OELAYOUT_ABI allows us to notify users when the format of TMPDIR changes in
-# an incompatible way. Such changes should usually be detailed in the commit
-# that breaks the format and have been previously discussed on the mailing list
-# with general agreement from the core team.
-#
-OELAYOUT_ABI = "12"
-
-# QA check settings - a little stricter than the OE-Core defaults
-WARN_TO_ERROR_QA = "already-stripped compile-host-path install-host-path \
-                    installed-vs-shipped ldflags pn-overrides rpaths staticdev \
-                    unknown-configure-option useless-rpaths"
-WARN_QA_remove = "${WARN_TO_ERROR_QA}"
-ERROR_QA_append = " ${WARN_TO_ERROR_QA}"
-
-BB_HASHBASE_WHITELIST_append = " DEBIAN_UNPACK_DIR"
-
-require conf/distro/include/no-static-libs.inc

--- a/conf/distro/include/emlinux-k510-preferred-provider.inc
+++ b/conf/distro/include/emlinux-k510-preferred-provider.inc
@@ -1,0 +1,6 @@
+# use simple kernel recipes instead of linux-yocto
+PREFERRED_PROVIDER_virtual/kernel = "linux-k510"
+PREFERRED_PROVIDER_linux-libc-headers = "linux-libc-headers-k510"
+PREFERRED_PROVIDER_nativesdk-linux-libc-headers = "nativesdk-linux-libc-headers-k510"
+PREFERRED_PROVIDER_virtual/crypt ?= "glibc"
+PREFERRED_PROVIDER_virtual/nativesdk-crypt ?= "nativesdk-glibc"

--- a/conf/distro/include/linux.inc
+++ b/conf/distro/include/linux.inc
@@ -1,0 +1,75 @@
+DISTRO_NAME = "EMLinux"
+DISTRO_VERSION = "2.3"
+DISTRO_CODENAME = "buster"
+SDK_VENDOR = "-emlinuxsdk"
+SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
+
+MAINTAINER = "Cybertrust Japan"
+
+TARGET_VENDOR = "-emlinux"
+
+LOCALCONF_VERSION = "1"
+
+DISTRO_VERSION[vardepsexclude] = "DATE"
+SDK_VERSION[vardepsexclude] = "DATE"
+
+# Override these in poky based distros
+EMLINUX_DEFAULT_DISTRO_FEATURES = "largefile opengl ptest multiarch wayland vulkan systemd"
+EMLINUX_DEFAULT_EXTRA_RDEPENDS = "packagegroup-core-boot"
+
+DISTRO_FEATURES ?= "${DISTRO_FEATURES_DEFAULT} ${DISTRO_FEATURES_LIBC} ${EMLINUX_DEFAULT_DISTRO_FEATURES}"
+
+SDK_NAME = "${DISTRO}-${TCLIBC}-${SDK_ARCH}-${IMAGE_BASENAME}-${TUNE_PKGARCH}"
+SDKPATH = "/opt/${DISTRO}/${SDK_VERSION}"
+
+DISTRO_EXTRA_RDEPENDS += " ${EMLINUX_DEFAULT_EXTRA_RDEPENDS}"
+
+LINUX_GIT_URI ?= "git://git.kernel.org/pub/scm/linux/kernel/git/cip"
+LINUX_GIT_PROTOCOL ?= "https"
+LINUX_GIT_PREFIX ?= ""
+# use toolchain mode for Debian instead of the default
+TCMODE ?= "emlinux"
+
+# Add an eventhandler that generates DEBIAN_SRC_URI information
+# from Debian apt repository.
+INHERIT += "debian-source"
+
+QEMU_TARGETS ?= "arm aarch64 i386 x86_64"
+
+PREMIRRORS ??= "\
+bzr://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
+cvs://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
+git://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
+gitsm://.*/.* http://downloads.yoctoproject.org/mirror/sources/ \n \
+hg://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
+osc://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n \
+p4://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n \
+svn://.*/.*   http://downloads.yoctoproject.org/mirror/sources/ \n"
+
+MIRRORS =+ "\
+ftp://.*/.*      http://downloads.yoctoproject.org/mirror/sources/ \n \
+http://.*/.*     http://downloads.yoctoproject.org/mirror/sources/ \n \
+https://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n"
+
+SANITY_TESTED_DISTROS ?= " \
+            ubuntu-18.04 \n \
+            "
+
+#
+# OELAYOUT_ABI allows us to notify users when the format of TMPDIR changes in
+# an incompatible way. Such changes should usually be detailed in the commit
+# that breaks the format and have been previously discussed on the mailing list
+# with general agreement from the core team.
+#
+OELAYOUT_ABI = "12"
+
+# QA check settings - a little stricter than the OE-Core defaults
+WARN_TO_ERROR_QA = "already-stripped compile-host-path install-host-path \
+                    installed-vs-shipped ldflags pn-overrides rpaths staticdev \
+                    unknown-configure-option useless-rpaths"
+WARN_QA_remove = "${WARN_TO_ERROR_QA}"
+ERROR_QA_append = " ${WARN_TO_ERROR_QA}"
+
+BB_HASHBASE_WHITELIST_append = " DEBIAN_UNPACK_DIR"
+
+require conf/distro/include/no-static-libs.inc

--- a/recipes-debian/perl/perl_debian.bbappend
+++ b/recipes-debian/perl/perl_debian.bbappend
@@ -1,0 +1,2 @@
+RDEPENDS_${PN}-ptest_remove = " linux-libc-headers-base-dev"
+RDEPENDS_${PN}-ptest_append = " linux-libc-headers-dev"

--- a/recipes-debian/qemu/qemu/0014-linux-user-fix-to-handle-variably-sized-SIOCGSTAMP-w-custom.patch
+++ b/recipes-debian/qemu/qemu/0014-linux-user-fix-to-handle-variably-sized-SIOCGSTAMP-w-custom.patch
@@ -1,0 +1,343 @@
+# This patch was copied from poky in thud branch.
+
+From 8104018ba4c66e568d2583a3a0ee940851ee7471 Mon Sep 17 00:00:00 2001
+From: Daniel P. Berrangé <berrange@redhat.com>
+Date: Tue, 23 Jul 2019 17:50:00 +0200
+Subject: [PATCH] linux-user: fix to handle variably sized SIOCGSTAMP with new
+ kernels
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The SIOCGSTAMP symbol was previously defined in the
+asm-generic/sockios.h header file. QEMU sees that header
+indirectly via sys/socket.h
+
+In linux kernel commit 0768e17073dc527ccd18ed5f96ce85f9985e9115
+the asm-generic/sockios.h header no longer defines SIOCGSTAMP.
+Instead it provides only SIOCGSTAMP_OLD, which only uses a
+32-bit time_t on 32-bit architectures.
+
+The linux/sockios.h header then defines SIOCGSTAMP using
+either SIOCGSTAMP_OLD or SIOCGSTAMP_NEW as appropriate. If
+SIOCGSTAMP_NEW is used, then the tv_sec field is 64-bit even
+on 32-bit architectures
+
+To cope with this we must now convert the old and new type from
+the target to the host one.
+
+Signed-off-by: Daniel P. Berrangé <berrange@redhat.com>
+Signed-off-by: Laurent Vivier <laurent@vivier.eu>
+Reviewed-by: Arnd Bergmann <arnd@arndb.de>
+Message-Id: <20190718130641.15294-1-laurent@vivier.eu>
+Signed-off-by: Laurent Vivier <laurent@vivier.eu>
+Signed-off-by: Bartosz Golaszewski <bgolaszewski@baylibre.com>
+---
+Uptream-status: Backport (upstream commit: 6d5d5dde9adb5acb32e6b8e3dfbf47fff0f308d2)
+
+ linux-user/ioctls.h        |  21 +++++-
+ linux-user/syscall.c       | 140 +++++++++++++++++++++++++++++--------
+ linux-user/syscall_defs.h  |  30 +++++++-
+ linux-user/syscall_types.h |   6 --
+ 4 files changed, 159 insertions(+), 38 deletions(-)
+
+diff --git a/linux-user/ioctls.h b/linux-user/ioctls.h
+index ae8951625f..e6a27ad9d6 100644
+--- a/linux-user/ioctls.h
++++ b/linux-user/ioctls.h
+@@ -219,8 +219,25 @@
+   IOCTL(SIOCGRARP, IOC_R, MK_PTR(MK_STRUCT(STRUCT_arpreq)))
+   IOCTL(SIOCGIWNAME, IOC_W | IOC_R, MK_PTR(MK_STRUCT(STRUCT_char_ifreq)))
+   IOCTL(SIOCGPGRP, IOC_R, MK_PTR(TYPE_INT)) /* pid_t */
+-  IOCTL(SIOCGSTAMP, IOC_R, MK_PTR(MK_STRUCT(STRUCT_timeval)))
+-  IOCTL(SIOCGSTAMPNS, IOC_R, MK_PTR(MK_STRUCT(STRUCT_timespec)))
++
++  /*
++   * We can't use IOCTL_SPECIAL() because it will set
++   * host_cmd to XXX_OLD and XXX_NEW and these macros
++   * are not defined with kernel prior to 5.2.
++   * We must set host_cmd to the same value as in target_cmd
++   * otherwise the consistency check in syscall_init()
++   * will trigger an error.
++   * host_cmd is ignored by the do_ioctl_XXX() helpers.
++   * FIXME: create a macro to define this kind of entry
++   */
++  { TARGET_SIOCGSTAMP_OLD, TARGET_SIOCGSTAMP_OLD,
++    "SIOCGSTAMP_OLD", IOC_R, do_ioctl_SIOCGSTAMP },
++  { TARGET_SIOCGSTAMPNS_OLD, TARGET_SIOCGSTAMPNS_OLD,
++    "SIOCGSTAMPNS_OLD", IOC_R, do_ioctl_SIOCGSTAMPNS },
++  { TARGET_SIOCGSTAMP_NEW, TARGET_SIOCGSTAMP_NEW,
++    "SIOCGSTAMP_NEW", IOC_R, do_ioctl_SIOCGSTAMP },
++  { TARGET_SIOCGSTAMPNS_NEW, TARGET_SIOCGSTAMPNS_NEW,
++    "SIOCGSTAMPNS_NEW", IOC_R, do_ioctl_SIOCGSTAMPNS },
+ 
+   IOCTL(RNDGETENTCNT, IOC_R, MK_PTR(TYPE_INT))
+   IOCTL(RNDADDTOENTCNT, IOC_W, MK_PTR(TYPE_INT))
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 96cd4bf86d..6df480e13d 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -37,6 +37,7 @@
+ #include <sched.h>
+ #include <sys/timex.h>
+ #include <sys/socket.h>
++#include <linux/sockios.h>
+ #include <sys/un.h>
+ #include <sys/uio.h>
+ #include <poll.h>
+@@ -1139,8 +1140,9 @@ static inline abi_long copy_from_user_timeval(struct timeval *tv,
+ {
+     struct target_timeval *target_tv;
+ 
+-    if (!lock_user_struct(VERIFY_READ, target_tv, target_tv_addr, 1))
++    if (!lock_user_struct(VERIFY_READ, target_tv, target_tv_addr, 1)) {
+         return -TARGET_EFAULT;
++    }
+ 
+     __get_user(tv->tv_sec, &target_tv->tv_sec);
+     __get_user(tv->tv_usec, &target_tv->tv_usec);
+@@ -1155,8 +1157,26 @@ static inline abi_long copy_to_user_timeval(abi_ulong target_tv_addr,
+ {
+     struct target_timeval *target_tv;
+ 
+-    if (!lock_user_struct(VERIFY_WRITE, target_tv, target_tv_addr, 0))
++    if (!lock_user_struct(VERIFY_WRITE, target_tv, target_tv_addr, 0)) {
++        return -TARGET_EFAULT;
++    }
++
++    __put_user(tv->tv_sec, &target_tv->tv_sec);
++    __put_user(tv->tv_usec, &target_tv->tv_usec);
++
++    unlock_user_struct(target_tv, target_tv_addr, 1);
++
++    return 0;
++}
++
++static inline abi_long copy_to_user_timeval64(abi_ulong target_tv_addr,
++                                             const struct timeval *tv)
++{
++    struct target__kernel_sock_timeval *target_tv;
++
++    if (!lock_user_struct(VERIFY_WRITE, target_tv, target_tv_addr, 0)) {
+         return -TARGET_EFAULT;
++    }
+ 
+     __put_user(tv->tv_sec, &target_tv->tv_sec);
+     __put_user(tv->tv_usec, &target_tv->tv_usec);
+@@ -1166,6 +1186,48 @@ static inline abi_long copy_to_user_timeval(abi_ulong target_tv_addr,
+     return 0;
+ }
+ 
++static inline abi_long target_to_host_timespec(struct timespec *host_ts,
++                                               abi_ulong target_addr)
++{
++    struct target_timespec *target_ts;
++
++    if (!lock_user_struct(VERIFY_READ, target_ts, target_addr, 1)) {
++        return -TARGET_EFAULT;
++    }
++    __get_user(host_ts->tv_sec, &target_ts->tv_sec);
++    __get_user(host_ts->tv_nsec, &target_ts->tv_nsec);
++    unlock_user_struct(target_ts, target_addr, 0);
++    return 0;
++}
++
++static inline abi_long host_to_target_timespec(abi_ulong target_addr,
++                                               struct timespec *host_ts)
++{
++    struct target_timespec *target_ts;
++
++    if (!lock_user_struct(VERIFY_WRITE, target_ts, target_addr, 0)) {
++        return -TARGET_EFAULT;
++    }
++    __put_user(host_ts->tv_sec, &target_ts->tv_sec);
++    __put_user(host_ts->tv_nsec, &target_ts->tv_nsec);
++    unlock_user_struct(target_ts, target_addr, 1);
++    return 0;
++}
++
++static inline abi_long host_to_target_timespec64(abi_ulong target_addr,
++                                                 struct timespec *host_ts)
++{
++    struct target__kernel_timespec *target_ts;
++
++    if (!lock_user_struct(VERIFY_WRITE, target_ts, target_addr, 0)) {
++        return -TARGET_EFAULT;
++    }
++    __put_user(host_ts->tv_sec, &target_ts->tv_sec);
++    __put_user(host_ts->tv_nsec, &target_ts->tv_nsec);
++    unlock_user_struct(target_ts, target_addr, 1);
++    return 0;
++}
++
+ static inline abi_long copy_from_user_timezone(struct timezone *tz,
+                                                abi_ulong target_tz_addr)
+ {
+@@ -4790,6 +4852,54 @@ static abi_long do_ioctl_kdsigaccept(const IOCTLEntry *ie, uint8_t *buf_temp,
+     return get_errno(safe_ioctl(fd, ie->host_cmd, sig));
+ }
+ 
++static abi_long do_ioctl_SIOCGSTAMP(const IOCTLEntry *ie, uint8_t *buf_temp,
++                                    int fd, int cmd, abi_long arg)
++{
++    struct timeval tv;
++    abi_long ret;
++
++    ret = get_errno(safe_ioctl(fd, SIOCGSTAMP, &tv));
++    if (is_error(ret)) {
++        return ret;
++    }
++
++    if (cmd == (int)TARGET_SIOCGSTAMP_OLD) {
++        if (copy_to_user_timeval(arg, &tv)) {
++            return -TARGET_EFAULT;
++        }
++    } else {
++        if (copy_to_user_timeval64(arg, &tv)) {
++            return -TARGET_EFAULT;
++        }
++    }
++
++    return ret;
++}
++
++static abi_long do_ioctl_SIOCGSTAMPNS(const IOCTLEntry *ie, uint8_t *buf_temp,
++                                      int fd, int cmd, abi_long arg)
++{
++    struct timespec ts;
++    abi_long ret;
++
++    ret = get_errno(safe_ioctl(fd, SIOCGSTAMPNS, &ts));
++    if (is_error(ret)) {
++        return ret;
++    }
++
++    if (cmd == (int)TARGET_SIOCGSTAMPNS_OLD) {
++        if (host_to_target_timespec(arg, &ts)) {
++            return -TARGET_EFAULT;
++        }
++    } else{
++        if (host_to_target_timespec64(arg, &ts)) {
++            return -TARGET_EFAULT;
++        }
++    }
++
++    return ret;
++}
++
+ #ifdef TIOCGPTPEER
+ static abi_long do_ioctl_tiocgptpeer(const IOCTLEntry *ie, uint8_t *buf_temp,
+                                      int fd, int cmd, abi_long arg)
+@@ -6160,32 +6270,6 @@ static inline abi_long target_ftruncate64(void *cpu_env, abi_long arg1,
+ }
+ #endif
+ 
+-static inline abi_long target_to_host_timespec(struct timespec *host_ts,
+-                                               abi_ulong target_addr)
+-{
+-    struct target_timespec *target_ts;
+-
+-    if (!lock_user_struct(VERIFY_READ, target_ts, target_addr, 1))
+-        return -TARGET_EFAULT;
+-    __get_user(host_ts->tv_sec, &target_ts->tv_sec);
+-    __get_user(host_ts->tv_nsec, &target_ts->tv_nsec);
+-    unlock_user_struct(target_ts, target_addr, 0);
+-    return 0;
+-}
+-
+-static inline abi_long host_to_target_timespec(abi_ulong target_addr,
+-                                               struct timespec *host_ts)
+-{
+-    struct target_timespec *target_ts;
+-
+-    if (!lock_user_struct(VERIFY_WRITE, target_ts, target_addr, 0))
+-        return -TARGET_EFAULT;
+-    __put_user(host_ts->tv_sec, &target_ts->tv_sec);
+-    __put_user(host_ts->tv_nsec, &target_ts->tv_nsec);
+-    unlock_user_struct(target_ts, target_addr, 1);
+-    return 0;
+-}
+-
+ static inline abi_long target_to_host_itimerspec(struct itimerspec *host_itspec,
+                                                  abi_ulong target_addr)
+ {
+diff --git a/linux-user/syscall_defs.h b/linux-user/syscall_defs.h
+index 12c8407144..c918419306 100644
+--- a/linux-user/syscall_defs.h
++++ b/linux-user/syscall_defs.h
+@@ -208,20 +208,34 @@
+     abi_int l_linger;       /* How long to linger for       */
+ };
+
++#if defined(TARGET_SPARC64) && !defined(TARGET_ABI32)
+ struct target_timeval {
+     abi_long tv_sec;
+-#if defined(TARGET_SPARC64) && !defined(TARGET_ABI32)
+     abi_int  tv_usec;
++};
++#define target__kernel_sock_timeval target_timeval
+ #else
++struct target_timeval {
++    abi_long tv_sec;
+     abi_long tv_usec;
+-#endif
+ };
+
++struct target__kernel_sock_timeval {
++    abi_llong tv_sec;
++    abi_llong tv_usec;
++};
++#endif
++
+ struct target_timespec {
+     abi_long tv_sec;
+     abi_long tv_nsec;
+ };
+
++struct target__kernel_timespec {
++    abi_llong tv_sec;
++    abi_llong tv_nsec;
++};
++
+ struct target_timezone {
+     abi_int tz_minuteswest;
+     abi_int tz_dsttime;
+@@ -750,8 +761,16 @@ struct target_pollfd {
+ #define TARGET_SIOCATMARK      0x8905
+ #define TARGET_SIOCGPGRP       0x8904
+ #endif
+-#define TARGET_SIOCGSTAMP      0x8906          /* Get stamp (timeval) */
+-#define TARGET_SIOCGSTAMPNS    0x8907          /* Get stamp (timespec) */
++#if defined(TARGET_SH4)
++#define TARGET_SIOCGSTAMP_OLD   TARGET_IOR('s', 100, struct target_timeval)
++#define TARGET_SIOCGSTAMPNS_OLD TARGET_IOR('s', 101, struct target_timespec)
++#else
++#define TARGET_SIOCGSTAMP_OLD   0x8906
++#define TARGET_SIOCGSTAMPNS_OLD 0x8907
++#endif
++
++#define TARGET_SIOCGSTAMP_NEW   TARGET_IOR(0x89, 0x06, abi_llong[2])
++#define TARGET_SIOCGSTAMPNS_NEW TARGET_IOR(0x89, 0x07, abi_llong[2])
+ 
+ /* Networking ioctls */
+ #define TARGET_SIOCADDRT       0x890B          /* add routing table entry */
+diff --git a/linux-user/syscall_types.h b/linux-user/syscall_types.h
+index b98a23b0f1..4e36983826 100644
+--- a/linux-user/syscall_types.h
++++ b/linux-user/syscall_types.h
+@@ -14,12 +14,6 @@ STRUCT(serial_icounter_struct,
+ STRUCT(sockaddr,
+        TYPE_SHORT, MK_ARRAY(TYPE_CHAR, 14))
+ 
+-STRUCT(timeval,
+-       MK_ARRAY(TYPE_LONG, 2))
+-
+-STRUCT(timespec,
+-       MK_ARRAY(TYPE_LONG, 2))
+-
+ STRUCT(rtentry,
+        TYPE_ULONG, MK_STRUCT(STRUCT_sockaddr), MK_STRUCT(STRUCT_sockaddr), MK_STRUCT(STRUCT_sockaddr),
+        TYPE_SHORT, TYPE_SHORT, TYPE_ULONG, TYPE_PTRVOID, TYPE_SHORT, TYPE_PTRVOID,
+-- 
+2.21.0
+

--- a/recipes-debian/qemu/qemu_debian.bbappend
+++ b/recipes-debian/qemu/qemu_debian.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/qemu:"
+
+SRC_URI += " \
+	file://0014-linux-user-fix-to-handle-variably-sized-SIOCGSTAMP-w-custom.patch \
+"

--- a/recipes-images/images/core-image-sdk.inc
+++ b/recipes-images/images/core-image-sdk.inc
@@ -3,11 +3,11 @@ IMAGE_INSTALL_append = " kernel-devsrc "
 # Post process after installed sdk
 sdk_post_process () {
         # Set up kernel for building kernel module now
-        echo "configuring scripts of kernel source for building .ko file..."
         $SUDO_EXEC bash -c 'source "$0" && cd "${OECORE_TARGET_SYSROOT}/usr/src/kernel" && make scripts' $target_sdk_dir/environment-setup-@REAL_MULTIMACH_TARGET_SYS@
 
         # Set up kernel headers for building user application
-        $SUDO_EXEC bash -c 'source "$0" && cd "${OECORE_TARGET_SYSROOT}/usr/src/kernel" && make mrproper; make headers_check; make INSTALL_HDR_PATH=${OECORE_TARGET_SYSROOT}/usr headers_install' $target_sdk_dir/environment-setup-@REAL_MULTIMACH_TARGET_SYS@
+        $SUDO_EXEC bash -c 'source "$0" && cd "${OECORE_TARGET_SYSROOT}/usr/src/kernel" && cp include/config/kernel.release _kernel.release; cp include/generated/utsrelease.h _utsrelease.h; make prepare; mv _kernel.release include/config/kernel.release; mv _utsrelease.h include/generated/utsrelease.h; make headers_check; make INSTALL_HDR_PATH=${OECORE_TARGET_SYSROOT}/usr headers_install' $target_sdk_dir/environment-setup-@REAL_MULTIMACH_TARGET_SYS@
 }
+
 SDK_POST_INSTALL_COMMAND_append = " ${sdk_post_process}"
 

--- a/recipes-kernel/linux-libc-headers/linux-libc-headers-k510.bb
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers-k510.bb
@@ -1,0 +1,5 @@
+require recipes-kernel/linux-libc-headers/linux-libc-headers-base_git.bb
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+DEPENDS += " rsync-native"

--- a/recipes-kernel/linux/kernel-devsrc.bbappend
+++ b/recipes-kernel/linux/kernel-devsrc.bbappend
@@ -1,0 +1,32 @@
+do_install_prepend() {
+    cd ${S}
+    if [ "${@bb.utils.vercmp_string_op(d.getVar("KERNEL_VERSION"), '5.10', '>=')}" = "True" ]; then
+        touch arch/arm64/kernel/vdso/gettimeofday.S
+        touch arch/arm64/kernel/module.lds
+    fi
+}
+
+do_install_append() {
+    if [ "${@bb.utils.vercmp_string_op(d.getVar("KERNEL_VERSION"), '5.10', '>=')}" = "True" ]; then
+        cd ${S}
+        if [ "${ARCH}" = "arm64" ]; then
+            install -D arch/arm64/kernel/vdso/*gettimeofday.* \
+                $kerneldir/build/arch/arm64/kernel/vdso/
+        fi
+        install -D lib/vdso/gettimeofday.* $kerneldir/build/lib/vdso/
+        install -D Kbuild $kerneldir/build/
+        install -D Kconfig $kerneldir/build/
+        install -D kernel/bounds.c $kerneldir/build/kernel/
+        install -D kernel/time/timeconst.bc $kerneldir/build/kernel/time/
+        install -D arch/arm64/kernel/asm-offsets.c $kerneldir/build/arch/arm64/kernel/
+
+        cd ${B}
+        install -D scripts/module.lds $kerneldir/build/scripts/
+    else
+        cd ${S}
+        install -D kernel/bounds.c $kerneldir/build/kernel/
+        install -D kernel/time/timeconst.bc $kerneldir/build/kernel/time/
+        install -D arch/arm64/kernel/asm-offsets.c $kerneldir/build/arch/arm64/kernel/
+    fi
+}
+

--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -1,19 +1,8 @@
+require linux-common.inc
+
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI_append = " \
 	file://base.config \
 "
-
-SRC_URI_append_qemuall += "file://qemu-emlinux.config"
-SRC_URI_append_qemuarm += "file://qemuarm.config"
-
-SRC_URI_append_raspberrypi3-64 += "file://raspberrypi3-64.config"
-LINUX_DEFCONFIG_raspberrypi3-64 = "defconfig"
-KERNEL_IMAGETYPE_raspberrypi3-64 = "Image"
-KERNEL_DEVICETREE_raspberrypi3-64 = "broadcom/bcm2837-rpi-3-b-plus.dtb \
-                                     broadcom/bcm2837-rpi-3-b.dtb"
-
-SRC_URI_append_beaglebone += "file://beaglebone.config"
-
-LINUX_DEFCONFIG_genericx86-64 = "x86_64_defconfig"
 
 CVE_VERSION = "${LINUX_CVE_VERSION}"

--- a/recipes-kernel/linux/linux-common.inc
+++ b/recipes-kernel/linux/linux-common.inc
@@ -1,0 +1,12 @@
+SRC_URI_append_qemuall += "file://qemu-emlinux.config"
+SRC_URI_append_qemuarm += "file://qemuarm.config"
+
+SRC_URI_append_raspberrypi3-64 += "file://raspberrypi3-64.config"
+LINUX_DEFCONFIG_raspberrypi3-64 = "defconfig"
+KERNEL_IMAGETYPE_raspberrypi3-64 = "Image"
+KERNEL_DEVICETREE_raspberrypi3-64 = "broadcom/bcm2837-rpi-3-b-plus.dtb \
+                                     broadcom/bcm2837-rpi-3-b.dtb"
+
+SRC_URI_append_beaglebone += "file://beaglebone.config"
+
+LINUX_DEFCONFIG_genericx86-64 = "x86_64_defconfig"

--- a/recipes-kernel/linux/linux-k510.bb
+++ b/recipes-kernel/linux/linux-k510.bb
@@ -1,0 +1,31 @@
+require linux-common.inc
+require recipes-kernel/linux/linux-base_git.bb
+
+PROVIDES += " linux-k510"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI_append = " \
+	file://base.config \
+"
+
+FILESEXTRAPATHS_append := ":${LAYERDIR_DEBIAN_debian}/recipes-kernel/linux/files/"
+
+KERNEL_CONFIG_COMMAND = "oe_runmake_call O=${B} -C ${S} olddefconfig"
+
+CVE_VERSION = "${LINUX_CVE_VERSION}"
+
+addtask shared_workdir_modules after do_compile_kernelmodules before do_sizecheck
+
+do_shared_workdir_modules () {
+        cd ${B}
+        kerneldir=${STAGING_KERNEL_BUILDDIR}
+
+        install -d $kerneldir/scripts 
+        [ -e scripts/module.lds ] && cp scripts/module.lds $kerneldir/scripts
+}
+
+do_shared_workdir_prepend () {
+        cd ${B}
+        touch Module.symvers
+}


### PR DESCRIPTION
Add 5.10 repository.
  conf/distro/emlinux.conf
  recipes-kernel/linux/linux-cip_5.10.bb
  recipes-kernel/linux-libc-headers/
Fix compile error.
  recipes-debian/qemu/qemu/
Fix SDK installer.
  recipes-images/images/core-image-sdk.inc
  recipes-kernel/linux/kernel-devsrc.bbappend

# Purpose of pull request

prototype for linux-cip 5.10 support.

# Test
## How to test
```
'# bitbake core-image-minimal
'# bitbake core-image-minimal-sdk -c populate_sdk
and install sdk.
```

## Test result
complete compile, and sdk install was succeeded.



