### PR TITLE
linux: Remove base.config

### DIFF
--- a/recipes-kernel/linux/files/base.config
+++ b/recipes-kernel/linux/files/base.config
@@ -1,2 +1,0 @@
-# Framebuffer
-CONFIG_FB_SIMPLE=y

--- a/recipes-kernel/linux/files/raspberrypi3-64.config
+++ b/recipes-kernel/linux/files/raspberrypi3-64.config
@@ -1,3 +1,6 @@
+# Framebuffer
+CONFIG_FB_SIMPLE=y
+
 # lan
 CONFIG_USB_LAN78XX=y
 

--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -3,8 +3,5 @@ require linux-common.inc
 PV = "4.19"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI_append = " \
-	file://base.config \
-"
 
 CVE_VERSION = "${LINUX_CVE_VERSION}"

--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -7,9 +7,6 @@ PROVIDES += " linux-k510"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
-SRC_URI_append = " \
-	file://base.config \
-"
 
 FILESEXTRAPATHS_append := ":${LAYERDIR_DEBIAN_debian}/recipes-kernel/linux/files/"
 


### PR DESCRIPTION
# Purpose of pull request

raspberrypi3-64 requires CONFIG_FB_SIMPLE to output via HDMI, but other MACHINE does not, so I moved the setting of CONFIG_FB_SIMPLE to raspberrypi3-64.config.

qemuarm64: CONFIG_FB_SIMPLE is not needed
qemuarm: Already enabled in defconfig
beaglbone: Even if CONFIG_FB_SIMPLE is enabled, it will be disabled in the configure process.

I deleted base.config because it only has CONFIG_FB_SIMPLE setting.

# Test
## How to test

Build linux-base and check .config file contains CONFIG_FB_SIMPLE.

```
$ MACHINE=raspberrypi3-64 bitbake linux-base
```

## Test result

CONFIG_FB_SIMPLE is enabled as before.

```
$ grep CONFIG_FB_SIMPLE tmp-glibc/work/raspberrypi3_64-emlinux-linux/linux-base/4.19-r0/build/.config
CONFIG_FB_SIMPLE=y

```



