### PR TITLE
Update kernel version to v4.19.207-cip58

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "425e38cc5d37221e1e058adba114721516ac16d1"
-LINUX_CVE_VERSION ??= "4.19.206"
-LINUX_CIP_VERSION ??= "v4.19.206-cip57"
+LINUX_GIT_SRCREV ?= "c3737f5637179738a7e899359a490e349ee75d82"
+LINUX_CVE_VERSION ??= "4.19.207"
+LINUX_CIP_VERSION ??= "v4.19.207-cip58"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
# Purpose of pull request

Update kernel version from v4.19.206-cip57 to v4.19.207-cip58.



# Test
## How to test

Build core-image-minimal or core-image-weston and run it.

```
# bitbake core-image-weston
# runqemu qemuarm64
```

## Test result

core-image-weston with new kernel works fine.

![Screenshot from 2021-09-30 21-17-39](https://user-images.githubusercontent.com/165052/135453930-8e598ae7-faea-4e94-93a6-e4019519d6ae.png)



