### PR TITLE
rpi3: Remove fixed-size option

### DIFF
--- a/wic/raspberrypi3-64.wks
+++ b/wic/raspberrypi3-64.wks
@@ -5,4 +5,4 @@
 #  2nd partition: ext4, 1GB for rootfs.
 
 part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 1024 --fixed-size 65
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 1024 --fixed-size 1024
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label root --align 1024


### PR DESCRIPTION
# Purpose of pull request
Do not set fixed-size option to set flexible size of root filesystem.

# Test
## How to test

Build image and run emlinux on the raspberry pi device.


```
# bitbake core-image-minimal
```

## Test result

Root file system size is not 1GB fixed size. The partition size is enough size to store root file system files. 

```
root@raspberrypi3-64:~# df -h
Filesystem                Size      Used Available Use% Mounted on
/dev/root                85.7M     49.5M     29.8M  62% /
devtmpfs                465.5M         0    465.5M   0% /dev
tmpfs                   482.1M    236.0K    481.9M   0% /run
tmpfs                   482.1M     60.0K    482.1M   0% /var/volatile
/dev/mmcblk0p1           64.9M     42.3M     22.6M  65% /boot
 
```



