### PR TITLE
raspberrypi3bplus-64: Enable dtoverlay and dtparams

### DIFF
--- a/recipes-bsp/rpi-boot-setting/files/boot.cmd
+++ b/recipes-bsp/rpi-boot-setting/files/boot.cmd
@@ -1,4 +1,5 @@
 fatload mmc 0 ${kernel_addr_r} Image
-fatload mmc 0 ${fdt_addr_r} bcm2837-rpi-3-b-plus.dtb
+setenv fdt_addr_r 0x02600000
+fdt addr ${fdt_addr_r}
 setenv bootargs dwc_otg.lpm_enable=0 earlyprintk root=/dev/mmcblk0p2 rootfstype=ext4 rootwait
 booti ${kernel_addr_r} - ${fdt_addr_r}

--- a/recipes-bsp/rpi-boot-setting/files/config.txt
+++ b/recipes-bsp/rpi-boot-setting/files/config.txt
@@ -13,3 +13,5 @@ enable_uart=1
 
 gpu_mem=16
 mask_gpu_interrupt1=0x100
+
+device_tree_address=0x02600000

--- a/recipes-kernel/linux/files/0001-ARM-dts-bcm2837-rpi-3-b-plus-Add-an-__overrides__-no.patch
+++ b/recipes-kernel/linux/files/0001-ARM-dts-bcm2837-rpi-3-b-plus-Add-an-__overrides__-no.patch
@@ -1,0 +1,88 @@
+From c89cbf3445e610405f7cd8d31b7e340ccb0fae2e Mon Sep 17 00:00:00 2001
+From: Kazunori Kobayashi <kazunori.kobayashi@cybertrust.co.jp>
+Date: Thu, 29 Jun 2023 14:06:16 +0000
+Subject: [PATCH 1/2] ARM: dts: bcm2837-rpi-3-b-plus: Add an __overrides__ node
+ to declare parameters modified via dtparams
+
+The __overrides__ declaration is derived from the dts files of
+Raspberry Pi Kernel. Parameters that are not referred to by mainline
+Kernel are excluded.
+
+Missing labels are satisfied accordingly for reference from the
+__overrides__ node.
+---
+ arch/arm/boot/dts/bcm2837-rpi-3-b-plus.dts | 44 ++++++++++++++++++++--
+ 1 file changed, 41 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/boot/dts/bcm2837-rpi-3-b-plus.dts b/arch/arm/boot/dts/bcm2837-rpi-3-b-plus.dts
+index ec721d323ac5..53bec45d53cd 100644
+--- a/arch/arm/boot/dts/bcm2837-rpi-3-b-plus.dts
++++ b/arch/arm/boot/dts/bcm2837-rpi-3-b-plus.dts
+@@ -10,7 +10,7 @@ / {
+ 	compatible = "raspberrypi,3-model-b-plus", "brcm,bcm2837";
+ 	model = "Raspberry Pi 3 Model B+";
+ 
+-	chosen {
++	chosen: chosen {
+ 		/* 8250 auxiliary UART instead of pl011 */
+ 		stdout-path = "serial1:115200n8";
+ 	};
+@@ -21,11 +21,11 @@ memory@0 {
+ 	};
+ 
+ 	leds {
+-		led-act {
++		act_led: led-act {
+ 			gpios = <&gpio 29 GPIO_ACTIVE_HIGH>;
+ 		};
+ 
+-		led-pwr {
++		pwr_led: led-pwr {
+ 			label = "PWR";
+ 			gpios = <&expgpio 2 GPIO_ACTIVE_LOW>;
+ 			default-state = "keep";
+@@ -160,3 +160,41 @@ &uart1 {
+ &wifi_pwrseq {
+ 	reset-gpios = <&expgpio 1 GPIO_ACTIVE_LOW>;
+ };
++
++/ {
++	__overrides__ {
++		audio = <&chosen>,"bootargs{on='snd_bcm2835.enable_headphones=1 snd_bcm2835.enable_hdmi=1',off='snd_bcm2835.enable_headphones=0 snd_bcm2835.enable_hdmi=0'}";
++
++		act_led_gpio = <&act_led>,"gpios:4";
++		act_led_activelow = <&act_led>,"gpios:8";
++		act_led_trigger = <&act_led>,"linux,default-trigger";
++
++		pwr_led_gpio = <&pwr_led>,"gpios:4";
++		pwr_led_activelow = <&pwr_led>,"gpios:8";
++		pwr_led_trigger = <&pwr_led>,"linux,default-trigger";
++
++		hdmi = <&hdmi>,"status";
++		i2c2_iknowwhatimdoing = <&i2c2>,"status";
++		i2c2_baudrate = <&i2c2>,"clock-frequency:0";
++		sd = <&sdhost>,"status";
++		sd_poll_once = <&sdhost>,"non-removable?";
++
++		cache_line_size;
++
++		uart0 = <&uart0>,"status";
++		uart1 = <&uart1>,"status";
++		i2s = <&i2s>,"status";
++		i2c1 = <&i2c1>,"status";
++		i2c = <&i2c1>,"status";
++		i2c_arm = <&i2c1>,"status";
++		i2c1_baudrate = <&i2c1>,"clock-frequency:0";
++		i2c_baudrate = <&i2c1>,"clock-frequency:0";
++		i2c_arm_baudrate = <&i2c1>,"clock-frequency:0";
++
++		watchdog = <&pm>,"status";
++
++		bdaddr = <&bt>,"local-bd-address[";
++		krnbt = <&bt>,"status";
++		krnbt_baudrate = <&bt>,"max-speed:0";
++        };
++};
+-- 
+2.39.2
+

--- a/recipes-kernel/linux/files/0002-arm64-dts-broadcom-Add-a-compilation-flag-to-include.patch
+++ b/recipes-kernel/linux/files/0002-arm64-dts-broadcom-Add-a-compilation-flag-to-include.patch
@@ -1,0 +1,30 @@
+From 140cd8ada3fac53a0e6c6634e59e77ae0311253e Mon Sep 17 00:00:00 2001
+From: Kazunori Kobayashi <kazunori.kobayashi@cybertrust.co.jp>
+Date: Thu, 29 Jun 2023 16:47:50 +0000
+Subject: [PATCH 2/2] arm64: dts: broadcom: Add a compilation flag to include
+ symbols in dtb
+
+Symbols in dtb are necessary to enable dtoverlay on Raspberry Pi.
+This flag has been ported from the following code of Raspberry Pi Kernel.
+
+https://github.com/raspberrypi/linux/blob/rpi-6.1.y/arch/arm/boot/dts/Makefile#L1665
+---
+ arch/arm64/boot/dts/broadcom/Makefile | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/broadcom/Makefile b/arch/arm64/boot/dts/broadcom/Makefile
+index 05d8c5ecf3b0..f8101603c1ed 100644
+--- a/arch/arm64/boot/dts/broadcom/Makefile
++++ b/arch/arm64/boot/dts/broadcom/Makefile
+@@ -11,3 +11,8 @@ dtb-$(CONFIG_ARCH_BCM2835) += bcm2711-rpi-400.dtb \
+ subdir-y	+= bcmbca
+ subdir-y	+= northstar2
+ subdir-y	+= stingray
++
++# Enable fixups to support overlays on BCM2835 platforms
++ifeq ($(CONFIG_ARCH_BCM2835),y)
++DTC_FLAGS += -@
++endif
+-- 
+2.39.2
+

--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -21,7 +21,11 @@ SRC_URI += " \
 SRC_URI:append:qemu-arm64 = " file://qemu-arm64_defconfig"
 SRC_URI:append:qemu-amd64 = " file://qemu-amd64_defconfig"
 SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
-SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
+SRC_URI:append:raspberrypi3bplus-64 = " \
+    file://raspberrypi3-64_defconfig \
+    file://0001-ARM-dts-bcm2837-rpi-3-b-plus-Add-an-__overrides__-no.patch \
+    file://0002-arm64-dts-broadcom-Add-a-compilation-flag-to-include.patch \
+"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
 SRCREV = "e84a4e368abe42cf359fe237f0238820859d5044"


### PR DESCRIPTION
This request allows for the dtoverlay and dtparams usage as the dtb file of mainline Kernel stays used.