### PR TITLE
conf: Update kernel version to v4.19.225-cip65

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "3cc384e269b518ae60e439249ece8ae4c189a810"
-LINUX_CVE_VERSION ??= "4.19.222"
-LINUX_CIP_VERSION ??= "v4.19.222-cip64"
+LINUX_GIT_SRCREV ?= "def5c8e4375baf1ae9c6421ce39f5cad2f3f2052"
+LINUX_CVE_VERSION ??= "4.19.225"
+LINUX_CIP_VERSION ??= "v4.19.225-cip65"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel version from v4.19.222-cip64 to v4.19.225-cip65

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>