### PR TITLE
Update kernel to v4.19.271-cip90 and v5.10.165-cip25

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "7ef5f1fda52a95426084959dac09acdb3c81327b"
-LINUX_CVE_VERSION ??= "5.10.162"
-LINUX_CIP_VERSION ?= "v5.10.162-cip24"
+LINUX_GIT_SRCREV ?= "52aae1dc6afe62fedb14c89fd4feca1d8bb13416"
+LINUX_CVE_VERSION ??= "5.10.165"
+LINUX_CIP_VERSION ?= "v5.10.165-cip25"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "8cbf38242b91f4f98d6fc776bae10cc74740eff2"
-LINUX_CVE_VERSION ??= "4.19.270"
-LINUX_CIP_VERSION ??= "v4.19.270-cip89"
+LINUX_GIT_SRCREV ?= "6cd0670e124d09e80f2daaf2ecb13922a603f30d"
+LINUX_CVE_VERSION ??= "4.19.271"
+LINUX_CIP_VERSION ??= "v4.19.271-cip90"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.271-cip90 and v5.10.165-cip25

This pull request update the kernel to the following cip versions:
v4.19.271-cip90 with hash tag 6cd0670e124d09e80f2daaf2ecb13922a603f30d
v5.10.165-cip25 with hash tag 52aae1dc6afe62fedb14c89fd4feca1d8bb13416
