### PR TITLE
distro: bump up version for EMLinux 2.4 release

### DIFF
--- a/conf/distro/include/emlinux.inc
+++ b/conf/distro/include/emlinux.inc
@@ -1,5 +1,5 @@
 DISTRO_NAME = "EMLinux"
-DISTRO_VERSION = "2.3"
+DISTRO_VERSION = "2.4"
 DISTRO_CODENAME = "buster"
 SDK_VENDOR = "-emlinuxsdk"
 SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"


### PR DESCRIPTION
This just increments the minor version of EMLinux.