### PR TITLE
init-ifupdown: Use prepend instead of append

### DIFF
--- a/recipes-core/init-ifupdown/init-ifupdown_1.0.bbappend
+++ b/recipes-core/init-ifupdown/init-ifupdown_1.0.bbappend
@@ -1,5 +1,5 @@
 # interfaces file is based on commit 733ae41f20983a7e6f1c147188aa6b4db951d05b.
-FILESEXTRAPATHS_append := "${THISDIR}/${PN}-${PV}"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}-${PV}:"
 
 SRC_URI += "file://wait-iface.sh"
 


### PR DESCRIPTION
# Purpose of pull request

Use FILESEXTRAPATHS_prepend instead of FILESEXTRAPATHS_append.

# Test
## How to test

build and run qemu image

```
# bitbake core-image-minimal
# runqemu core-image-minimal slirp
```

## Test result

It can get ip address from dhcp.

```
root@qemuarm64:~# cat /proc/cmdline 
root=/dev/vda rw highres=off  console=ttyS0 mem=512M ip=dhcp console=ttyAMA0 
root@qemuarm64:~# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast qlen 1000
    link/ether 52:54:00:12:35:02 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global eth0
       valid_lft forever preferred_lft forever
```
