### PR TITLE
Move kernel version info to distro features

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -1,6 +1,8 @@
 require include/emlinux.inc
 
 DISTRO = "emlinux-k510"
+DISTRO_FEATURES_append = " kernel-510"
+DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
 LINUX_GIT_SRCREV ?= "02e30f9cbbfce3d687cb1ab288e46ad20079e8e0"

--- a/recipes-debian/qemu/qemu_debian.bbappend
+++ b/recipes-debian/qemu/qemu_debian.bbappend
@@ -1,4 +1,4 @@
 SRC_URI_append_class-nativesdk += "\
-  ${@oe.utils.conditional("DISTRO", "emlinux-k510", \
+  ${@bb.utils.contains("DISTRO_FEATURES", "kernel-510", \
     "file://0014-linux-user-fix-to-handle-variably-sized-SIOCGSTAMP-w-custom.patch", "", d)} \
 "


### PR DESCRIPTION
# Purpose of pull request

Move kernel version information to DISTRO_FEATURES variable and change conditional variable from DISTRO to DISTRO_FEATURES.
Because currently, some recipes depend on kernel version requires DISTRO is set to "emlinux-k510".
So if user uses own DISTRO name, these recipes don't work correctly.  

# Test
## How to test

Set DISTRO to "emlinux-k510" and then run following command.
```
$ bitbake core-image-minimal
```

Next, create new DISTRO "emlinux-k510-custom"  and set it as DISTRO, and then run following command.
```
$ bitbake core-image-minimal
$ bitbake core-image-minimal-sdk -c populate_sdk
```
