### PR TITLE
Update kernel to v4.19.264-cip84 and v5.10.153-cip19

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux-k510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "ef9425de71e3d6cd46470415b2648f2244057840"
-LINUX_CVE_VERSION ??= "5.10.147"
-LINUX_CIP_VERSION ?= "v5.10.147-cip18"
+LINUX_GIT_SRCREV ?= "0f7fc281d55b27b299e8388c7d44809289ba8b99"
+LINUX_CVE_VERSION ??= "5.10.153"
+LINUX_CIP_VERSION ?= "v5.10.153-cip19"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "34b3125bdd71113063c74c32f4ecfbbb122dff57"
-LINUX_CVE_VERSION ??= "4.19.261"
-LINUX_CIP_VERSION ??= "v4.19.261-cip83"
+LINUX_GIT_SRCREV ?= "4e20f3800768ffe0d18b4cece5744ec28709b4d3"
+LINUX_CVE_VERSION ??= "4.19.264"
+LINUX_CIP_VERSION ??= "v4.19.264-cip84"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.264-cip84 and v5.10.153-cip19

This pull request update the kernel to the following cip versions:
v4.19.264-cip84 with hash tag 4e20f3800768ffe0d18b4cece5744ec28709b4d3
v5.10.153-cip19 with hash tag 0f7fc281d55b27b299e8388c7d44809289ba8b99
