### PR TITLE
linux: Add debug setting config

### DIFF
--- a/recipes-kernel/linux/files/kernel-debug.config
+++ b/recipes-kernel/linux/files/kernel-debug.config
@@ -1,0 +1,21 @@
+# Coverage collection.
+CONFIG_KCOV=y
+CONFIG_KCOV_ENABLE_COMPARISONS=y
+CONFIG_KCOV_INSTRUMENT_ALL=y
+
+# Debug info for symbolization.
+CONFIG_DEBUG_INFO=y
+
+# Memory bug detector
+CONFIG_KASAN=y
+CONFIG_KASAN_INLINE=y
+
+# kernel memory leak detector
+CONFIG_DEBUG_KMEMLEAK=y
+
+# Add debug interface
+CONFIG_DEBUG_FS=y
+
+# syzkaller will use 9p protocol
+CONFIG_NET_9P=y
+CONFIG_NET_9P_VIRTIO=y

--- a/recipes-kernel/linux/linux-common.inc
+++ b/recipes-kernel/linux/linux-common.inc
@@ -19,3 +19,7 @@ SRC_URI_append_genericx86-64 += "file://nvme.config"
 SRC_URI_append = " \
     ${@oe.utils.conditional("EMLINUX_SECURITY_HARDENED", "1", " file://emlinux-security-hardened.config", "", d)} \
 "
+
+SRC_URI_append = " \
+    ${@oe.utils.conditional("EMLINUX_ENABLE_KERNEL_DEBUG", "1", " file://kernel-debug.config", "", d)} \
+"


### PR DESCRIPTION
# Purpose of pull request

Added kernel-debug.config for testing linux kernel such as using
the syzkaller, memory leak detector, and etc.

# Test
## How to test

1. Build image with/without EMLINUX_ENABLE_KERNEL_DEBUG variable
2. check /proc/config.gz to set/unset debug options 

Build with debug setting.
Add following line in local.conf

```
EMLINUX_ENABLE_KERNEL_DEBUG = "1"
```

Build without debug setting.
Remove following line from local.conf

```
EMLINUX_ENABLE_KERNEL_DEBUG = "1"
```

## Test result

with debug options

Build succeeded.

```
masami@ubuntu1804:~/emlinux/qemuarm64-emlinux$ bitbake -f core-image-minimal
Loading cache: 100% |##########################################################################################################################################################################################################| Time: 0:00:00
Loaded 2356 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.5"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:50914537ad7c4d1a7d75cf79a93adc239c5e3d05"
meta-debian-extended = "warrior:afc17e0ec85d5f2ba0e578f686ddcec16f719d9f"
meta-emlinux         = "add-debug-conf:d67b1e1ee081f59deb4f664fa2090b1fae1b3f77"

NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/qemuarm64-emlinux/../repos/poky/meta/recipes-core/images/core-image-minimal.bb, do_build                                                                     | ETA:  0:00:00
WARNING: /home/masami/emlinux/qemuarm64-emlinux/../repos/meta-debian/recipes-kernel/linux/linux-base_git.bb.do_build is tainted from a forced run                                                                              | ETA:  0:00:00
WARNING: /home/masami/emlinux/qemuarm64-emlinux/../repos/poky/meta/recipes-core/images/core-image-minimal.bb.do_build is tainted from a forced run
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 3 Found 0 Missed 3 Current 855 (0% match, 99% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3019 tasks of which 2962 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```

KMEMLEAK option is enabled.

```
root@qemuarm64:~# zcat /proc/config.gz > config
root@qemuarm64:~# grep KMEMLEAK config 
CONFIG_HAVE_DEBUG_KMEMLEAK=y
CONFIG_DEBUG_KMEMLEAK=y
CONFIG_DEBUG_KMEMLEAK_EARLY_LOG_SIZE=16000
# CONFIG_DEBUG_KMEMLEAK_TEST is not set
# CONFIG_DEBUG_KMEMLEAK_DEFAULT_OFF is not set
```

Build without debug options.
Build succeeded.

```
masami@ubuntu1804:~/emlinux/qemuarm64-emlinux$ bitbake -f core-image-minimal
Loading cache: 100% |##########################################################################################################################################################################################################| Time: 0:00:00
Loaded 2356 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies
                                                                                                                                                                                                                                              
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"                                                                         
MACHINE              = "qemuarm64"                                                                                     
DISTRO               = "emlinux"                                                                                       
DISTRO_VERSION       = "2.5"                                                                                           
TUNE_FEATURES        = "aarch64 armv8a crc"                                                                            
TARGET_FPU           = ""                                                                                              
meta                                                                                                                   
meta-yocto-bsp       = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"                                              
meta-debian          = "warrior:50914537ad7c4d1a7d75cf79a93adc239c5e3d05"                                              
meta-debian-extended = "warrior:afc17e0ec85d5f2ba0e578f686ddcec16f719d9f"                  
meta-emlinux         = "add-debug-conf:d67b1e1ee081f59deb4f664fa2090b1fae1b3f77"                                       
                                                                                                                       
NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/qemuarm64-emlinux/../repos/poky/meta/recipes-core/images/core-image-minimal.bb, do_build                                                                     | ETA:  0:00:00
WARNING: /home/masami/emlinux/qemuarm64-emlinux/../repos/poky/meta/recipes-core/images/core-image-minimal.bb.do_build is tainted from a forced run                                                                             | ETA:  0:00:00
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 11 Found 7 Missed 4 Current 847 (63% match, 99% complete)                                       
NOTE: Executing SetScene Tasks                                                                                         
NOTE: Executing RunQueue Tasks                                                                                         
NOTE: Tasks Summary: Attempted 3019 tasks of which 2961 didn't need to be rerun and all succeeded.               
                                                                                                                                                                                                                                              
Summary: There was 1 WARNING message shown.     
```

KMEMLEAK option is not set.

```
root@qemuarm64:~# grep KMEMLEAK config 
CONFIG_HAVE_DEBUG_KMEMLEAK=y
# CONFIG_DEBUG_KMEMLEAK is not set
```