### PR TITLE
Security features

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -1,0 +1,104 @@
+# 
+# CVE check class
+# Copyright (c) Cybertrust Japan Co., Ltd.
+#
+# Authors:
+#  Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+#
+# SPDX-License-Identifier: MIT
+#
+
+CVE_CHECK_TRIVY_VERSION ??= "0.37.3"
+CVE_CHECK_TRIVY_SHA256SUM = "4a10870563e7db4bc6abfe1b74bf7f3921873ba9765d9169625419f8143cda90"
+CVE_CHECK_TRIVY_FORMAT ??= "cyclonedx"
+CVE_CHECK_TRIVY_OUTPUT_FILE ??= "cve_check_cyclonedx-scan-log.json"
+
+# trivy release file checksum.
+SRC_URI[sha256sum] = "${CVE_CHECK_TRIVY_SHA256SUM}"
+
+def cve_check_download_trivy(d):
+    import os
+
+    dldir = d.getVar('DL_DIR', True)
+    unpack_dir = f'{dldir}/trivy'
+
+    d.setVar('CVE_CHECK_TRIVY_BIN_PATH', f'{unpack_dir}/trivy')
+
+    if os.path.exists(unpack_dir):
+        return True
+
+    import subprocess
+
+    trivy = f'trivy_{d.getVar("CVE_CHECK_TRIVY_VERSION", True)}_Linux-64bit.tar.gz'
+    url = f'https://github.com/aquasecurity/trivy/releases/download/v{d.getVar("CVE_CHECK_TRIVY_VERSION", True)}/{trivy}'
+
+    try:
+        bb.plain('Downloading trivy ...')
+        fetcher = bb.fetch2.Fetch([url], d)
+        fetcher.download()
+    except bb.fetch2.BBFetchException as e:
+        bb.error('Failed to fetch trivy')
+        return False
+
+    os.mkdir(unpack_dir)
+
+    cmd = [ 'tar', 'xf', f'{dldir}/{trivy}', '-C', unpack_dir ]
+    with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
+        proc.wait()
+    
+        retcode = int(proc.returncode)
+        if not retcode == 0:
+            bb.error('Failed to unpack trivy')
+            return False
+
+    return True
+
+def cve_check_run_trivy(d):
+    import subprocess
+
+    rootfs = f'{d.getVar("WORKDIR", True)}/rootfs'
+    
+    output_path = f'{d.getVar("WORKDIR", True)}/temp/{d.getVar("CVE_CHECK_TRIVY_OUTPUT_FILE", True)}'
+
+    cmd = [ d.getVar('CVE_CHECK_TRIVY_BIN_PATH', True), 'fs', rootfs, '-f', d.getVar('CVE_CHECK_TRIVY_FORMAT', True), '--scanners', 'vuln', '-o', output_path ]
+    
+    with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
+        proc.wait()
+    
+        retcode = int(proc.returncode)
+        if not retcode == 0:
+            bb.error('Failed to run trivy')
+            return False
+
+    return True
+
+def cve_check_report_cves(d):
+    cve_file = f'{d.getVar("WORKDIR", True)}/temp/{d.getVar("CVE_CHECK_TRIVY_OUTPUT_FILE", True)}'
+
+    import json
+    import re
+
+    with open(cve_file) as f:
+        data = json.load(f)
+
+    for cve in data['vulnerabilities']:
+        id = cve['id']
+        pkgs = []
+        for affect in cve['affects']:
+            ref = affect['ref']
+            tmp = re.search(r'(\w+:\w+/\w+/)(\w+)(@\w*)', ref)
+            if not tmp is None:
+                pkgs.append(tmp.groups()[1])
+                version = affect['versions'][0]['version']
+        
+        if len(pkgs) > 0:
+            msg = f'CVE ({id}) is found in version {version} of {" ".join(pkgs)}'
+            bb.warn(msg)
+   
+python do_cve_check() {
+    if cve_check_download_trivy(d):
+        if cve_check_run_trivy(d):
+            cve_check_report_cves(d)
+}
+
+addtask cve_check after do_rootfs

--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -13,13 +13,15 @@ CVE_CHECK_TRIVY_SHA256SUM = "4a10870563e7db4bc6abfe1b74bf7f3921873ba9765d9169625
 CVE_CHECK_TRIVY_FORMAT ??= "cyclonedx"
 CVE_CHECK_TRIVY_OUTPUT_FILE ??= "cve_check_cyclonedx-scan-log.json"
 
+KERNEL_PN ??= "linux-cip"
+
 # trivy release file checksum.
 SRC_URI[sha256sum] = "${CVE_CHECK_TRIVY_SHA256SUM}"
 
 def cve_check_download_trivy(d):
     import os
 
-    dldir = d.getVar('DL_DIR', True)
+    dldir = d.getVar('DL_DIR')
     unpack_dir = f'{dldir}/trivy'
 
     d.setVar('CVE_CHECK_TRIVY_BIN_PATH', f'{unpack_dir}/trivy')
@@ -29,8 +31,8 @@ def cve_check_download_trivy(d):
 
     import subprocess
 
-    trivy = f'trivy_{d.getVar("CVE_CHECK_TRIVY_VERSION", True)}_Linux-64bit.tar.gz'
-    url = f'https://github.com/aquasecurity/trivy/releases/download/v{d.getVar("CVE_CHECK_TRIVY_VERSION", True)}/{trivy}'
+    trivy = f'trivy_{d.getVar("CVE_CHECK_TRIVY_VERSION")}_Linux-64bit.tar.gz'
+    url = f'https://github.com/aquasecurity/trivy/releases/download/v{d.getVar("CVE_CHECK_TRIVY_VERSION")}/{trivy}'
 
     try:
         bb.plain('Downloading trivy ...')
@@ -56,11 +58,11 @@ def cve_check_download_trivy(d):
 def cve_check_run_trivy(d):
     import subprocess
 
-    rootfs = f'{d.getVar("WORKDIR", True)}/rootfs'
+    rootfs = f'{d.getVar("WORKDIR")}/rootfs'
     
-    output_path = f'{d.getVar("WORKDIR", True)}/temp/{d.getVar("CVE_CHECK_TRIVY_OUTPUT_FILE", True)}'
+    output_path = f'{d.getVar("WORKDIR")}/temp/{d.getVar("CVE_CHECK_TRIVY_OUTPUT_FILE")}'
 
-    cmd = [ d.getVar('CVE_CHECK_TRIVY_BIN_PATH', True), 'fs', rootfs, '-f', d.getVar('CVE_CHECK_TRIVY_FORMAT', True), '--scanners', 'vuln', '-o', output_path ]
+    cmd = [ d.getVar('CVE_CHECK_TRIVY_BIN_PATH'), 'fs', rootfs, '-f', d.getVar('CVE_CHECK_TRIVY_FORMAT'), '--scanners', 'vuln', '-o', output_path ]
     
     with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
         proc.wait()
@@ -73,7 +75,7 @@ def cve_check_run_trivy(d):
     return True
 
 def cve_check_report_cves(d):
-    cve_file = f'{d.getVar("WORKDIR", True)}/temp/{d.getVar("CVE_CHECK_TRIVY_OUTPUT_FILE", True)}'
+    cve_file = f'{d.getVar("WORKDIR")}/temp/{d.getVar("CVE_CHECK_TRIVY_OUTPUT_FILE")}'
 
     import json
     import re
@@ -96,6 +98,10 @@ def cve_check_report_cves(d):
             bb.warn(msg)
    
 python do_cve_check() {
+    # skip this cve-check if recipe is linux kernel
+    if d.getVar('PN') == d.getVar('KERNEL_PN'):
+        return
+
     if cve_check_download_trivy(d):
         if cve_check_run_trivy(d):
             cve_check_report_cves(d)

--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -1,0 +1,155 @@
+# 
+# Kernel CVE check class
+# Copyright (c) Cybertrust Japan Co., Ltd.
+#
+# Authors:
+#  Masami Ichikawa <masami.ichikawa@miraclelinux.com>
+#
+# SPDX-License-Identifier: MIT
+#
+
+inherit cve-check
+
+KERNEL_CVE_CHECK_CIP_KERNEL_SEC_DIR ??= ""
+
+# TODO: Change to "cip" when CIP Project releases linux-6.1.y-cip.
+KERNEL_CVE_CHECK_REMOTE_TARGET = "stable"
+
+# Show ignored CVEs
+KERNEL_CVE_CHECK_INCLUDE_IGNORE ??= "1"
+
+# Remote branch name. bitbake detects it from kernel-src by default.
+KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO ??= ""
+KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT ??= "1"
+
+KERNEL_CVE_CHECK_RESULT_FILE = "kernel_cve_check_result.json"
+
+# It requires an initial value to ignore kernel cve check if PN is not kernel
+KERNEL_CVE_CHECK_TASK_ORDER = ""
+KERNEL_PN ??= 'linux-cip'
+
+def remove_remote(d, workdir):
+    """
+    Remove needless remotes from remotes.yml.
+    """
+    import yaml
+
+    remotes_path = os.path.join(workdir, 'remotes.yml')
+
+    with open(remotes_path) as f:
+        content = yaml.safe_load(f)
+
+    remote = d.getVar('KERNEL_CVE_CHECK_REMOTE_TARGET')
+    with open(remotes_path, 'w') as f:
+        yaml.dump({remote: content[remote]}, f, default_flow_style=False)
+
+def kernel_cve_check_update_cip_kernel_sec(d):
+    """
+    Update cip-kernel-sec repository.
+    """
+    import os
+    from bb.fetch2 import runfetchcmd
+
+    kernel_cve_check_dir = d.getVar('DL_DIR')
+    d.setVar('KERNEL_CVE_CHECK_CIP_KERNEL_SEC_DIR', kernel_cve_check_dir)
+
+    cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, 'cip-kernel-sec')
+    git_uri = 'https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec.git'
+
+    if not os.path.isdir(kernel_cve_check_dir):
+        os.mkdir(kernel_cve_check_dir)
+
+    if not os.path.isdir(cip_kernel_sec_path):
+        # first run
+        runfetchcmd("git clone %s cip-kernel-sec" % git_uri, d,  workdir=kernel_cve_check_dir)
+        remove_remote(d, os.path.join(cip_kernel_sec_path, "conf"))
+        runfetchcmd("git update-index --skip-worktree conf/remotes.yml", d, workdir=cip_kernel_sec_path)
+    else:
+        runfetchcmd("git pull", d, workdir=cip_kernel_sec_path)
+
+    return True
+
+def get_issue_list(cip_kernel_sec_path):
+    """
+    Get issue list registered to cip-kernel-sec.
+    """
+    import glob
+    glob_param = cip_kernel_sec_path + "/issues/CVE-*.yml"
+
+    return [os.path.basename(name)[:-4] for name in glob.glob(glob_param)]
+
+def kernel_cve_check_run(d):
+    """
+    Check cves by cip-kernel-sec
+    """
+    from bb.fetch2 import runfetchcmd
+    import requests
+    import bb.process
+
+    kernel_path = d.getVar("S")
+    linux_cip_ver = d.getVar('LINUX_CIP_VERSION')
+    cip_kernel_sec_path = f'{d.getVar("KERNEL_CVE_CHECK_CIP_KERNEL_SEC_DIR")}/cip-kernel-sec'
+    include_ignore = d.getVar('KERNEL_CVE_CHECK_INCLUDE_IGNORE')
+    remote_repo_name = d.getVar('KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO')
+    remote_repo_autodetect = d.getVar('KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT')
+    remote_target = d.getVar('KERNEL_CVE_CHECK_REMOTE_TARGET')
+
+    opt_ignore = "--include-ignored" if include_ignore == "1" else ""
+
+    # Try to get remote name from kernel repository
+    if not remote_repo_name and remote_repo_autodetect == "1":
+        try:
+            bb.debug(2, 'No remote name is defined and KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT is set. bitbake detects remote name from kernel-src')
+            stdout, _ = bb.process.run('git remote', cwd=kernel_path, shell=True)
+            remote_repo_name = stdout.splitlines()[0]
+        except bb.process.ExecutionError as e:
+            bb.warn("Failed to detect remote name. bitbake assumes that remote is 'origin'. Please consider setting KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO")
+
+    cert_path = requests.certs.where()
+    cmd = f'SSL_CERT_FILE={cert_path} python3 {cip_kernel_sec_path}/scripts/report_affected.py {opt_ignore} --remote-name {remote_target}:{remote_repo_name} --git-repo {kernel_path} {linux_cip_ver}'
+    output = runfetchcmd(cmd, d, workdir=cip_kernel_sec_path)
+    affect_cves = output.split(":")[2].strip().split()
+    
+    if len(affect_cves) > 0:
+        bb.warn(output)
+
+    whitelist = []
+    for cve in get_issue_list(cip_kernel_sec_path):
+        if cve not in affect_cves:
+            whitelist.append(cve)
+
+    bb.debug(2, 'Whitelisted by cip-kernel-sec:\n    {"\n    ".join(whitelist)}')
+    d.appendVar('CVE_CHECK_WHITELIST', ' ' + ' '.join(whitelist))
+
+    return affect_cves
+
+def kernel_cve_check_merge_affected_cves_and_whitelist(d, cves):
+    whitelist = d.getVar('CVE_CHECK_WHITELIST')
+
+    triaged_cves = []
+    for cve in cves:
+        if not cve in whitelist: 
+            triaged_cves.append(cve)
+
+    return triaged_cves
+
+def kernel_cve_check_write_result(d, affected_cves):
+    result_file = f'{d.getVar("WORKDIR")}/temp/{d.getVar("KERNEL_CVE_CHECK_RESULT_FILE")}'
+    
+    import json
+
+    tmp = { 'cves': affected_cves }
+
+    with open(result_file, 'w') as f:
+        f.write(json.dumps(tmp))
+
+python kernel_cve_check() {
+    if kernel_cve_check_update_cip_kernel_sec(d):
+        cves = kernel_cve_check_run(d)
+        if len(cves) > 0:
+            affected_cves = kernel_cve_check_merge_affected_cves_and_whitelist(d, cves)
+            kernel_cve_check_write_result(d, affected_cves)
+}
+
+do_cve_check[postfuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'kernel_cve_check', '', d)}"
+do_cve_check[depends] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), d.getVar('KERNEL_CVE_CHECK_TASK_ORDER'), '', d)}"

--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,6 +12,7 @@ FILESEXTRAPATHS_prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
+LINUX_CIP_VERSION = "v6.1.10"
 PV = "6.1.10"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;branch=linux-6.1.y;destsuffix=${P};protocol=https \
@@ -22,4 +23,3 @@ KERNEL_DEFCONFIG = "${MACHINE}_defconfig"
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
 SRCREV = "17d99ea98b6238e7e483fba27e8f7a7842d0f345"
 
-#S = "${WORKDIR}/linux-${PV}"

--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,12 +12,14 @@ FILESEXTRAPATHS_prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
+PV = "6.1.10"
 SRC_URI += " \
-    https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-${PV}.tar.gz \
+    git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;branch=linux-6.1.y;destsuffix=${P};protocol=https \
     file://${MACHINE}_defconfig \
 "
 
 KERNEL_DEFCONFIG = "${MACHINE}_defconfig"
-SRC_URI[sha256sum] = "003176045aaddb245e5b64cd88c34846b8265f1197ca14baa43c91c9ec7d5e23"
+SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
+SRCREV = "17d99ea98b6238e7e483fba27e8f7a7842d0f345"
 
-S = "${WORKDIR}/linux-${PV}"
+#S = "${WORKDIR}/linux-${PV}"


### PR DESCRIPTION
This PR added kernel-cve-check class which uses cip-kernel-sec tool to check CVEs. However, this tool need kernel's commit log so that we need to have commit histories but tar file doesn't contain it. Therefore,  changing the kernel recipe to download the linux kernel via git instead of tar file.
To run CVE check,  add following line in local.conf.

```
INHERIT += "cve-check kernel-cve-check"
```
