### PR TITLE
classes: kernel-cve-check: Disable KERNEL_CVE_CHECK_INCLUDE_IGNORE

### DIFF
--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -19,7 +19,7 @@ KERNEL_CVE_CHECK_DIR ?= "${CVE_CHECK_DB_DIR}/KERNEL"
 
 # Consider ignore information.
 # If value is "0", add CVEs that are registered as negligible to whitelist.
-KERNEL_CVE_CHECK_INCLUDE_IGNORE ?= "1"
+KERNEL_CVE_CHECK_INCLUDE_IGNORE ?= "0"
 
 # Add ignore information to cve manifest.
 KERNEL_CVE_CHECK_SHOW_IGNORE_INFO ?= "0"


### PR DESCRIPTION
# Purpose of pull request

When KERNEL_CVE_CHECK_INCLUDE_IGNORE is set to 1, it adds
--include-ignore option to report_affected.py. This means tell
reporte_affected.py to show CVEs which are marked as ignore. Therefore,
if ignored CVE is not fixed in NVD database, it will be reported as not
fixed.  This is not expected result because cip-kernel-sec decided to
ignore the CVE.
So, disable KERNEL_CVE_CHECK_INCLUDE_IGNORE flag to not show CVEs which
are marked as ignore.

If we don't have any problems with this setting, we can remove
KERNEL_CVE_CHECK_INCLUDE_IGNORE and KERNEL_CVE_CHECK_SHOW_IGNORE_INFO
related code in the future.

# Test
## How to test

1. Add INHERIT += "cve-check debian-cve-check kernel-cve-check" to conf/local.conf
2. Run kernel-cve-check

## Test result

kernel cve check works fine.
```
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2015-2877 CVE-2015-7312 CVE-2019-16089 CVE-2019-19338 CVE-2019-20794 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2021-20177 CVE-2021-20320 CVE-2021-29155 CVE-2021-32078 CVE-2021-3773 CVE-2021-3847 CVE-2021-42327 CVE-2021-44879 CVE-2022-0382 CVE-2022-1789 CVE-2022-25265), for more information check /home/build/emlinux/latest-dev/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
```

Set KERNEL_CVE_CHECK_INCLUDE_IGNORE="1" shows following CVEs.

```
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2015-2877 CVE-2015-7312 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-16089 CVE-2019-19083 CVE-2019-19338 CVE-2019-20794 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2021-20177 CVE-2021-20320 CVE-2021-26934 CVE-2021-29155 CVE-2021-32078 CVE-2021-3773 CVE-2021-3847 CVE-2021-4150 CVE-2021-42327 CVE-2021-43057 CVE-2021-44879 CVE-2021-45402 CVE-2022-0382 CVE-2022-1015 CVE-2022-1789 CVE-2022-25265 CVE-2022-29582), for more information check /home/build/emlinux/latest-dev/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 508 tasks of which 506 didn't need to be rerun and all succeeded.
```

I checked the result of KERNEL_CVE_CHECK_INCLUDE_IGNORE="0" only shows CVEs which are not marked as fixed in cip-kernel-sec.
 