### PR TITLE
recipes-kernel: Add CONFIG_NFS_V3_ACL to the kernel configuration

### DIFF
--- a/recipes-kernel/linux/files/kernel-nfs-acl.config
+++ b/recipes-kernel/linux/files/kernel-nfs-acl.config
@@ -1,0 +1,2 @@
+# enable nfs acl
+CONFIG_NFS_V3_ACL=y

--- a/recipes-kernel/linux/linux-common.inc
+++ b/recipes-kernel/linux/linux-common.inc
@@ -23,3 +23,7 @@ SRC_URI_append = " \
 SRC_URI_append = " \
     ${@oe.utils.conditional("EMLINUX_ENABLE_KERNEL_DEBUG", "1", " file://kernel-debug.config", "", d)} \
 "
+
+SRC_URI_append = " \
+    ${@oe.utils.conditional("EMLINUX_ENABLE_NFS_ACL", "1", " file://kernel-nfs-acl.config", "", d)} \
+"


### PR DESCRIPTION
Add option for enabling NFS V3 ACL useful for enabling NFS ACL for testing purpose on lava NFS overlay

Signed-off-by: Alice Ferrazzi <alice.ferrazzi@miraclelinux.com>


