### PR TITLE
Update kernel to v4.19.272-cip91 and v5.10.167-cip26

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "52aae1dc6afe62fedb14c89fd4feca1d8bb13416"
-LINUX_CVE_VERSION ??= "5.10.165"
-LINUX_CIP_VERSION ?= "v5.10.165-cip25"
+LINUX_GIT_SRCREV ?= "dd0dd3e572fd82c1c232ad1f089ca628d7dc16de"
+LINUX_CVE_VERSION ??= "5.10.167"
+LINUX_CIP_VERSION ?= "v5.10.167-cip26"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "6cd0670e124d09e80f2daaf2ecb13922a603f30d"
-LINUX_CVE_VERSION ??= "4.19.271"
-LINUX_CIP_VERSION ??= "v4.19.271-cip90"
+LINUX_GIT_SRCREV ?= "a308535fd0f82d23c6acc4bb20c69066ca01bdd6"
+LINUX_CVE_VERSION ??= "4.19.272"
+LINUX_CIP_VERSION ??= "v4.19.272-cip91"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.272-cip91 and v5.10.167-cip26

This pull request update the kernel to the following cip versions:
v4.19.272-cip91 with hash tag a308535fd0f82d23c6acc4bb20c69066ca01bdd6
v5.10.167-cip26 with hash tag dd0dd3e572fd82c1c232ad1f089ca628d7dc16de
