### PR TITLE
Update kernel to v4.19.280-cip96 and v5.10.177-cip31

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "530cf8a4dace471f6e04e5887f4993ba1fcd3109"
-LINUX_CVE_VERSION ??= "5.10.176"
-LINUX_CIP_VERSION ?= "v5.10.176-cip30"
+LINUX_GIT_SRCREV ?= "deb75c99ed78d677587a345854b8a00fb2cac68c"
+LINUX_CVE_VERSION ??= "5.10.177"
+LINUX_CIP_VERSION ?= "v5.10.177-cip31"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "a166e121fe317e5b7a79c09a0ca641ca15cb61cf"
-LINUX_CVE_VERSION ??= "4.19.279"
-LINUX_CIP_VERSION ??= "v4.19.279-cip95"
+LINUX_GIT_SRCREV ?= "0f5788ca10e5121ce62a8a58a84c723b7d99607f"
+LINUX_CVE_VERSION ??= "4.19.280"
+LINUX_CIP_VERSION ??= "v4.19.280-cip96"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.280-cip96 and v5.10.177-cip31

This pull request update the kernel to the following cip versions:
v4.19.280-cip96 with hash tag 0f5788ca10e5121ce62a8a58a84c723b7d99607f
v5.10.177-cip31 with hash tag deb75c99ed78d677587a345854b8a00fb2cac68c
