### PR TITLE
conf: Update kernel version to v5.10.100-cip2

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO = "emlinux-k510"
 LINUX_GIT_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/cip"
 LINUX_GIT_REPO = "linux-cip.git"
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "2332f07a324fd78d7c7436deeed23cd7db441ea7"
-LINUX_CVE_VERSION ??= "5.10.83"
-LINUX_CIP_VERSION ?= "v5.10.83-cip1"
+LINUX_GIT_SRCREV ?= "cacf08e29f7abd0acd44dd086650d57fb159d76e"
+LINUX_CVE_VERSION ??= "5.10.100"
+LINUX_CIP_VERSION ?= "v5.10.100-cip2"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel version from v5.10.83-cip1 to v5.10.100-cip2

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>