### PR TITLE
Remove sudo package from instsall package

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ $ sudo apt install \
   quilt \
   qemu-user-static \
   reprepro \
-  sudo \
   git-buildpackage \
   pristine-tar \
   sbuild \


### PR DESCRIPTION
sudo command doesn't need to install in install step because it must be installed before run install step.
