### PR TITLE
kernel-cve-check: Make remote repo name configurable

### DIFF
--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -24,6 +24,9 @@ KERNEL_CVE_CHECK_INCLUDE_IGNORE ?= "1"
 # Add ignore information to cve manifest.
 KERNEL_CVE_CHECK_SHOW_IGNORE_INFO ?= "0"
 
+# Remote branch name.
+KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO ??= "origin"
+
 python() {
     if d.getVar("PN") == "linux-base":
         d.appendVar("DEPENDS", " python3-html5lib-native python3-pyyaml-native ")
@@ -97,6 +100,7 @@ python kernel_cve_check () {
     cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
     include_ignore = d.getVar("KERNEL_CVE_CHECK_INCLUDE_IGNORE")
     python_path = d.getVar("STAGING_BINDIR_NATIVE") + "/python3-native/python3"
+    remote_repo_name = d.getVar("KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO")
 
     if linux_cip_ver is None:
         bb.error("LINUX_CIP_VERSION is not set. Please set version")
@@ -105,7 +109,7 @@ python kernel_cve_check () {
     opt_ignore = "--include-ignored" if include_ignore == "1" else ""
 
     cert_path = requests.certs.where()
-    cmd = "SSL_CERT_FILE='%s' %s scripts/report_affected.py %s --remote-name cip:origin --git-repo %s %s" % (cert_path, python_path, opt_ignore, kernel_path, linux_cip_ver)
+    cmd = "SSL_CERT_FILE='%s' %s scripts/report_affected.py %s --remote-name cip:%s --git-repo %s %s" % (cert_path, python_path, opt_ignore, remote_repo_name, kernel_path, linux_cip_ver)
     output = runfetchcmd(cmd, d, workdir=cip_kernel_sec_path)
 
     affect_cves = output.split(":")[2].strip().split()


### PR DESCRIPTION
# Purpose of pull request

If user uses different remote name other than origin, kernel cve check
will fail because it use origin as remote repository name.
So, add specific environment value to support different remote repo name.

# Test

## How to test

Change remote repository name.

```
masami@ubuntu1804:~/emlinux/qemuarm64-build/tmp-glibc/work-shared/qemuarm64/kernel-source$ git remote
origin
masami@ubuntu1804:~/emlinux/qemuarm64-build/tmp-glibc/work-shared/qemuarm64/kernel-source$ git remote rename origin myorigin
masami@ubuntu1804:~/emlinux/qemuarm64-build/tmp-glibc/work-shared/qemuarm64/kernel-source$ git remote
myorigin
```

Add  these setting in conf/local.conf.

```
INHERIT += "cve-check debian-cve-check kernel-cve-check"
KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO = "myorigin"
```

Then run cve_check task.

## Test result

cve_check task should success.

```
masami@ubuntu1804:~/emlinux/qemuarm64-build$ bitbake -f linux-base -c cve_check 
>>> snip <<<
WARNING: linux-base-gitAUTOINC+71e662f430-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2015-0569 CVE-2015-0570 CVE-2015-0571 CVE-2015-2877 CVE-2015-7312 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-15213 CVE-2019-16089 CVE-2019-19036 CVE-2019-19083 CVE-2019-19338 CVE-2019-20794 CVE-2019-25044 CVE-2019-25045 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-36310 CVE-2020-36311 CVE-2020-36322 CVE-2020-36385 CVE-2020-36386 CVE-2021-20177 CVE-2021-23133 CVE-2021-23134 CVE-2021-26934 CVE-2021-29155 CVE-2021-32399 CVE-2021-33034 CVE-2021-33200 CVE-2021-3444 CVE-2021-3506 CVE-2021-3564), for more information check /home/masami/emlinux/qemuarm64-build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/gitAUTOINC+71e662f430-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 508 tasks of which 506 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```