### PR TITLE
linux: linux-base: Add CVE-2023-1872 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -14,8 +14,9 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2022-0168: This issue was introduced in 4.20-rc1. 4.19.y is not affected.
 # CVE-2022-1508: This is io_uring issue. linux 4.19 doesn't have this feature.
 # CVE-2022-1789: This issue was introduced in 5.8-rc1. 4.19.y is not affected.
+# CVE-2023-1872: This is io_uring issue. linux 4.19 doesn't have this feature.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
-    CVE-2022-1508 CVE-2022-1789 \
+    CVE-2022-1508 CVE-2022-1789 CVE-2023-1872 \
 "


### PR DESCRIPTION
# Purpose of pull request
CVE-2023-1872 is io_uring issue which is not implemented in 4.19.y.  
So, it is okay to add this CVE to the CVE_CHECK_WHITELIST.

# Test
## How to test
1. Build linux-base and with CVE check

## Test result
Without this PR shows CVE-2023-1872.
```
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:b622b264446afaab533290ceb59ad84096caedc7"
meta-debian-extended = "HEAD:e7fb87cdea0e8f0a598142fa86108a12e39e32f4"
meta-emlinux         = "HEAD:274ff063532e8d251a5a5a71fc7e2dbdf3a6dac8"
meta-emlinux-private = "HEAD:8207525289999d2c41983eb8155127b62621cdb1"

Initialising tasks: 100% |#############################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 80 Found 0 Missed 80 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2015-2877 CVE-2015-7312 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-16089 CVE-2019-19083 CVE-2019-20794 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2020-36691 CVE-2021-32078 CVE-2021-3773 CVE-2021-3847 CVE-2021-3923 CVE-2021-4037 CVE-2021-44879 CVE-2022-0480 CVE-2022-1015 CVE-2022-25265 CVE-2022-2961 CVE-2022-3108 CVE-2022-3303 CVE-2022-3344 CVE-2022-39189 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-45884 CVE-2022-45885 CVE-2022-45886 CVE-2022-45887 CVE-2022-45919 CVE-2022-47520 CVE-2022-48502 CVE-2023-0590 CVE-2023-1249 CVE-2023-1582 CVE-2023-1872 CVE-2023-2007 CVE-2023-2124 CVE-2023-2177 CVE-2023-23000 CVE-2023-23039 CVE-2023-26242 CVE-2023-28466 CVE-2023-3111 CVE-2023-33288), for more information check /project/emlinux-cve-check/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 694 tasks of which 0 didn't need to be rerun and all succeeded.
```

With this PR disappears CVE-2023-1872.
```
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:b622b264446afaab533290ceb59ad84096caedc7"
meta-debian-extended = "HEAD:e7fb87cdea0e8f0a598142fa86108a12e39e32f4"
meta-emlinux         = "add-CVE-2023-1872-to-whitelist:3f74f5c45f3f453d78c169a41c68f2a2b9425ce7"
meta-emlinux-private = "HEAD:8207525289999d2c41983eb8155127b62621cdb1"

Initialising tasks: 100% |#############################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 0 Found 0 Missed 0 Current 80 (0% match, 100% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2015-2877 CVE-2015-7312 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-16089 CVE-2019-19083 CVE-2019-20794 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2020-36691 CVE-2021-32078 CVE-2021-3773 CVE-2021-3847 CVE-2021-3923 CVE-2021-4037 CVE-2021-44879 CVE-2022-0480 CVE-2022-1015 CVE-2022-25265 CVE-2022-2961 CVE-2022-3108 CVE-2022-3303 CVE-2022-3344 CVE-2022-39189 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-45884 CVE-2022-45885 CVE-2022-45886 CVE-2022-45887 CVE-2022-45919 CVE-2022-47520 CVE-2022-48502 CVE-2023-0590 CVE-2023-1249 CVE-2023-1582 CVE-2023-2007 CVE-2023-2124 CVE-2023-2177 CVE-2023-23000 CVE-2023-23039 CVE-2023-26242 CVE-2023-28466 CVE-2023-3111 CVE-2023-33288), for more information check /project/emlinux-cve-check/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 694 tasks of which 691 didn't need to be rerun and all succeeded.
```

