### PR TITLE
kernel-cve-check: Detect remote name from kernel-src

### DIFF
--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -24,8 +24,9 @@ KERNEL_CVE_CHECK_INCLUDE_IGNORE ?= "1"
 # Add ignore information to cve manifest.
 KERNEL_CVE_CHECK_SHOW_IGNORE_INFO ?= "0"
 
-# Remote branch name.
-KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO ??= "origin"
+# Remote branch name. bitbake detects it from kernel-src by default.
+KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO ??= ""
+KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT ??= "1"
 
 python() {
     if d.getVar("PN") == "linux-base":
@@ -93,6 +94,7 @@ python kernel_cve_check () {
     """
     from bb.fetch2 import runfetchcmd
     import requests
+    import bb.process
 
     kernel_path = d.getVar("S")
     linux_cip_ver = d.getVar("LINUX_CIP_VERSION")
@@ -101,12 +103,22 @@ python kernel_cve_check () {
     include_ignore = d.getVar("KERNEL_CVE_CHECK_INCLUDE_IGNORE")
     python_path = d.getVar("STAGING_BINDIR_NATIVE") + "/python3-native/python3"
     remote_repo_name = d.getVar("KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO")
+    remote_repo_autodetect = d.getVar("KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT")
 
     if linux_cip_ver is None:
         bb.error("LINUX_CIP_VERSION is not set. Please set version")
         return
 
     opt_ignore = "--include-ignored" if include_ignore == "1" else ""
+
+    # Try to get remote name from kernel repository
+    if not remote_repo_name and remote_repo_autodetect == "1":
+        try:
+            bb.debug(2, "No remote name is defined and KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT is set. bitbake detects remote name from kernel-src")
+            stdout, _ = bb.process.run('git remote', cwd=kernel_path, shell=True)
+            remote_repo_name = stdout.splitlines()[0]
+        except bb.process.ExecutionError as e:
+            bb.warn("Failed to detect remote name. bitbake assumes that remote is 'origin'. Please consider setting KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO")
 
     cert_path = requests.certs.where()
     cmd = "SSL_CERT_FILE='%s' %s scripts/report_affected.py %s --remote-name cip:%s --git-repo %s %s" % (cert_path, python_path, opt_ignore, remote_repo_name, kernel_path, linux_cip_ver)


### PR DESCRIPTION
This commit allows bitbake to detect remote name from kernel-src.
If detection fails, bitbake will use 'origin' as remote name.
This feature is disabled if `KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO` is defined by the user.

# Test
## How to test
Run following command from console (almost same as PR#115)

```
$: cd tmp-glibc/work-shared/qemuarm64/kernel-source/
$: git remote rename origin myorigin
$: cd -
```

Add these setting in conf/local.conf. 

```
INHERIT += "cve-check debian-cve-check kernel-cve-check"
```

Then run cve_check task.


## Test result

cve_check task should success even if `KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO` is not set.

```
$: bitbake -fc cve_check linux-base
...(snip)...
WARNING: linux-base-gitAUTOINC+71e662f430-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 ...
NOTE: Tasks Summary: Attempted 508 tasks of which 506 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```



