### PR TITLE
Update kernel to v4.19.277-cip94 and v5.10.175-cip29

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "2988848bfa1d1f2c02318f2193b06874fb5f62eb"
-LINUX_CVE_VERSION ??= "5.10.173"
-LINUX_CIP_VERSION ?= "v5.10.173-cip28"
+LINUX_GIT_SRCREV ?= "bb7267e6d2a6f131bb46ba14f0d3c418379e8bd4"
+LINUX_CVE_VERSION ??= "5.10.175"
+LINUX_CIP_VERSION ?= "v5.10.175-cip29"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "849e6920f9039d78588d7ab644573c58cca7e64e"
-LINUX_CVE_VERSION ??= "4.19.276"
-LINUX_CIP_VERSION ??= "v4.19.276-cip93"
+LINUX_GIT_SRCREV ?= "7027f305d14858b8392890a56cfe71edd50df202"
+LINUX_CVE_VERSION ??= "4.19.277"
+LINUX_CIP_VERSION ??= "v4.19.277-cip94"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.277-cip94 and v5.10.175-cip29

This pull request update the kernel to the following cip versions:
v4.19.277-cip94 with hash tag 7027f305d14858b8392890a56cfe71edd50df202
v5.10.175-cip29 with hash tag bb7267e6d2a6f131bb46ba14f0d3c418379e8bd4
