### PR TITLE
conf: Use stable kernel tree for k510

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,8 +5,8 @@ DISTRO = "emlinux-k510"
 LINUX_GIT_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable"
 LINUX_GIT_REPO = "linux.git"
 LINUX_GIT_BRANCH ?= "linux-5.10.y"
-LINUX_GIT_SRCREV ?= "7a1519a74f3d0b06598fb95387688cde41e465d8"
-LINUX_CVE_VERSION ??= "5.10.8"
+LINUX_GIT_SRCREV ?= "3a9842b42e421f6496a78a42a123639cf6d7ed31"
+LINUX_CVE_VERSION ??= "5.10.75"
 LINUX_CIP_VERSION ?= ""
 #
 # If you want to use latest revision of the kernel, append the following line

--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -2,8 +2,10 @@ require include/emlinux.inc
 
 DISTRO = "emlinux-k510"
 
-LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "3ddbe9bf6a006b50d35887b00f96c5768a32b7f3"
+LINUX_GIT_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable"
+LINUX_GIT_REPO = "linux.git"
+LINUX_GIT_BRANCH ?= "linux-5.10.y"
+LINUX_GIT_SRCREV ?= "7a1519a74f3d0b06598fb95387688cde41e465d8"
 LINUX_CVE_VERSION ??= "5.10.8"
 LINUX_CIP_VERSION ?= ""
 #


### PR DESCRIPTION
# Purpose of pull request

Use stable kernel tree until CIP project supports 5.10.y series.
This PR changes git repository only so it doesn't change kernel version.
 
# Test
## How to test

Set following value to conf/local.conf

```
DISTRO = "emlinux-k510"
```

Build and run image.

```
# bitbake core-image-minimal
```

Check remote repository which should be stable repo.

## Test result

remote repository

![Screenshot from 2021-10-21 09-54-05](https://user-images.githubusercontent.com/165052/138192199-3e990108-5ab3-4a6c-ab84-1983f0ec4238.png)

run core-image-minimal

![Screenshot from 2021-10-21 09-44-56](https://user-images.githubusercontent.com/165052/138192074-f05d9237-86f8-4ef5-a635-fae639c46eca.png)



