### PR TITLE
linux: Update linux kernel version from 6.1.10 to 6.1.24

### DIFF
--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.10"
-PV = "6.1.10"
+LINUX_CIP_VERSION = "v6.1.24"
+PV = "6.1.24"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;branch=linux-6.1.y;destsuffix=${P};protocol=https \
     file://${MACHINE}_defconfig \
@@ -21,6 +21,6 @@ SRC_URI += " \
 
 KERNEL_DEFCONFIG = "${MACHINE}_defconfig"
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
-SRCREV = "17d99ea98b6238e7e483fba27e8f7a7842d0f345"
+SRCREV = "0102425ac76bd184704c698cab7cb4fe37997556"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
# Purpose of pull request

Update to latest stable kernel 6.1.24 as of 2023-04-18.


# Test
## How to test

1. Build kernel
2. Run qemu image

## Test result

Build result.

```
build@8130b81d062c:~/work/build$ bitbake linux-cip
Loading cache: 100% |                                                                                                                                                                 | ETA:  --:--:--
Loaded 0 entries from dependency cache.
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:00
Parsing of 60 .bb files complete (0 cached, 60 parsed). 114 targets, 0 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 3 Local 0 Mirrors 0 Missed 3 Current 0 (0% match, 0% complete)
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 28 tasks of which 0 didn't need to be rerun and all succeeded.
```

Run qemu-arm64.

```
EMLinux 3.0 EMLinux3 ttyAMA0
EMLinux3 login: root
Password: 
Linux EMLinux3 6.1.24-g0102425ac76b #1 SMP PREEMPT Thu, 01 Jan 1970 01:00:00 +0000 aarch64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
root@EMLinux3:~# uname -a
Linux EMLinux3 6.1.24-g0102425ac76b #1 SMP PREEMPT Thu, 01 Jan 1970 01:00:00 +0000 aarch64 GNU/Linux
```

Run qemu-amd64.

```
EMLinux3 login: root
Password: 
Linux EMLinux3 6.1.24-g0102425ac76b #1 SMP PREEMPT_DYNAMIC Thu, 01 Jan 1970 01:00:00 +0000 x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
root@EMLinux3:~# uname -a
Linux EMLinux3 6.1.24-g0102425ac76b #1 SMP PREEMPT_DYNAMIC Thu, 01 Jan 1970 01:00:00 +0000 x86_64 GNU/Linux
```
