### PR TITLE
Update kernel to v4.19.276-cip93 and v5.10.173-cip28

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "cc82f737b68c179240070fa34771bcfd0a5fa421"
-LINUX_CVE_VERSION ??= "5.10.168"
-LINUX_CIP_VERSION ?= "v5.10.168-cip27"
+LINUX_GIT_SRCREV ?= "2988848bfa1d1f2c02318f2193b06874fb5f62eb"
+LINUX_CVE_VERSION ??= "5.10.173"
+LINUX_CIP_VERSION ?= "v5.10.173-cip28"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "13b591404faff8a66449dfa80682930f5325b869"
-LINUX_CVE_VERSION ??= "4.19.273"
-LINUX_CIP_VERSION ??= "v4.19.273-cip92"
+LINUX_GIT_SRCREV ?= "849e6920f9039d78588d7ab644573c58cca7e64e"
+LINUX_CVE_VERSION ??= "4.19.276"
+LINUX_CIP_VERSION ??= "v4.19.276-cip93"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.276-cip93 and v5.10.173-cip28

This pull request update the kernel to the following cip versions:
v4.19.276-cip93 with hash tag 849e6920f9039d78588d7ab644573c58cca7e64e
v5.10.173-cip28 with hash tag 2988848bfa1d1f2c02318f2193b06874fb5f62eb
