### PR TITLE
Update kernel to v4.19.282-cip97 and v5.10.179-cip32

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "deb75c99ed78d677587a345854b8a00fb2cac68c"
-LINUX_CVE_VERSION ??= "5.10.177"
-LINUX_CIP_VERSION ?= "v5.10.177-cip31"
+LINUX_GIT_SRCREV ?= "113faaf50d23879378cb772597f4d6fdb1f4cc20"
+LINUX_CVE_VERSION ??= "5.10.179"
+LINUX_CIP_VERSION ?= "v5.10.179-cip32"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "0f5788ca10e5121ce62a8a58a84c723b7d99607f"
-LINUX_CVE_VERSION ??= "4.19.280"
-LINUX_CIP_VERSION ??= "v4.19.280-cip96"
+LINUX_GIT_SRCREV ?= "2806abebc536fd0cfae1a365ce76816febe69606"
+LINUX_CVE_VERSION ??= "4.19.282"
+LINUX_CIP_VERSION ??= "v4.19.282-cip97"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.282-cip97 and v5.10.179-cip32

This pull request update the kernel to the following cip versions:
v4.19.282-cip97 with hash tag 2806abebc536fd0cfae1a365ce76816febe69606
v5.10.179-cip32 with hash tag 113faaf50d23879378cb772597f4d6fdb1f4cc20
