### PR TITLE
conf: Use emlinux-k510 use cip kernel instead of stable kernel

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -2,12 +2,12 @@ require include/emlinux.inc
 
 DISTRO = "emlinux-k510"
 
-LINUX_GIT_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable"
-LINUX_GIT_REPO = "linux.git"
-LINUX_GIT_BRANCH ?= "linux-5.10.y"
-LINUX_GIT_SRCREV ?= "3a9842b42e421f6496a78a42a123639cf6d7ed31"
-LINUX_CVE_VERSION ??= "5.10.75"
-LINUX_CIP_VERSION ?= ""
+LINUX_GIT_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/cip"
+LINUX_GIT_REPO = "linux-cip.git"
+LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
+LINUX_GIT_SRCREV ?= "2332f07a324fd78d7c7436deeed23cd7db441ea7"
+LINUX_CVE_VERSION ??= "5.10.83"
+LINUX_CIP_VERSION ?= "v5.10.83-cip1"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
# Purpose of pull request

cip/5.10 series has been released. so use cip kernel instead of vanilla stable
kernel.

# Test
## How to test

build and run core-image-weston.

## Test result

![image](https://user-images.githubusercontent.com/165052/144963716-06500efa-9ecd-4a7e-8595-739597b2ad1d.png)



