### PR TITLE
Update kernel to v4.19.265-cip85 and v5.10.154-cip20

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux-k510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "0f7fc281d55b27b299e8388c7d44809289ba8b99"
-LINUX_CVE_VERSION ??= "5.10.153"
-LINUX_CIP_VERSION ?= "v5.10.153-cip19"
+LINUX_GIT_SRCREV ?= "efa0ded8f5c8a9e3835e4aea63caa6cffb0ccda8"
+LINUX_CVE_VERSION ??= "5.10.154"
+LINUX_CIP_VERSION ?= "v5.10.154-cip20"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "4e20f3800768ffe0d18b4cece5744ec28709b4d3"
-LINUX_CVE_VERSION ??= "4.19.264"
-LINUX_CIP_VERSION ??= "v4.19.264-cip84"
+LINUX_GIT_SRCREV ?= "f79656a3459e88f17f36f060c6e711b0556bb755"
+LINUX_CVE_VERSION ??= "4.19.265"
+LINUX_CIP_VERSION ??= "v4.19.265-cip85"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.265-cip85 and v5.10.154-cip20

This pull request update the kernel to the following cip versions:
v4.19.265-cip85 with hash tag f79656a3459e88f17f36f060c6e711b0556bb755
v5.10.154-cip20 with hash tag efa0ded8f5c8a9e3835e4aea63caa6cffb0ccda8
