### PR TITLE
cve-check: Store scan result file in deploy directory

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -60,10 +60,10 @@ def cve_check_run_trivy(d):
 
     rootfs = f'{d.getVar("WORKDIR")}/rootfs'
     
-    output_path = f'{d.getVar("WORKDIR")}/temp/{d.getVar("CVE_CHECK_TRIVY_OUTPUT_FILE")}'
+    output_path = f'{d.getVar("CVE_CHECK_RESULT_DIR")}/{d.getVar("CVE_CHECK_TRIVY_OUTPUT_FILE")}'
 
     cmd = [ d.getVar('CVE_CHECK_TRIVY_BIN_PATH'), 'fs', rootfs, '-f', d.getVar('CVE_CHECK_TRIVY_FORMAT'), '--scanners', 'vuln', '-o', output_path ]
-    
+
     with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
         proc.wait()
     
@@ -75,7 +75,7 @@ def cve_check_run_trivy(d):
     return True
 
 def cve_check_report_cves(d):
-    cve_file = f'{d.getVar("WORKDIR")}/temp/{d.getVar("CVE_CHECK_TRIVY_OUTPUT_FILE")}'
+    cve_file = f'{d.getVar("CVE_CHECK_RESULT_DIR")}/{d.getVar("CVE_CHECK_TRIVY_OUTPUT_FILE")}'
 
     import json
     import re
@@ -98,6 +98,14 @@ def cve_check_report_cves(d):
             bb.warn(msg)
    
 python do_cve_check() {
+    import os
+    result_dir = f'{d.getVar("DEPLOY_DIR")}/cve'
+
+    if not os.path.exists(result_dir):
+        os.mkdir(result_dir)
+
+    d.setVar('CVE_CHECK_RESULT_DIR', result_dir)
+
     # skip this cve-check if recipe is linux kernel
     if d.getVar('PN') == d.getVar('KERNEL_PN'):
         return

--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -134,7 +134,7 @@ def kernel_cve_check_merge_affected_cves_and_whitelist(d, cves):
     return triaged_cves
 
 def kernel_cve_check_write_result(d, affected_cves):
-    result_file = f'{d.getVar("WORKDIR")}/temp/{d.getVar("KERNEL_CVE_CHECK_RESULT_FILE")}'
+    result_file = f'{d.getVar("CVE_CHECK_RESULT_DIR")}/{d.getVar("KERNEL_CVE_CHECK_RESULT_FILE")}'
     
     import json
 


### PR DESCRIPTION
Store scan result file in the $DEPLOY_DIR/cve instead of recipe's log directory.
