### PR TITLE
classes:kernel-cve-check: Fix linux-k510 is not handled

### DIFF
--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -28,9 +28,14 @@ KERNEL_CVE_CHECK_SHOW_IGNORE_INFO ?= "0"
 KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO ??= ""
 KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT ??= "1"
 
+KERNEL_PN = ""
+KERNEL_CVE_CHECK_TASK_ORDER = ""
+
 python() {
-    if d.getVar("PN") == "linux-base":
+    if d.getVar("PN") in ['linux-base', 'linux-k510']:
         d.appendVar("DEPENDS", " python3-html5lib-native python3-pyyaml-native ")
+        d.setVar('KERNEL_PN', d.getVar('PN'))
+        d.setVar('KERNEL_CVE_CHECK_TASK_ORDER', '{}:do_unpack {}:do_prepare_recipe_sysroot'.format(d.getVar('KERNEL_PN'), d.getVar('KERNEL_PN')))
 }
 
 ###############################################################################
@@ -135,8 +140,8 @@ python kernel_cve_check () {
     d.appendVar("CVE_CHECK_WHITELIST", ' ' + ' '.join(whitelist))
 }
 
-do_cve_check[prefuncs] += "${@bb.utils.contains('PN', 'linux-base', 'kernel_cve_check', '', d)}"
-do_cve_check[depends] += "${@bb.utils.contains('PN', 'linux-base', 'linux-base:do_unpack linux-base:do_prepare_recipe_sysroot', '', d)}"
+do_cve_check[prefuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'kernel_cve_check', '', d)}"
+do_cve_check[depends] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), d.getVar('KERNEL_CVE_CHECK_TASK_ORDER'), '', d)}"
 
 ###############################################################################
 # write_ignore_info
@@ -181,7 +186,7 @@ def insert_ignore_info(file_name, d):
         ignore_info = None
         if line.startswith("PACKAGE NAME:"):
             pkg_name = line.split()[2]
-        if line.startswith("CVE:") and pkg_name == "linux-base":
+        if line.startswith("CVE:") and pkg_name == d.getVar('KERNEL_PN'):
             cve_id = line.split()[1]
             if cve_id in issue_list:
                 ignore_info = get_ignore_info(cip_kernel_sec_path, cve_id, d)
@@ -211,4 +216,4 @@ python write_ignore_info () {
         insert_ignore_info(tmp_file, d)
 }
 
-do_cve_check[postfuncs] += "${@bb.utils.contains('PN', 'linux-base', 'write_ignore_info', '', d) if d.getVar('KERNEL_CVE_CHECK_SHOW_IGNORE_INFO') == '1' else ''}"
+do_cve_check[postfuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'write_ignore_info', '', d) if d.getVar('KERNEL_CVE_CHECK_SHOW_IGNORE_INFO') == '1' else ''}"


### PR DESCRIPTION
# Purpose of pull request

There is two kernel types the one is linux-base and the other is
linux-k510. This commit supports both kernel types.

# Test
## How to test

Build linux kernel with cve check feature

Add following lines to enable cve check.

```
INHERIT += "cve-check debian-cve-check kernel-cve-check"
```

cve check should success and result must be different both kernels.

Set  DISTRO to target distribution.

```
#DISTRO = "emlinux-k510"
DISTRO = "emlinux"
```

## Test result

DISTRO=emlinux -k510

```
masami@ubuntu1804:~/emlinux/k510-build$ bitbake linux-k510 
Parsing recipes: 100% |########################################################################################################################################################################################################| Time: 0:00:26
Parsing of 1317 .bb files complete (0 cached, 1317 parsed). 2334 targets, 75 skipped, 4 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux-k510"
DISTRO_VERSION       = "2.3"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "warrior:c8c383d958807b991e31d22f612ba2a81a3860a4"
meta-debian          = "warrior:2caf6c5cc97982ca335f4693cc8ccfedb71bf81c"
meta-debian-extended = "warrior:bda787a691f29e4fa3b0084db2865a8b029b33c7"
meta-emlinux         = "cvecheck-support-k510:e64832c25af18769b7ae3d084015a7cb2ceb6472"

WARNING: /home/masami/emlinux/k510-build/../repos/meta-emlinux/recipes-kernel/linux/linux-k510.bb.do_build is tainted from a forced run                                                                                        | ETA:  0:00:00
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 0 Found 0 Missed 0 Current 82 (0% match, 100% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: linux-k510-gitAUTOINC+3ddbe9bf6a-r0 do_cve_check: Found unpatched CVE (CVE-2020-16120 CVE-2021-29155 CVE-2021-29264 CVE-2021-32078 CVE-2021-33033 CVE-2021-33200 CVE-2021-33624 CVE-2021-34556 CVE-2021-3506 CVE-2021-35477 CVE-2021-37159 CVE-2021-38198 CVE-2021-38199), for more information check /home/masami/emlinux/k510-build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-k510/gitAUTOINC+3ddbe9bf6a-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 713 tasks of which 710 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```

DISTRO=emlinux

```
masami@ubuntu1804:~/emlinux/k510-build$ bitbake linux-base
Parsing recipes: 100% |########################################################################################################################################################################################################| Time: 0:00:27
Parsing of 1317 .bb files complete (0 cached, 1317 parsed). 2334 targets, 75 skipped, 4 masked, 0 errors.
Removing 1 recipes from the aarch64 sysroot: 100% |############################################################################################################################################################################| Time: 0:00:06
Removing 2 recipes from the qemuarm64 sysroot: 100% |##########################################################################################################################################################################| Time: 0:00:03
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.3"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "warrior:c8c383d958807b991e31d22f612ba2a81a3860a4"
meta-debian          = "warrior:2caf6c5cc97982ca335f4693cc8ccfedb71bf81c"
meta-debian-extended = "warrior:bda787a691f29e4fa3b0084db2865a8b029b33c7"
meta-emlinux         = "cvecheck-support-k510:e64832c25af18769b7ae3d084015a7cb2ceb6472"

Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 14 Found 0 Missed 14 Current 66 (0% match, 82% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: linux-base-gitAUTOINC+ad19e133ae-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2015-0569 CVE-2015-0570 CVE-2015-0571 CVE-2015-2877 CVE-2015-7312 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-15213 CVE-2019-16089 CVE-2019-19036 CVE-2019-19083 CVE-2019-19338 CVE-2019-20794 CVE-2019-25044 CVE-2019-25045 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-36310 CVE-2020-36322 CVE-2020-36385 CVE-2021-20177 CVE-2021-26934 CVE-2021-29155 CVE-2021-32078 CVE-2021-3444 CVE-2021-34556 CVE-2021-35477 CVE-2021-3635 CVE-2021-37159), for more information check /home/masami/emlinux/k510-build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/gitAUTOINC+ad19e133ae-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 694 tasks of which 653 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```


