### PR TITLE
Update kernel to v4.19.268-cip87 and v5.10.158-cip22

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux-k510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "02e30f9cbbfce3d687cb1ab288e46ad20079e8e0"
-LINUX_CVE_VERSION ??= "5.10.155"
-LINUX_CIP_VERSION ?= "v5.10.155-cip21"
+LINUX_GIT_SRCREV ?= "f37e570b7c4ab8bcfacf36780a9e204878f2c181"
+LINUX_CVE_VERSION ??= "5.10.158"
+LINUX_CIP_VERSION ?= "v5.10.158-cip22"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "8c8d57a3cae5b94b0a26c176e2a32f260fc529ae"
-LINUX_CVE_VERSION ??= "4.19.266"
-LINUX_CIP_VERSION ??= "v4.19.266-cip86"
+LINUX_GIT_SRCREV ?= "268e570d0a5691ceb479fa0368a6c73c5b080f89"
+LINUX_CVE_VERSION ??= "4.19.268"
+LINUX_CIP_VERSION ??= "v4.19.268-cip87"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.268-cip87 and v5.10.158-cip22

This pull request update the kernel to the following cip versions:
v4.19.268-cip87 with hash tag 268e570d0a5691ceb479fa0368a6c73c5b080f89
v5.10.158-cip22 with hash tag f37e570b7c4ab8bcfacf36780a9e204878f2c181
