### PR TITLE
Update kernel version to latest release version

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "ad19e133aebcec558066ea338f896ec0b7338254"
-LINUX_CVE_VERSION ??= "4.19.205"
-LINUX_CIP_VERSION ??= "v4.19.205-cip56"
+LINUX_GIT_SRCREV ?= "425e38cc5d37221e1e058adba114721516ac16d1"
+LINUX_CVE_VERSION ??= "4.19.206"
+LINUX_CIP_VERSION ??= "v4.19.206-cip57"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
# Purpose of pull request

Update kernel version from v4.19.205-cip56 to v4.19.206-cip57.

# Test
## How to test

Build core-image-minimal and run it.

```
$ bitbake core-image-minimal
$ runqemu nographic qemuarm64
```

Make core-image-minimal should be succeeded.

## Test result

kernel should be updated version.

```
EMLinux 2.3 qemuarm64 /dev/ttyAMA0

qemuarm64 login: root
root@qemuarm64:~# uname -a
Linux qemuarm64 4.19.206-cip57 #1 SMP PREEMPT Tue Sep 14 07:21:41 UTC 2021 aarch64 GNU/Linux```
```


