### PR TITLE
pseudo: Import bug fix patch

### DIFF
--- a/recipes-debian/pseudo/pseudo/0001-don-t-renameat2-please.patch
+++ b/recipes-debian/pseudo/pseudo/0001-don-t-renameat2-please.patch
@@ -1,0 +1,74 @@
+From c1375a6df4379c620d4e2a622eb58e5d7a1b556a Mon Sep 17 00:00:00 2001
+From: Seebs <seebs@seebs.net>
+Date: Tue, 9 Apr 2019 18:05:43 -0500
+Subject: [PATCH] don't renameat2 please
+
+commit 6ebc7d6bc8ab973d0ba949eeb363821811ce8dc5 upstream
+
+So renameat2 now has a glibc wrapper in some recent glibc, which
+means that mv can use it, and thus bypass all our clever testing,
+and since we can't intercept the actual syscall (gnulib's implementation
+apparently doesn't hit the glibc syscall() wrapper?), this results
+in files being moved without pseudo knowing about them.
+
+Implementing the semantics properly is Very Hard, but possibly we
+can just fail politely for now.
+
+We'll be back to this later.
+---
+ ChangeLog.txt                |  4 ++++
+ ports/linux/guts/renameat2.c | 20 ++++++++++++++++++++
+ ports/linux/wrapfuncs.in     |  1 +
+ 3 files changed, 25 insertions(+)
+ create mode 100644 ports/linux/guts/renameat2.c
+
+diff --git a/ChangeLog.txt b/ChangeLog.txt
+index e0c66fc..8b98dca 100644
+--- a/ChangeLog.txt
++++ b/ChangeLog.txt
+@@ -1,3 +1,7 @@
++2019-04-09:
++	* (seebs) Make a glibc renameat2 wrapper that just fails because
++	implementing renameat2 semantics is Surprisingly Hard.
++
+ 2018-09-20:
+ 	* (seebs) coerce inodes to signed int64_t range when shoving
+ 	  them into sqlite.
+diff --git a/ports/linux/guts/renameat2.c b/ports/linux/guts/renameat2.c
+new file mode 100644
+index 0000000..0df8369
+--- /dev/null
++++ b/ports/linux/guts/renameat2.c
+@@ -0,0 +1,20 @@
++/*
++ * Copyright (c) 2019 Peter Seebach/Seebs <seebs@seebs.net>; see
++ * guts/COPYRIGHT for information.
++ *
++ * [Note: copyright added by code generator, may be
++ * incorrect. Remove this if you fix it.]
++ *
++ * int renameat2(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, unsigned int flags)
++ *	int rc = -1;
++ */
++
++	/* for now, let's try just failing out hard, and hope things retry with a
++	 * different syscall.
++	 */
++	errno = ENOSYS;
++	rc = -1;
++
++/*	return rc;
++ * }
++ */
+diff --git a/ports/linux/wrapfuncs.in b/ports/linux/wrapfuncs.in
+index e47acc3..a129eba 100644
+--- a/ports/linux/wrapfuncs.in
++++ b/ports/linux/wrapfuncs.in
+@@ -55,3 +55,4 @@ int getpwent_r(struct passwd *pwbuf, char *buf, size_t buflen, struct passwd **p
+ int getgrent_r(struct group *gbuf, char *buf, size_t buflen, struct group **gbufp);
+ int capset(cap_user_header_t hdrp, const cap_user_data_t datap); /* real_func=pseudo_capset */
+ long syscall(long nr, ...); /* hand_wrapped=1 */
++int renameat2(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, unsigned int flags); /* flags=AT_SYMLINK_NOFOLLOW */
+-- 
+2.20.1
+

--- a/recipes-debian/pseudo/pseudo_debian.bb
+++ b/recipes-debian/pseudo/pseudo_debian.bb
@@ -1,0 +1,22 @@
+# base recipe: meta/recipes-devtools/pseudo/pseudo_git.bb
+# base branch: warrior
+# base commit: bf363493fec990eaf7577769f1862d439404bd10
+
+require ${COREBASE}/meta/recipes-devtools/pseudo/pseudo.inc
+
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
+
+inherit debian-package
+require recipes-debian/sources/pseudo.inc
+FILESPATH_append = ":${COREBASE}/meta/recipes-devtools/pseudo/files:${THISDIR}/pseudo"
+
+SRC_URI += " \
+           file://0001-configure-Prune-PIE-flags.patch \
+           file://fallback-passwd \
+           file://fallback-group \
+           file://moreretries.patch \
+           file://toomanyfiles.patch \
+           file://0001-Add-statx.patch \
+           file://0001-don-t-renameat2-please.patch \
+           "


### PR DESCRIPTION
# Purpose of pull request

This commit imports bug fix patch from meta-debian PR #297[1] for tempolary.

1: https://github.com/meta-debian/meta-debian/pull/297

# Test
## How to test

Build coreutils.


## Test result

The host-user-contaminated warning shouldn't be displayed.

```
masami@ubuntu2004:~/emlinux/build$ bitbake -f coreutils -c cleanall ; bitbake -f coreutils
Loading cache: 100% |##########################################################################################################################################################################################################| Time: 0:00:00
Loaded 2332 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.4"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:fca5f3f1dad606bfd73b733671b70a518be28f39"
meta-debian-extended = "warrior:0860772190c0067bad1b3cfd98c85a8d62d864b6"
meta-emlinux         = "import-pseudo-fix-patch:e2f7425738f13b85c72e4eecee847d5f31f3f5bb"

Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3 tasks of which 0 didn't need to be rerun and all succeeded.
Loading cache: 100% |##########################################################################################################################################################################################################| Time: 0:00:00
Loaded 2332 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.4"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:fca5f3f1dad606bfd73b733671b70a518be28f39"
meta-debian-extended = "warrior:0860772190c0067bad1b3cfd98c85a8d62d864b6"
meta-emlinux         = "import-pseudo-fix-patch:e2f7425738f13b85c72e4eecee847d5f31f3f5bb"

NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/build/../repos/meta-debian-extended/recipes-debian/coreutils/coreutils_debian.bb, do_build                                                                   | ETA:  0:00:00
WARNING: /home/masami/emlinux/build/../repos/meta-debian-extended/recipes-debian/coreutils/coreutils_debian.bb.do_build is tainted from a forced run                                                                           | ETA:  0:00:00
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 6 Found 0 Missed 6 Current 421 (0% match, 98% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1970 tasks of which 1954 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```



