### PR TITLE
scripts: Add debian security updates repository to mirror list

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -56,6 +56,9 @@ if [ -z "$TEMPLATECONF" ] && [ "${EML_BUILDDIR_SETUP_DONE}" = "false" ]; then
     echo "DL_DIR = \"\${TOPDIR}/../downloads\"" >> conf/local.conf
     cat ${REPOS}/meta-emlinux/scripts/bbmask.conf >> conf/local.conf
 
+    # Add debian security updates repository
+    echo "DEBIAN_SECURITY_UPDATE_MIRROR=\"http://security.debian.org/debian-security/pool/updates\"" >> conf/local.conf
+
     if [ -d "${EML_HOOKS}" ]; then
 	for hook in $(\ls ${EML_HOOKS}); do
 	    source ${EML_HOOKS}/$hook


### PR DESCRIPTION
# Purpose of pull request

This change adds debian security updates repository url to mirror list.
It only adds url to mirror list, so it doesn't enable feature of
download update package from debian security mirror server.

It supports downloading debian source package from debian security
updates repository, if DEBIAN_SRC_URI contains
DEBIAN_SECURITY_UPDATE_MIRROR variable.

If user want to update package version to get security fix from debian
security updates repository, user must set DEBIAN_SOURCE_ENABLED,
DEBIAN_SRC_FORCE_REGEN, and DEBIAN_SECURITY_UPDATE_ENABLED by themself.

# Test
## How to test

1. run setup-emlinux script.
2. add following lines to local.conf then, run some bitbake command.

```
DEBIAN_SOURCE_ENABLED = "1"
DEBIAN_SRC_FORCE_REGEN = "1"

DEBIAN_SECURITY_UPDATE_ENABLED = "1"
```
## Test result

local.conf contains following lines.

```
DEBIAN_SECURITY_UPDATE_MIRROR="http://security.debian.org/debian-security/pool/updates"
MIRRORS+="${DEBIAN_MIRROR}    ${DEBIAN_SECURITY_UPDATE_MIRROR}"
```
Following log shows some packages are updated.

```
masami@emlinuxdev:~/emlinux/truly-latest/build-emlinux$ bitbake core-image-minimal -c cleanall
WARNING: debian security update repository is enabled
Checking Debian Release ...
Fetching Debian Sources.xz ...
Parsing Debian Sources.xz ...
WARNING: Source code for package "gzip" has been updated from "1.9-3" to "1.9-3+deb10u1"
WARNING: Source code for package "xz-utils" has been updated from "5.2.4-1" to "5.2.4-1+deb10u1"
WARNING: Source code for package "zlib" has been updated from "1.2.11.dfsg-1" to "1.2.11.dfsg-1+deb10u1"
WARNING: Source code for package "tiff" has been updated from "4.1.0+git191117-2~deb10u3" to "4.1.0+git191117-2~deb10u4"
WARNING: Source code for package "openjdk-11" has been updated from "11.0.14+9-1~deb10u1" to "11.0.15+10-1~deb10u1"
Checking Debian Release ...
Fetching Debian Sources.xz ...
Parsing Debian Sources.xz ...
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:27
Parsing of 1336 .bb files complete (0 cached, 1336 parsed). 2354 targets, 78 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
```



