### PR TITLE
Support ubuntu 20.04 as build host os

### DIFF
--- a/conf/distro/include/emlinux.inc
+++ b/conf/distro/include/emlinux.inc
@@ -53,6 +53,7 @@ https://.*/.*    http://downloads.yoctoproject.org/mirror/sources/ \n"
 
 SANITY_TESTED_DISTROS ?= " \
             ubuntu-18.04 \n \
+            ubuntu-20.04 \n \
             "
 
 #

--- a/recipes-debian/qemu/qemu-native_debian.bbappend
+++ b/recipes-debian/qemu/qemu-native_debian.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/qemu:"
+
+SRC_URI += " \
+	file://0001-Apply-patch-0001-linux-user-assume-__NR_gettid-alway.patch \
+	file://0002-Apply-patch-0001-linux-user-rename-gettid-to-sys_get.patch \
+	file://0003-Apply-patch-0011-linux-user-remove-host-stime-sysca.patch \
+	file://0014-linux-user-fix-to-handle-variably-sized-SIOCGSTAMP-w-custom.patch \
+"

--- a/recipes-debian/qemu/qemu/0001-Apply-patch-0001-linux-user-assume-__NR_gettid-alway.patch
+++ b/recipes-debian/qemu/qemu/0001-Apply-patch-0001-linux-user-assume-__NR_gettid-alway.patch
@@ -1,0 +1,42 @@
+From 3906b2b60881f34d8c9ee7aeb73786f003425690 Mon Sep 17 00:00:00 2001
+From: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+Date: Fri, 25 Jun 2021 10:39:29 +0900
+Subject: [PATCH 1/3] Apply patch:
+ 0001-linux-user-assume-__NR_gettid-always-exists.patch
+
+Backport patch 0001-linux-user-assume-__NR_gettid-always-exists.patch[1]
+from poky thud branch.
+
+This commit fixed hunk.
+
+1:
+https://git.yoctoproject.org/cgit/cgit.cgi/poky/patch/meta/recipes-devtools/qemu/qemu/0001-linux-user-assume-__NR_gettid-always-exists.patch?id=f3a4b208500790f2163dab3fefc8f18b57d37621
+
+Signed-off-by: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+---
+ linux-user/syscall.c | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index efdd000..8c2e8ec 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -249,15 +249,7 @@ static type name (type1 arg1,type2 arg2,type3 arg3,type4 arg4,type5 arg5,	\
+ #define TARGET_NR__llseek TARGET_NR_llseek
+ #endif
+ 
+-#ifdef __NR_gettid
+ _syscall0(int, gettid)
+-#else
+-/* This is a replacement for the host gettid() and must return a host
+-   errno. */
+-static int gettid(void) {
+-    return -ENOSYS;
+-}
+-#endif
+ 
+ /* For the 64-bit guest on 32-bit host case we must emulate
+  * getdents using getdents64, because otherwise the host
+-- 
+2.25.1
+

--- a/recipes-debian/qemu/qemu/0002-Apply-patch-0001-linux-user-rename-gettid-to-sys_get.patch
+++ b/recipes-debian/qemu/qemu/0002-Apply-patch-0001-linux-user-rename-gettid-to-sys_get.patch
@@ -1,0 +1,65 @@
+From 0f044697ec66ed52c01ef5089733d8af130c292a Mon Sep 17 00:00:00 2001
+From: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+Date: Fri, 25 Jun 2021 10:44:33 +0900
+Subject: [PATCH 2/3] Apply patch:
+ 0001-linux-user-rename-gettid-to-sys_gettid-to-avoid-clas.patch
+
+Backport patch 0001-linux-user-rename-gettid-to-sys_gettid-to-avoid-clas.patch[1] from poky thud branch.
+
+This commit fixed hunk.
+
+1:
+https://git.yoctoproject.org/cgit/cgit.cgi/poky/patch/meta/recipes-devtools/qemu/qemu/0001-linux-user-rename-gettid-to-sys_gettid-to-avoid-clas.patch?id=f3a4b208500790f2163dab3fefc8f18b57d37621
+
+Signed-off-by: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+---
+ linux-user/syscall.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 8c2e8ec..384da6a 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -249,7 +249,8 @@ static type name (type1 arg1,type2 arg2,type3 arg3,type4 arg4,type5 arg5,	\
+ #define TARGET_NR__llseek TARGET_NR_llseek
+ #endif
+ 
+-_syscall0(int, gettid)
++#define __NR_sys_gettid __NR_gettid
++_syscall0(int, sys_gettid)
+ 
+ /* For the 64-bit guest on 32-bit host case we must emulate
+  * getdents using getdents64, because otherwise the host
+@@ -5373,7 +5374,7 @@ static void *clone_func(void *arg)
+     cpu = ENV_GET_CPU(env);
+     thread_cpu = cpu;
+     ts = (TaskState *)cpu->opaque;
+-    info->tid = gettid();
++    info->tid = sys_gettid();
+     task_settid(ts);
+     if (info->child_tidptr)
+         put_user_u32(info->tid, info->child_tidptr);
+@@ -5518,9 +5519,9 @@ static int do_fork(CPUArchState *env, unsigned int flags, abi_ulong newsp,
+                mapping.  We can't repeat the spinlock hack used above because
+                the child process gets its own copy of the lock.  */
+             if (flags & CLONE_CHILD_SETTID)
+-                put_user_u32(gettid(), child_tidptr);
++                put_user_u32(sys_gettid(), child_tidptr);
+             if (flags & CLONE_PARENT_SETTID)
+-                put_user_u32(gettid(), parent_tidptr);
++                put_user_u32(sys_gettid(), parent_tidptr);
+             ts = (TaskState *)cpu->opaque;
+             if (flags & CLONE_SETTLS)
+                 cpu_set_tls (env, newtls);
+@@ -10504,7 +10505,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+         return TARGET_PAGE_SIZE;
+ #endif
+     case TARGET_NR_gettid:
+-        return get_errno(gettid());
++        return get_errno(sys_gettid());
+ #ifdef TARGET_NR_readahead
+     case TARGET_NR_readahead:
+ #if TARGET_ABI_BITS == 32
+-- 
+2.25.1
+

--- a/recipes-debian/qemu/qemu/0003-Apply-patch-0011-linux-user-remove-host-stime-sysca.patch
+++ b/recipes-debian/qemu/qemu/0003-Apply-patch-0011-linux-user-remove-host-stime-sysca.patch
@@ -1,0 +1,41 @@
+From b7e6e848230a69c62f34378921a2d2289c6291c3 Mon Sep 17 00:00:00 2001
+From: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+Date: Fri, 25 Jun 2021 10:58:18 +0900
+Subject: [PATCH 3/3] Apply patch:
+ 0011-linux-user-remove-host-stime-syscall.patch
+
+Backport patch 0011-linux-user-remove-host-stime-syscall.patch[1] from poky
+thud branch.
+
+This commit fixed hunk and patching error.
+
+1:
+https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/meta/recipes-devtools/qemu/qemu/0011-linux-user-remove-host-stime-syscall.patch?h=thud&id=e52122a3e6912575ff401a4af6ac1bf3070092bc
+
+Signed-off-by: Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+---
+ linux-user/syscall.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 384da6a..aaf4d50 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -7314,10 +7314,11 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+ #ifdef TARGET_NR_stime /* not on alpha */
+     case TARGET_NR_stime:
+         {
+-            time_t host_time;
+-            if (get_user_sal(host_time, arg1))
++            struct timespec ts;
++            ts.tv_nsec = 0;
++            if (get_user_sal(ts.tv_sec, arg1))
+                 return -TARGET_EFAULT;
+-            return get_errno(stime(&host_time));
++            return get_errno(clock_settime(CLOCK_REALTIME, &ts));
+         }
+ #endif
+ #ifdef TARGET_NR_alarm /* not on alpha */
+-- 
+2.25.1
+


### PR DESCRIPTION
# Purpose of pull request

This PR supports ubuntu 20.04 as build host.

There is three patches backport from poky thud branch to fix build issues.

1. 0001-Apply-patch-0001-linux-user-assume-__NR_gettid-alway.patch

Upstream patch is [0001-linux-user-assume-__NR_gettid-always-exists.patch](https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-devtools/qemu/qemu/0001-linux-user-assume-__NR_gettid-always-exists.patch?h=thud).  Upstream patch file is able to patch, but has some hunk so  these are fixed.

2. 0002-Apply-patch-0001-linux-user-rename-gettid-to-sys_get.patch

Upstream patch is [0001-linux-user-rename-gettid-to-sys_gettid-to-avoid-clas.patch](https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-devtools/qemu/qemu/0001-linux-user-rename-gettid-to-sys_gettid-to-avoid-clas.patch?h=thud).  Upstream patch file is able to patch, but has some hunk so  these are fixed.

3. 0003-Apply-patch-0011-linux-user-remove-host-stime-sysca.patch

Upstream patch is [0011-linux-user-remove-host-stime-syscall.patch](https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-devtools/qemu/qemu/0011-linux-user-remove-host-stime-syscall.patch?h=thud). Upstream patch cannot apply to meta-debian's qemu source code. so I fixed it.

# Test
## How to test

build core-image-minimal and core-image-weston then execute runqemu command to start these images.

## Test result

Build and run on ubuntu 20.04 host.

![qemu_ubuntu2004](https://user-images.githubusercontent.com/165052/123390446-e31cd500-d5d5-11eb-9452-df549805e4ad.png)

Build and run on ubuntu 18.04 host.

![qemu_ubuntu1804](https://user-images.githubusercontent.com/165052/123390494-f2038780-d5d5-11eb-8eea-befb7c53e208.png)
