### PR TITLE
Update kernel to v4.19.273-cip92 and v5.10.168-cip27

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "dd0dd3e572fd82c1c232ad1f089ca628d7dc16de"
-LINUX_CVE_VERSION ??= "5.10.167"
-LINUX_CIP_VERSION ?= "v5.10.167-cip26"
+LINUX_GIT_SRCREV ?= "cc82f737b68c179240070fa34771bcfd0a5fa421"
+LINUX_CVE_VERSION ??= "5.10.168"
+LINUX_CIP_VERSION ?= "v5.10.168-cip27"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "a308535fd0f82d23c6acc4bb20c69066ca01bdd6"
-LINUX_CVE_VERSION ??= "4.19.272"
-LINUX_CIP_VERSION ??= "v4.19.272-cip91"
+LINUX_GIT_SRCREV ?= "13b591404faff8a66449dfa80682930f5325b869"
+LINUX_CVE_VERSION ??= "4.19.273"
+LINUX_CIP_VERSION ??= "v4.19.273-cip92"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.273-cip92 and v5.10.168-cip27

This pull request update the kernel to the following cip versions:
v4.19.273-cip92 with hash tag 13b591404faff8a66449dfa80682930f5325b869
v5.10.168-cip27 with hash tag cc82f737b68c179240070fa34771bcfd0a5fa421
