### PR TITLE
Fix lacked quotation in raspi3 doc

### DIFF
--- a/doc/raspberrypi3.md
+++ b/doc/raspberrypi3.md
@@ -31,7 +31,7 @@ In the build directroy, you can build image. You needs to set raspberrypi3-64 to
 
 ```
 $ echo 'MACHINE = "raspberrypi3-64"' >> conf/local.conf
-$ echo 'IMAGE_INSTALL_append = " kernel-modules" >> conf/local.conf
+$ echo 'IMAGE_INSTALL_append = " kernel-modules"' >> conf/local.conf
 $ bitbake core-image-minimal
 ```
 


### PR DESCRIPTION
# Purpose of pull request

This pr fixes lacked quotation in raspi3 doc

# Test
## How to test

Following existing command has only one `'` and it cannot execute.

```
$ echo 'IMAGE_INSTALL_append = " kernel-modules" >> conf/local.conf
```