### PR TITLE
classes: cve-check: Set TASK_USE_NETWORK to cve_check task

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -115,4 +115,5 @@ python do_cve_check() {
             cve_check_report_cves(d)
 }
 
+do_cve_check[network] = "${TASK_USE_NETWORK}"
 addtask cve_check after do_rootfs


### PR DESCRIPTION
Since commit fea0f64 (“meta: mark network and sudo tasks“), task needs to set TASK_USE_NETWORK variable if task accesses network.

Link:
https://github.com/ilbers/isar/commit/fea0f649fc3a03388ccb1c1bc73293bfa4509dc8
