### PR TITLE
machine: x86-64: Add wic.xz image type

### DIFF
--- a/conf/machine/generic-x86-64.conf
+++ b/conf/machine/generic-x86-64.conf
@@ -9,6 +9,6 @@
 #
 DISTRO_ARCH ?= "amd64"
 
-IMAGE_FSTYPES ?= "wic"
+IMAGE_FSTYPES ?= "wic wic.xz"
 IMAGER_INSTALL += "${GRUB_BOOTLOADER_INSTALL}"
 


### PR DESCRIPTION
Add wic.xz to minimize build image which is easy to copy to other machine via network.
