### PR TITLE
conf: Update kernel version to v4.19.217-cip62

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "6ecdd66903013bb4aaaacbf91a7ebfda140b3c9c"
-LINUX_CVE_VERSION ??= "4.19.216"
-LINUX_CIP_VERSION ??= "v4.19.216-cip61"
+LINUX_GIT_SRCREV ?= "dc62e26e3be875a7324b85b8274c13a335e610dd"
+LINUX_CVE_VERSION ??= "v4.19.217"
+LINUX_CIP_VERSION ??= "v4.19.217-cip62"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
# Purpose of pull request

Update kernel version rom v4.19.216-cip61 to v4.19.217-cip62.

## How to test

build core-image-weston and run it.

## Test result

It works.

![Screenshot from 2021-11-30 14-52-48](https://user-images.githubusercontent.com/165052/143993389-3e6225af-5669-4537-b312-9654b28f6a97.png)
