### PR TITLE
kernel: Update kernel version to v4.19.209-cip59

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "c3737f5637179738a7e899359a490e349ee75d82"
-LINUX_CVE_VERSION ??= "4.19.207"
-LINUX_CIP_VERSION ??= "v4.19.207-cip58"
+LINUX_GIT_SRCREV ?= "11e803e05e061dc32e92deb7bd73c20dfbc48ae5"
+LINUX_CVE_VERSION ??= "4.19.209"
+LINUX_CIP_VERSION ??= "v4.19.209-cip59"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
# Purpose of pull request

Update kernel version from v4.19.207-cip58 to v4.19.209-cip59.

# Test
## How to test

Build and run core-image-weston

## Test result

core-image-weston with new kernel works fine.

![core-image-weston-v4 19 209-cip59](https://user-images.githubusercontent.com/165052/137053199-0bad6509-de5e-4590-82d5-b2f11228e807.png)



