### PR TITLE
distro: fix wrong tag for LINUX_CIP_VERSION

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -1,10 +1,11 @@
 require include/emlinux.inc
 
 DISTRO = "emlinux"
+
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
 LINUX_GIT_SRCREV ?= "71e662f43092838cb809fac8b537b35e484310bf"
 LINUX_CVE_VERSION ??= "4.19.190"
-LINUX_CIP_VERSION ?= "4.19.190-cip49"
+LINUX_CIP_VERSION ??= "v4.19.190-cip49"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
# Test
## How to test

Run following command from console

```
$ echo 'MACHINE = "qemuarm64"' >> conf/local.conf
$ echo 'INHERIT += "kernel-cve-check"' >> conf/local.conf
$ bitbake -c cve_check linux-base
```

## Test result

The do_cve_check finishes successfully.

Example:
```
WARNING: linux-base-gitAUTOINC+71e662f430-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2015-0569 CVE-2015-0570 CVE-2015-0571 CVE-2015-2877 CVE-2015-7312 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-15213 CVE-2019-16089 CVE-2019-19036 CVE-2019-19083 CVE-2019-19338 CVE-2019-20794 CVE-2019-25044 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-36310 CVE-2020-36311 CVE-2020-36322 CVE-2021-20177 CVE-2021-23133 CVE-2021-23134 CVE-2021-26934 CVE-2021-29155 CVE-2021-32399 CVE-2021-33034 CVE-2021-33200 CVE-2021-3444 CVE-2021-3506), for more information check /work3/t/cvecheck/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/gitAUTOINC+71e662f430-r0/temp/cve.log
```
