### PR TITLE
linux-base: Ignore CVE-2021-26934

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -5,3 +5,6 @@ PV = "4.19"
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 CVE_VERSION = "${LINUX_CVE_VERSION}"
+
+# CVE-2021-26934: It's Xen document problem. Not a kernel bug. http://xenbits.xen.org/xsa/advisory-363.html
+CVE_CHECK_WHITELIST = "CVE-2021-26934"


### PR DESCRIPTION
# Purpose of pull request

CVE-2021-26934 is Xen's document problem not kernel bug. We can ignore this CVE.

linux-k510 doesn't show this CVE so adding CVE_CHECK_WHITELIST to linux-base is enough.

# Test
## How to test

Run CVE check.

## Test result

```
┌──masami@ubuntu1804:~/emlinux/build
└─$ bitbake -f linux-base 
Loading cache: 100% |##########################################################################################################################################################################################################| Time: 0:00:00
Loaded 2354 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.5"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "deb10.12-1:266d13ef90229b44b8a82a0e1e465af004469b8c"
meta-debian-extended = "HEAD:ec2c8c419ed61b40ee32a9445296da0cbd08a98c"
meta-emlinux         = "ignore-CVE-2021-26934:d793528539f5eb980f44c7f0ef921da90d45b444"

NOTE: Tainting hash to force rebuild of task /home/masami/emlinux/build/../repos/meta-debian/recipes-kernel/linux/linux-base_git.bb, do_build                                                                                  | ETA:  0:00:00
WARNING: /home/masami/emlinux/build/../repos/meta-debian/recipes-kernel/linux/linux-base_git.bb.do_build is tainted from a forced run                                                                                          | ETA:  0:00:00
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 2 Found 2 Missed 0 Current 78 (100% match, 100% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2015-2877 CVE-2015-7312 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-16089 CVE-2019-19083 CVE-2019-19338 CVE-2019-20794 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2021-20320 CVE-2021-32078 CVE-2021-3773 CVE-2021-3847 CVE-2021-4150 CVE-2021-42327 CVE-2021-43057 CVE-2021-44879 CVE-2021-45402 CVE-2022-1015 CVE-2022-1789 CVE-2022-25265 CVE-2022-29582 CVE-2022-36879), for more information check /home/masami/emlinux/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 694 tasks of which 691 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.

```



