### PR TITLE
linux: update kernel version to v4.19.216-cip61

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "7f69205acfea12da63e10ba3dcad0898b5fd88e5"
-LINUX_CVE_VERSION ??= "4.19.213"
-LINUX_CIP_VERSION ??= "v4.19.213-cip60"
+LINUX_GIT_SRCREV ?= "6ecdd66903013bb4aaaacbf91a7ebfda140b3c9c"
+LINUX_CVE_VERSION ??= "4.19.216"
+LINUX_CIP_VERSION ??= "v4.19.216-cip61"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
# Purpose of pull request

This PR updates kernel version to v4.19.216-cip61

# Test
## How to test

e.g. 

Build core-image-weston and run it.

```
$ bitbake core-image-weston
$ runqemu core-image-weston qemuarm64
```

## Test result

core-image-weston works fine.

![Screenshot from 2021-11-15 15-20-23](https://user-images.githubusercontent.com/165052/141732542-d89a188f-4a23-4f53-9142-f576450cc534.png)
