### PR TITLE
scripts: Fix build error on bitbake world

### DIFF
--- a/scripts/bbmask.conf
+++ b/scripts/bbmask.conf
@@ -3,5 +3,7 @@ BBMASK += "meta-debian/recipes-core"
 # use poky's base-files package temporary.
 BBMASK += "meta-debian/recipes-debian/base-files/base-files_debian.bb"
 BBMASK += "poky/meta/recipes-sato/webkit/webkitgtk_2.22.7.bb \
+           poky/meta/recipes-gnome/epiphany/epiphany_3.30.3.bb \
+           poky/meta/recipes-core/packagegroups/packagegroup-self-hosted.bb \
            poky/meta/recipes-graphics/xorg-lib/libxxf86misc_1.0.4.bb \
            meta-debian/recipes-debian/fcode-utils/fcode-utils_debian.bb"


### PR DESCRIPTION
# Purpose of pull request

The epiphany and packagegroup-self-hosted require webkitgtk so
both reciepes need to be added in BBMASK to build bitbake world.

# Test
## How to test

```
$ bitbake world
```

## Test result

build succeeded.

```
masami@emlinuxdev:~/emlinux/truly-latest/build$ bitbake -f world
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Loaded 2356 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.5"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:aecbfc0d5c84cb48c4f08dfa8534442631b7fd8a"
meta-debian-extended = "HEAD:27821f6b789ab21e4b65a92fe477d8bbef4088a3"
meta-emlinux         = "add-more-recipe-to-bbmask:bc975afb55a63fce9e15d03ecaf54f09c6f9a8b6"
                                                                                                                                                                                                      
NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/truly-latest/build/../repos/poky/meta/recipes-core/packagegroups/packagegroup-core-boot.bb, do_build                 | ETA:  0:00:02
NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/truly-latest/build/../repos/poky/meta/recipes-core/volatile-binds/volatile-binds.bb, do_build
NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/truly-latest/build/../repos/poky/meta/recipes-multimedia/libtheora/libtheora_1.1.1.bb, do_build
>>> cut here <<<                                     
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:11
Sstate summary: Wanted 4626 Found 0 Missed 4626 Current 395 (0% match, 7% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: gpgme-1.12.0-r0 do_configure: LANGUAGES: cpp python3
WARNING: waffle-1.5.2-r0 do_fetch: Checksum mismatch for local file /home/masami/emlinux/truly-latest/build/../downloads/waffle-1.5.2.tar.xz
Cleaning and trying again.
WARNING: waffle-1.5.2-r0 do_fetch: Renaming /home/masami/emlinux/truly-latest/build/../downloads/waffle-1.5.2.tar.xz to /home/masami/emlinux/truly-latest/build/../downloads/waffle-1.5.2.tar.xz_bad-checksum_0adfd00a1db3e3aa1f0f37a3e4a9bcf3
WARNING: waffle-1.5.2-r0 do_fetch: Checksum failure encountered with download of http://waffle-gl.org/files/release/waffle-1.5.2/waffle-1.5.2.tar.xz - will attempt other sources if available
WARNING: stress-1.0.4-r0 do_fetch: Failed to fetch URL https://fossies.org/linux/privat/stress-1.0.4.tar.gz, attempting MIRRORS if available
WARNING: msmtp-1.6.6-r0 do_fetch: Failed to fetch URL http://sourceforge.net/projects/msmtp/files/msmtp/1.6.6/msmtp-1.6.6.tar.xz, attempting MIRRORS if available
WARNING: lttng-modules-2.10.8-r0 do_package: lttng-modules: no modules were created; this may be due to CONFIG_TRACEPOINTS not being enabled in your kernel.
WARNING: libpwquality-1.4.0-r0 do_populate_lic: libpwquality: No generic license file exists for: libpwquality in any provider
WARNING: syslog-ng-3.19.1-r0 do_populate_lic: syslog-ng: No generic license file exists for: LGPL-2.1-with-OpenSSL-exception in any provider
NOTE: Tasks Summary: Attempted 14238 tasks of which 2343 didn't need to be rerun and all succeeded.

Summary: There were 785 WARNING messages shown.
```



