### PR TITLE
doc: Add python3-debian to install package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install essential packages for poky:
 ```sh
 $ sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
 build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
-xz-utils debianutils iputils-ping libsdl1.2-dev xterm
+python3-debian xz-utils debianutils iputils-ping libsdl1.2-dev xterm
 ```
 
 Clone meta-emlinux:


### PR DESCRIPTION
The python3-debian package is required to enable Debian security update
repository. see
https://github.com/meta-debian/meta-debian/blob/warrior/doc/6.security-update.md


