### PR TITLE
distro: keep LINUX_GIT_{URI,REPO} in the common place.

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -2,8 +2,6 @@ require include/emlinux.inc
 
 DISTRO = "emlinux-k510"
 
-LINUX_GIT_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/cip"
-LINUX_GIT_REPO = "linux-cip.git"
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
 LINUX_GIT_SRCREV ?= "19dd4538e81e4019bc96ac6521af3a4ec93e110c"
 LINUX_CVE_VERSION ??= "5.10.129"

--- a/conf/distro/include/emlinux.inc
+++ b/conf/distro/include/emlinux.inc
@@ -24,9 +24,12 @@ SDKPATH = "/opt/${DISTRO}/${SDK_VERSION}"
 
 DISTRO_EXTRA_RDEPENDS += " ${EMLINUX_DEFAULT_EXTRA_RDEPENDS}"
 
+# Common values for git access of Linux Kernel
 LINUX_GIT_URI ?= "git://git.kernel.org/pub/scm/linux/kernel/git/cip"
 LINUX_GIT_PROTOCOL ?= "https"
 LINUX_GIT_PREFIX ?= ""
+LINUX_GIT_REPO ?= "linux-cip.git"
+
 # use toolchain mode for Debian instead of the default
 TCMODE ?= "emlinux"
 


### PR DESCRIPTION
Now, we don't need these variables for each distro conf.