### PR TITLE
Update kernel to v4.19.261-cip83 and v5.10.147-cip18

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux-k510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "93a53e86925ce8c2e0608e173e2c7b952ee61cdd"
-LINUX_CVE_VERSION ??= "5.10.145"
-LINUX_CIP_VERSION ?= "v5.10.145-cip17"
+LINUX_GIT_SRCREV ?= "ef9425de71e3d6cd46470415b2648f2244057840"
+LINUX_CVE_VERSION ??= "5.10.147"
+LINUX_CIP_VERSION ?= "v5.10.147-cip18"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "91f283faebd1a92efc2cfe0a3de7c568c87e5ee5"
-LINUX_CVE_VERSION ??= "4.19.259"
-LINUX_CIP_VERSION ??= "v4.19.259-cip82"
+LINUX_GIT_SRCREV ?= "34b3125bdd71113063c74c32f4ecfbbb122dff57"
+LINUX_CVE_VERSION ??= "4.19.261"
+LINUX_CIP_VERSION ??= "v4.19.261-cip83"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
This pull request update the kernel to the following cip versions:
v4.19.261-cip83 with hash tag 34b3125bdd71113063c74c32f4ecfbbb122dff57
v5.10.147-cip18 with hash tag ef9425de71e3d6cd46470415b2648f2244057840