### PR TITLE
conf: Fix LINUX_CVE_VERSION

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -4,7 +4,7 @@ DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
 LINUX_GIT_SRCREV ?= "dc62e26e3be875a7324b85b8274c13a335e610dd"
-LINUX_CVE_VERSION ??= "v4.19.217"
+LINUX_CVE_VERSION ??= "4.19.217"
 LINUX_CIP_VERSION ??= "v4.19.217-cip62"
 #
 # If you want to use latest revision of the kernel, append the following line


### PR DESCRIPTION
# Purpose of pull request

If LINUX_CVE_VERSION use v4.19.y format, it failed to compare versions.

WARNING: linux-base-4.19-r0 do_cve_check: linux_kernel: Failed to
compare v4.19.217 <= 2.2.3 for CVE-1999-0431

It should use 4.19.y format instead of v4.19.y format.

# Test
## How to test

Add following line in your conf/local.conf
```
INHERIT += "cve-check debian-cve-check kernel-cve-check"
```

Then, build linux-base

```
bitbake linux-base
```

## Test result

Shouldn't show  following warnings.

```
WARNING: linux-base-4.19-r0 do_cve_check: linux_kernel: Failed to compare v4.19.217 <= 2.2.3 for CVE-1999-0431
```

Should show normal cve check result.

```
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2015-0569 CVE-2015-0570 CVE-2015-0571 CVE-2015-2877 CVE-2015-7312 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-15213 CVE-2019-16089 CVE-2019-19036 CVE-2019-19083 CVE-2019-19338 CVE-2019-20794 CVE-2019-25044 CVE-2019-25045 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-36310 CVE-2020-36322 CVE-2020-36385 CVE-2021-20177 CVE-2021-26934 CVE-2021-29155 CVE-2021-32078 CVE-2021-3444 CVE-2021-42327 CVE-2021-43057 CVE-2021-43975 CVE-2021-43976), for more information check /home/masami/emlinux/truly-latest/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 508 tasks of which 506 didn't need to be rerun and all succeeded.
```


