### PR TITLE
linux: Fix typo in environment value

### DIFF
--- a/recipes-kernel/linux/linux-common.inc
+++ b/recipes-kernel/linux/linux-common.inc
@@ -16,5 +16,5 @@ SRC_URI_append_beaglebone += "file://beaglebone.config"
 LINUX_DEFCONFIG_genericx86-64 = "x86_64_defconfig"
 
 SRC_URI_append = " \
-    ${@oe.utils.conditional("EMLINUX_SECURITY_HARDEND", "1", " file://emlinux-security-hardened.config", "", d)} \
+    ${@oe.utils.conditional("EMLINUX_SECURITY_HARDENED", "1", " file://emlinux-security-hardened.config", "", d)} \
 "


### PR DESCRIPTION
# Purpose of pull request

Fix typo s/HARDEND/HARDENED/ .

# Test
## How to test

Set ``` EMLINUX_SECURITY_HARDENED = "1" ``` in your conf/local.conf and Build image. 
Check /proc/config.gz to CONFIG_ value is correct or not.

## Test result

```
root@qemuarm64:~# zcat /proc/config.gz  > config
root@qemuarm64:~# grep CONFIG_DEBUG_FS config 
# CONFIG_DEBUG_FS is not set
root@qemuarm64:~# grep CONFIG_USER_NS config 
# CONFIG_USER_NS is not set
root@qemuarm64:~# grep CONFIG_RANDOMIZE_BASE config 
CONFIG_RANDOMIZE_BASE=y
```



