### PR TITLE
conf: Remove contrib and non-free reposisotries

### DIFF
--- a/conf/distro/emlinux-bookworm.list
+++ b/conf/distro/emlinux-bookworm.list
@@ -1,8 +1,8 @@
-deb	http://deb.debian.org/debian bookworm main contrib non-free
-deb-src	http://deb.debian.org/debian bookworm main contrib non-free
+deb	http://deb.debian.org/debian bookworm main
+deb-src	http://deb.debian.org/debian bookworm main
 
-deb	http://deb.debian.org/debian-security/ bookworm-security main contrib non-free
-deb-src	http://deb.debian.org/debian-security/ bookworm-security main contrib non-free
+deb	http://deb.debian.org/debian-security/ bookworm-security main
+deb-src	http://deb.debian.org/debian-security/ bookworm-security main
 
-deb	http://deb.debian.org/debian bookworm-updates main contrib non-free
-deb-src	http://deb.debian.org/debian bookworm-updates main contrib non-free
+deb	http://deb.debian.org/debian bookworm-updates main
+deb-src	http://deb.debian.org/debian bookworm-updates main


### PR DESCRIPTION
Basically, emlinux will support main respository so that remove contrib and non-free repositories from configuration.
