### PR TITLE
Update kernel to v4.19.266-cip86 and v5.10.155-cip21

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux-k510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "efa0ded8f5c8a9e3835e4aea63caa6cffb0ccda8"
-LINUX_CVE_VERSION ??= "5.10.154"
-LINUX_CIP_VERSION ?= "v5.10.154-cip20"
+LINUX_GIT_SRCREV ?= "02e30f9cbbfce3d687cb1ab288e46ad20079e8e0"
+LINUX_CVE_VERSION ??= "5.10.155"
+LINUX_CIP_VERSION ?= "v5.10.155-cip21"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "f79656a3459e88f17f36f060c6e711b0556bb755"
-LINUX_CVE_VERSION ??= "4.19.265"
-LINUX_CIP_VERSION ??= "v4.19.265-cip85"
+LINUX_GIT_SRCREV ?= "8c8d57a3cae5b94b0a26c176e2a32f260fc529ae"
+LINUX_CVE_VERSION ??= "4.19.266"
+LINUX_CIP_VERSION ??= "v4.19.266-cip86"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.266-cip86 and v5.10.155-cip21

This pull request update the kernel to the following cip versions:
v4.19.266-cip86 with hash tag 8c8d57a3cae5b94b0a26c176e2a32f260fc529ae
v5.10.155-cip21 with hash tag 02e30f9cbbfce3d687cb1ab288e46ad20079e8e0
