### PR TITLE
Update kernel to v4.19.284 cip99 and v5.10.182 cip35

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "aa80091745d6b40c944d419c12ba8cb65b1a57a5"
-LINUX_CVE_VERSION ??= "5.10.180"
-LINUX_CIP_VERSION ?= "v5.10.180-cip34"
+LINUX_GIT_SRCREV ?= "52f00829380df13d144d530b732464a175350508"
+LINUX_CVE_VERSION ??= "5.10.182"
+LINUX_CIP_VERSION ?= "v5.10.182-cip35"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "31603fc59adb456f6eb0f58de8bb989b41572c2a"
-LINUX_CVE_VERSION ??= "4.19.283"
-LINUX_CIP_VERSION ??= "v4.19.283-cip98"
+LINUX_GIT_SRCREV ?= "a13de4c6b84ab64a5cb3ef5e852b1620686d0309"
+LINUX_CVE_VERSION ??= "4.19.284"
+LINUX_CIP_VERSION ??= "v4.19.284-cip99"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.284 cip99 and v5.10.182 cip35

This pull request update the kernel to the following cip versions:
v4.19.284 cip99 with hash tag a13de4c6b84ab64a5cb3ef5e852b1620686d0309
v5.10.182 cip35 with hash tag 52f00829380df13d144d530b732464a175350508