### PR TITLE
kernel: update kernel version to v4.19.213-cip60

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "11e803e05e061dc32e92deb7bd73c20dfbc48ae5"
-LINUX_CVE_VERSION ??= "4.19.209"
-LINUX_CIP_VERSION ??= "v4.19.209-cip59"
+LINUX_GIT_SRCREV ?= "7f69205acfea12da63e10ba3dcad0898b5fd88e5"
+LINUX_CVE_VERSION ??= "4.19.213"
+LINUX_CIP_VERSION ??= "v4.19.213-cip60"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
# Purpose of pull request

Update kernel version to v4.19.213-cip60.

# Test
## How to test

Build and run core-image-minimal.

## Test result

 v4.19.213-cip60 works fine.

![Screenshot from 2021-10-29 15-48-13](https://user-images.githubusercontent.com/165052/139388966-958b2243-6856-4d33-898d-7d0790f15fee.png)



