### PR TITLE
classes: che-check: Use makedires instead of mkdir

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -42,7 +42,7 @@ def cve_check_download_trivy(d):
         bb.error('Failed to fetch trivy')
         return False
 
-    os.mkdir(unpack_dir)
+    os.makedirs(unpack_dir)
 
     cmd = [ 'tar', 'xf', f'{dldir}/{trivy}', '-C', unpack_dir ]
     with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
@@ -102,7 +102,7 @@ python do_cve_check() {
     result_dir = f'{d.getVar("DEPLOY_DIR")}/cve'
 
     if not os.path.exists(result_dir):
-        os.mkdir(result_dir)
+        os.makedirs(result_dir)
 
     d.setVar('CVE_CHECK_RESULT_DIR', result_dir)
 

--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -57,7 +57,7 @@ def kernel_cve_check_update_cip_kernel_sec(d):
     git_uri = 'https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec.git'
 
     if not os.path.isdir(kernel_cve_check_dir):
-        os.mkdir(kernel_cve_check_dir)
+        os.makedirs(kernel_cve_check_dir)
 
     if not os.path.isdir(cip_kernel_sec_path):
         # first run


### PR DESCRIPTION
The os.makedirs() do same as "mkdir -p" which is more better than os.mkdir(). The os.mkdir() may fail if parent directories are not found.

If the deploy directory is not found, we got following error.

```
File: '/home/build/work/build/../repos/meta-emlinux/classes/cve-check.bbclass', lineno: 105, function: do_cve_check
     0101:    import os
     0102:    result_dir = f'{d.getVar("DEPLOY_DIR")}/cve'
     0103:
     0104:    if not os.path.exists(result_dir):
 *** 0105:        os.mkdir(result_dir)
     0106:
     0107:    d.setVar('CVE_CHECK_RESULT_DIR', result_dir)
     0108:
     0109:    # skip this cve-check if recipe is linux kernel
```