### PR TITLE
rpi: Do not build firmware if MACHINE is not raspberry pi.

### DIFF
--- a/conf/machine/raspberrypi3-64.conf
+++ b/conf/machine/raspberrypi3-64.conf
@@ -1,5 +1,8 @@
 MACHINEOVERRIDES = "raspberrypi3:${MACHINE}"
 
+SOC_FAMILY = "rpi"
+include conf/machine/include/soc-family.inc
+
 require conf/machine/include/tune-cortexa53.inc
 
 SERIAL_CONSOLES ?= "115200;ttyS1"

--- a/recipes-bsp/bootfiles/rpi-bootfiles.bb
+++ b/recipes-bsp/bootfiles/rpi-bootfiles.bb
@@ -13,7 +13,7 @@ include recipes-bsp/common/raspberrypi-firmware.inc
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-COMPATIBLE_MACHINE = "^ras"
+COMPATIBLE_MACHINE = "^rpi$"
 
 PR = "r1"
 

--- a/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr.bb
@@ -5,7 +5,7 @@
 SUMMARY = "U-boot boot scripts for Raspberry Pi"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
-COMPATIBLE_MACHINE = "^ras"
+COMPATIBLE_MACHINE = "^rpi$"
 
 DEPENDS = "u-boot-mkimage-native"
 

--- a/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
+++ b/recipes-kernel/linux-firmware-rpidistro/linux-firmware-rpidistro_git.bb
@@ -8,6 +8,7 @@ RPi-Distro obtains these directly from Cypress; they are not submitted \
 to linux-firmware for general use."
 HOMEPAGE = "https://github.com/RPi-Distro/firmware-nonfree"
 SECTION = "kernel"
+COMPATIBLE_MACHINE = "^rpi$"
 
 # In maintained upstream linux-firmware:
 # * brcmfmac43430-sdio falls under LICENCE.cypress


### PR DESCRIPTION
# Purpose of pull request

linux-firmware-rpidistro_git recipe is raspberry pi specific recipe.
So, other machines(e.g. qemuarm64) don't need to build it.
This commit fixes build error when running bitabke world with MACHINE=qemarm64.

# Test
## How to test

for rpi3, build core-image-minimal should success
for qemuarm64, build linux-firmware-rpidistro  should fail because qemuarm64 is not in COMPATIBLE_MACHINE.

## Test result

### raspberrypi3-64

```
masami@ubuntu1804:~/emlinux/build$ bitbake core-image-minimal
Parsing recipes: 100% |########################################################################################################################################################################################################| Time: 0:00:38
Parsing of 1338 .bb files complete (0 cached, 1338 parsed). 2356 targets, 69 skipped, 4 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "raspberrypi3-64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.5"
TUNE_FEATURES        = "aarch64 cortexa53 crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:aecbfc0d5c84cb48c4f08dfa8534442631b7fd8a"
meta-debian-extended = "warrior:bbb54b3d23659529b106993a87f73493c49468ef"
meta-emlinux         = "update-rpi-recipe:00070a7282da00065a669eabc6ef6caf582ec02e"

Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 853 Found 0 Missed 853 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2942 tasks of which 5 didn't need to be rerun and all succeeded.
```
And, linux-firmware-rpidistro recipe copied license file(LICENCE.broadcom_bcm43xx) correctly.

```
masami@ubuntu1804:~/emlinux/build$ wic ls tmp-glibc/deploy/images/raspberrypi3-64/core-image-minimal-raspberrypi3-64.wic:2/lib/firmware
debugfs 1.44.1 (24-Mar-2018)
    766   40755 (2)      0      0    1024 26-Apr-2022 09:03 .
    156   40755 (2)      0      0    1024 26-Apr-2022 09:03 ..
    767   40755 (2)      0      0    1024 26-Apr-2022 09:03 brcm
    771  100644 (1)      0      0    4178 26-Apr-2022 09:02 LICENCE.broadcom_bcm43xx
```
### qemuarm64

Build error occurs as expected.

```
masami@ubuntu1804:~/emlinux/build$ MACHINE=qemuarm64 bitbake linux-firmware-rpidistro 
Parsing recipes: 100% |########################################################################################################################################################################################################| Time: 0:00:26
Parsing of 1338 .bb files complete (0 cached, 1338 parsed). 2356 targets, 78 skipped, 4 masked, 0 errors.
ERROR: Nothing PROVIDES 'linux-firmware-rpidistro'
linux-firmware-rpidistro was skipped: incompatible with machine qemuarm64 (not in COMPATIBLE_MACHINE)

Summary: There was 1 ERROR message shown, returning a non-zero exit code.
```
bitbake world was succeeded in qemuarm64.

```
masami@emlinuxdev:~/emlinux/truly-latest/build$ bitbake world
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Loaded 2358 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.5"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:aecbfc0d5c84cb48c4f08dfa8534442631b7fd8a"
meta-debian-extended = "HEAD:27821f6b789ab21e4b65a92fe477d8bbef4088a3"
meta-emlinux         = "update-rpi-recipe:00070a7282da00065a669eabc6ef6caf582ec02e"

Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:11
Sstate summary: Wanted 3969 Found 0 Missed 3969 Current 1052 (0% match, 20% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: lttng-modules-2.10.8-r0 do_package: lttng-modules: no modules were created; this may be due to CONFIG_TRACEPOINTS not being enabled in your kernel.
WARNING: libpwquality-1.4.0-r0 do_populate_lic: libpwquality: No generic license file exists for: libpwquality in any provider
WARNING: syslog-ng-3.19.1-r0 do_populate_lic: syslog-ng: No generic license file exists for: LGPL-2.1-with-OpenSSL-exception in any provider
NOTE: Tasks Summary: Attempted 14238 tasks of which 6019 didn't need to be rerun and all succeeded.

Summary: There were 3 WARNING messages shown.
```




