### PR TITLE
conf: Update kernel version to v4.19.231-cip68

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "c390d35f51edb249e63aab6fb5086ac4e0bf90d4"
-LINUX_CVE_VERSION ??= "4.19.229"
-LINUX_CIP_VERSION ??= "v4.19.229-cip67"
+LINUX_GIT_SRCREV ?= "c7477548dcf8c653b00e361f7a724f0b94e7d372"
+LINUX_CVE_VERSION ??= "4.19.231"
+LINUX_CIP_VERSION ??= "v4.19.231-cip68"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel version from v4.19.229-cip67 to v4.19.231-cip68

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>
