### PR TITLE
Update kernel to v4.19.270-cip89 and v5.10.162-cip24

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "986414929cfe870aedc5685f5ed4201f5032ca3e"
-LINUX_CVE_VERSION ??= "5.10.161"
-LINUX_CIP_VERSION ?= "v5.10.161-cip23"
+LINUX_GIT_SRCREV ?= "7ef5f1fda52a95426084959dac09acdb3c81327b"
+LINUX_CVE_VERSION ??= "5.10.162"
+LINUX_CIP_VERSION ?= "v5.10.162-cip24"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "68472fb565eddeb233132b8be94440d06330ffbb"
-LINUX_CVE_VERSION ??= "4.19.269"
-LINUX_CIP_VERSION ??= "v4.19.269-cip88"
+LINUX_GIT_SRCREV ?= "8cbf38242b91f4f98d6fc776bae10cc74740eff2"
+LINUX_CVE_VERSION ??= "4.19.270"
+LINUX_CIP_VERSION ??= "v4.19.270-cip89"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.270-cip89 and v5.10.162-cip24

This pull request update the kernel to the following cip versions:
v4.19.270-cip89 with hash tag 8cbf38242b91f4f98d6fc776bae10cc74740eff2
v5.10.162-cip24 with hash tag 7ef5f1fda52a95426084959dac09acdb3c81327b
