### PR TITLE
distro: bump up version for EMLinux 2.5 release

### DIFF
--- a/conf/distro/include/emlinux.inc
+++ b/conf/distro/include/emlinux.inc
@@ -1,5 +1,5 @@
 DISTRO_NAME = "EMLinux"
-DISTRO_VERSION = "2.4"
+DISTRO_VERSION = "2.5"
 DISTRO_CODENAME = "buster"
 SDK_VENDOR = "-emlinuxsdk"
 SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"


### PR DESCRIPTION
# Purpose of pull request

Update DISTRO_VERSION from 2.4 to 2.5 to prepare next release.

# Test
## How to test

Build and run emlinux then check emlinux version.

## Test result

```
EMLinux 2.5 qemuarm64 /dev/ttyAMA0

qemuarm64 login: root
root@qemuarm64:~# uname -a
Linux qemuarm64 4.19.229-cip67 #1 SMP PREEMPT Wed Mar 2 02:40:54 UTC 2022 aarch64 GNU/Linux
```



