### PR TITLE
doc: Add rsync to install package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install essential packages for poky:
 ```sh
 $ sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
 build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
-python3-debian xz-utils debianutils iputils-ping libsdl1.2-dev xterm
+python3-debian xz-utils debianutils iputils-ping libsdl1.2-dev xterm rsync
 ```
 
 Clone meta-emlinux:


### PR DESCRIPTION
# Purpose of pull request

emlinux-k510's sdk installer requires rsync command. 
So, added rsync in apt command line example.

```
  INSTALL
/home/build/sdk-test/sysroots/aarch64-emlinux-linux/usr/include
/bin/sh: 1: rsync: not found
Makefile:1302: recipe for target 'headers_install' failed
make: *** [headers_install] Error 127
SDK has been successfully set up and is ready to be used.
```
