### PR TITLE
bluez5: Fix build error for emlinux-k510

### DIFF
--- a/recipes-debian/bluez5/bluez5/tools_Fix_build_after_y2038_changes_in_glibc.patch
+++ b/recipes-debian/bluez5/bluez5/tools_Fix_build_after_y2038_changes_in_glibc.patch
@@ -1,0 +1,65 @@
+From f36f71f60b1e68c0f12e615b9b128d089ec3dd19 Mon Sep 17 00:00:00 2001
+From: Bastien Nocera <hadess@hadess.net>
+Date: Fri, 7 Jun 2019 09:51:33 +0200
+Subject: tools: Fix build after y2038 changes in glibc
+
+The 32-bit SIOCGSTAMP has been deprecated. Use the deprecated name
+to fix the build.
+---
+ tools/l2test.c | 6 +++++-
+ tools/rctest.c | 6 +++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+(limited to 'tools')
+
+diff --git a/tools/l2test.c b/tools/l2test.c
+index e755ac881..e787c2ce2 100644
+--- a/tools/l2test.c
++++ b/tools/l2test.c
+@@ -55,6 +55,10 @@
+ #define BREDR_DEFAULT_PSM	0x1011
+ #define LE_DEFAULT_PSM		0x0080
+ 
++#ifndef SIOCGSTAMP_OLD
++#define SIOCGSTAMP_OLD SIOCGSTAMP
++#endif
++
+ /* Test modes */
+ enum {
+ 	SEND,
+@@ -907,7 +911,7 @@ static void recv_mode(int sk)
+ 			if (timestamp) {
+ 				struct timeval tv;
+ 
+-				if (ioctl(sk, SIOCGSTAMP, &tv) < 0) {
++				if (ioctl(sk, SIOCGSTAMP_OLD, &tv) < 0) {
+ 					timestamp = 0;
+ 					memset(ts, 0, sizeof(ts));
+ 				} else {
+diff --git a/tools/rctest.c b/tools/rctest.c
+index 94490f462..bc8ed875d 100644
+--- a/tools/rctest.c
++++ b/tools/rctest.c
+@@ -50,6 +50,10 @@
+ 
+ #include "src/shared/util.h"
+ 
++#ifndef SIOCGSTAMP_OLD
++#define SIOCGSTAMP_OLD SIOCGSTAMP
++#endif
++
+ /* Test modes */
+ enum {
+ 	SEND,
+@@ -505,7 +509,7 @@ static void recv_mode(int sk)
+ 			if (timestamp) {
+ 				struct timeval tv;
+ 
+-				if (ioctl(sk, SIOCGSTAMP, &tv) < 0) {
++				if (ioctl(sk, SIOCGSTAMP_OLD, &tv) < 0) {
+ 					timestamp = 0;
+ 					memset(ts, 0, sizeof(ts));
+ 				} else {
+-- 
+cgit 1.2.3-1.el7
+

--- a/recipes-debian/bluez5/bluez5_debian.bbappend
+++ b/recipes-debian/bluez5/bluez5_debian.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/bluez5:"
+
+SRC_URI += " \
+	file://tools_Fix_build_after_y2038_changes_in_glibc.patch \	
+"


### PR DESCRIPTION
# Purpose of pull request
If DISTRO is set to emlinux-k510, building bluez5 is failed because of y2038 changes in glibc.

```
| ../bluez-5.50/tools/rctest.c: In function 'recv_mode':
| ../bluez-5.50/tools/rctest.c:507:19: error: 'SIOCGSTAMP' undeclared
(first use in this function); did you mean 'SIOCGARP'?
|      if (ioctl(sk, SIOCGSTAMP, &tv) < 0) {
|                    ^~~~~~~~~~
|                    SIOCGARP
| ../bluez-5.50/tools/rctest.c:507:19: note: each undeclared identifier
is reported only once for each function it appears in
| Makefile:6223: recipe for target 'tools/rctest.o' failed
| make[1]: *** [tools/rctest.o] Error 1
| make[1]: *** Waiting for unfinished jobs....
| aarch64-emlinux-linux-libtool: link: aarch64-emlinux-linux-gcc-ar cru
src/.libs/libshared-mainloop.a src/shared/.libs/queue.o
```

To fix this, import upstream patch[1].

1:
https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/tools?id=f36f71f60b1e68c0f12e615b9b128d089ec3dd19

# Test
## How to test

Set following line to conf/local.conf

```
DISTRO = "emlinux-k510"
```

Then build core-image-weston.

## Test result

```
masami@ubuntu1804:~/emlinux/qemuarm64-build$ bitbake -f core-image-weston
Loading cache: 100% |##########################################################################################################################################################################################################| Time: 0:00:00
Loaded 2330 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux-k510"
DISTRO_VERSION       = "2.3"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 = "warrior:c8c383d958807b991e31d22f612ba2a81a3860a4"
meta-debian          = "warrior:a02e7a8bc7dccdf08fa8f3d2a4b9705a271a1215"
meta-debian-extended = "warrior:70cefb817171dba7fa159f087076f827548c201b"
meta-emlinux         = "warrior:46b6d15a1529f214dfc3afab9b0f6b9b17f598bc"

NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/qemuarm64-build/../repos/poky/meta/recipes-graphics/images/core-image-weston.bb, do_build                                                                    | ETA:  0:00:00
WARNING: /home/masami/emlinux/qemuarm64-build/../repos/meta-debian-extended/recipes-debian/bluez5/bluez5_debian.bb.do_build is tainted from a forced run                                                                       | ETA:  0:00:00
WARNING: /home/masami/emlinux/qemuarm64-build/../repos/poky/meta/recipes-graphics/images/core-image-weston.bb.do_build is tainted from a forced run
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:02
Sstate summary: Wanted 980 Found 0 Missed 980 Current 586 (0% match, 37% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 5159 tasks of which 2922 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```