### PR TITLE
Update kernel to v4.19.269-cip88 and v5.10.161-cip23

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "f37e570b7c4ab8bcfacf36780a9e204878f2c181"
-LINUX_CVE_VERSION ??= "5.10.158"
-LINUX_CIP_VERSION ?= "v5.10.158-cip22"
+LINUX_GIT_SRCREV ?= "986414929cfe870aedc5685f5ed4201f5032ca3e"
+LINUX_CVE_VERSION ??= "5.10.161"
+LINUX_CIP_VERSION ?= "v5.10.161-cip23"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "268e570d0a5691ceb479fa0368a6c73c5b080f89"
-LINUX_CVE_VERSION ??= "4.19.268"
-LINUX_CIP_VERSION ??= "v4.19.268-cip87"
+LINUX_GIT_SRCREV ?= "68472fb565eddeb233132b8be94440d06330ffbb"
+LINUX_CVE_VERSION ??= "4.19.269"
+LINUX_CIP_VERSION ??= "v4.19.269-cip88"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.269-cip88 and v5.10.161-cip23

This pull request update the kernel to the following cip versions:
v4.19.269-cip88 with hash tag 68472fb565eddeb233132b8be94440d06330ffbb
v5.10.161-cip23 with hash tag 986414929cfe870aedc5685f5ed4201f5032ca3e
