### PR TITLE
emlinux.inc: Fix esdk install error

### DIFF
--- a/conf/distro/include/emlinux.inc
+++ b/conf/distro/include/emlinux.inc
@@ -76,4 +76,6 @@ ERROR_QA_append = " ${WARN_TO_ERROR_QA}"
 
 BB_HASHBASE_WHITELIST_append = " DEBIAN_UNPACK_DIR"
 
+require conf/distro/include/yocto-uninative.inc
 require conf/distro/include/no-static-libs.inc
+INHERIT += "uninative"


### PR DESCRIPTION
# Purpose of pull request

Fix following error when installing an ESDK.

> ERROR: Task quilt-native.do_fetch attempted to execute unexpectedly

To fix above error, the uninative class was needed.

# Test
## How to test

1. Build and install SDks

## Test result

### Build and install ESDK

```
$ bitbake core-image-minimal -c populate_sdk_ext                                                                                                                                                    
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:16
Parsing of 1343 .bb files complete (0 cached, 1343 parsed). 2362 targets, 80 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies


Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.6"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:19fb75a3dea2939553d93fd00e5ccf73aba8da7f"
meta-debian-extended = "HEAD:c846a16975610bb618e398419134f978976e46a9"
meta-emlinux         = "fix-esdk-install-error:0ca3972e4f24ddc5d6556e30f17a0cb533567a75"
meta-emlinux-private = "HEAD:b290dafea47dfbd8df7ee9b04af38c9b73c87b68"

Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 1074 Found 0 Missed 1074 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3782 tasks of which 5 didn't need to be rerun and all succeeded.
```

install sdk

```
$ ./tmp-glibc/deploy/sdk/emlinux-glibc-x86_64-core-image-minimal-aarch64-toolchain-ext-2.6.sh -d ~/emlinux_sdk -y
EMLinux Extensible SDK installer version 2.6
============================================
You are about to install the SDK to "/home/build/emlinux_sdk". Proceed [Y/n]? Y
Extracting SDK...................................................done
Setting it up...
Extracting buildtools...
Preparing build system...
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:18
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:01
Checking sstate mirror object availability: 100% |#####################################################################################################################################| Time: 0:00:00
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
done
SDK has been successfully set up and is ready to be used.
Each time you wish to use the SDK in a new shell session, you need to source the environment setup script e.g.
 $ . /home/build/emlinux_sdk/environment-setup-aarch64-emlinux-linux
```
 
### Build and install ESDK (core-image-minimal)

build

```
$ bitbake core-image-minimal -c populate_sdk                                                                                                                                                        
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Loaded 2362 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.6"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:19fb75a3dea2939553d93fd00e5ccf73aba8da7f"
meta-debian-extended = "HEAD:c846a16975610bb618e398419134f978976e46a9"
meta-emlinux         = "fix-esdk-install-error:0ca3972e4f24ddc5d6556e30f17a0cb533567a75"
meta-emlinux-private = "HEAD:b290dafea47dfbd8df7ee9b04af38c9b73c87b68"

Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 229 Found 0 Missed 229 Current 579 (0% match, 71% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3303 tasks of which 2537 didn't need to be rerun and all succeeded.
```

install

```
$ ./tmp-glibc/deploy/sdk/emlinux-glibc-x86_64-core-image-minimal-aarch64-toolchain-2.6.sh -d ~/emlinux_sdk -y
EMLinux SDK installer version 2.6
=================================
You are about to install the SDK to "/home/build/emlinux_sdk". Proceed [Y/n]? Y
Extracting SDK...............................done
Setting it up...done
SDK has been successfully set up and is ready to be used.
Each time you wish to use the SDK in a new shell session, you need to source the environment setup script e.g.
 $ . /home/build/emlinux_sdk/environment-setup-aarch64-emlinux-linux
```

### Build and install sdk(core-image-minimal-sdk)

build

```
$ bitbake core-image-minimal-sdk -c populate_sdk
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Loaded 2362 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.6"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:19fb75a3dea2939553d93fd00e5ccf73aba8da7f"
meta-debian-extended = "HEAD:c846a16975610bb618e398419134f978976e46a9"
meta-emlinux         = "fix-esdk-install-error:0ca3972e4f24ddc5d6556e30f17a0cb533567a75"
meta-emlinux-private = "HEAD:b290dafea47dfbd8df7ee9b04af38c9b73c87b68"

Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 14 Found 0 Missed 14 Current 808 (0% match, 98% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3361 tasks of which 3302 didn't need to be rerun and all succeeded.
```

install

```
$ ./tmp-glibc/deploy/sdk/emlinux-glibc-x86_64-core-image-minimal-sdk-aarch64-toolchain-2.6.sh -d ~/emlinux_sdk -y
EMLinux SDK installer version 2.6
=================================
You are about to install the SDK to "/home/build/emlinux_sdk". Proceed [Y/n]? Y
Extracting SDK.............................................done
>>>> snip <<<<
  REMOVE  sg.h scsi_ioctl.h scsi.h
  INSTALL include/scsi (4 files)
  INSTALL include/scsi/fc (4 files)
  INSTALL include/sound (16 files)
  INSTALL include/video (3 files)
  INSTALL include/xen (4 files)
  REMOVE  swab-64.h kvm_para-64.h signal-64.h mman-64.h param-64.h ioctls-64.h unistd-64.h kvm-64.h bitsperlong-64.h statfs-64.h byteorder-64.h stat-64.h setup-64.h types-64.h hwcap-64.h ptrace-64.h auxvec-64.h sigcontext-64.h bpf_perf_event-64.h fcntl-64.h posix_types-64.h perf_regs-64.h siginfo-64.h
  INSTALL include/asm (36 files)
SDK has been successfully set up and is ready to be used.
Each time you wish to use the SDK in a new shell session, you need to source the environment setup script e.g.
```
```
```