### PR TITLE
Update kernel to v4.19.283-cip98 and v5.10.180-cip33

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "113faaf50d23879378cb772597f4d6fdb1f4cc20"
-LINUX_CVE_VERSION ??= "5.10.179"
-LINUX_CIP_VERSION ?= "v5.10.179-cip32"
+LINUX_GIT_SRCREV ?= "7f6b02104eb287caf662ade9a67f11896ab01fde"
+LINUX_CVE_VERSION ??= "5.10.180"
+LINUX_CIP_VERSION ?= "v5.10.180-cip33"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "2806abebc536fd0cfae1a365ce76816febe69606"
-LINUX_CVE_VERSION ??= "4.19.282"
-LINUX_CIP_VERSION ??= "v4.19.282-cip97"
+LINUX_GIT_SRCREV ?= "31603fc59adb456f6eb0f58de8bb989b41572c2a"
+LINUX_CVE_VERSION ??= "4.19.283"
+LINUX_CIP_VERSION ??= "v4.19.283-cip98"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.283-cip98 and v5.10.180-cip33

This pull request update the kernel to the following cip versions:
v4.19.283-cip98 with hash tag 31603fc59adb456f6eb0f58de8bb989b41572c2a
v5.10.180-cip33 with hash tag 7f6b02104eb287caf662ade9a67f11896ab01fde
