### PR TITLE
Update kernel to v4.19.279-cip95 and v5.10.176-cip30

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "bb7267e6d2a6f131bb46ba14f0d3c418379e8bd4"
-LINUX_CVE_VERSION ??= "5.10.175"
-LINUX_CIP_VERSION ?= "v5.10.175-cip29"
+LINUX_GIT_SRCREV ?= "530cf8a4dace471f6e04e5887f4993ba1fcd3109"
+LINUX_CVE_VERSION ??= "5.10.176"
+LINUX_CIP_VERSION ?= "v5.10.176-cip30"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "7027f305d14858b8392890a56cfe71edd50df202"
-LINUX_CVE_VERSION ??= "4.19.277"
-LINUX_CIP_VERSION ??= "v4.19.277-cip94"
+LINUX_GIT_SRCREV ?= "a166e121fe317e5b7a79c09a0ca641ca15cb61cf"
+LINUX_CVE_VERSION ??= "4.19.279"
+LINUX_CIP_VERSION ??= "v4.19.279-cip95"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.279-cip95 and v5.10.176-cip30

This pull request update the kernel to the following cip versions:
v4.19.279-cip95 with hash tag a166e121fe317e5b7a79c09a0ca641ca15cb61cf
v5.10.176-cip30 with hash tag 530cf8a4dace471f6e04e5887f4993ba1fcd3109
