### PR TITLE
conf: Update kernel version to v4.19.229-cip67

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "7eac607239ce3ce7e0e12a2d5c9c6baadc0e5369"
-LINUX_CVE_VERSION ??= "4.19.226"
-LINUX_CIP_VERSION ??= "v4.19.226-cip66"
+LINUX_GIT_SRCREV ?= "c390d35f51edb249e63aab6fb5086ac4e0bf90d4"
+LINUX_CVE_VERSION ??= "4.19.229"
+LINUX_CIP_VERSION ??= "v4.19.229-cip67"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel version from v4.19.226-cip66 to v4.19.229-cip67

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>