### PR TITLE
Fix SDK build error.

### DIFF
--- a/recipes-core/images/emlinux-image-base.bb
+++ b/recipes-core/images/emlinux-image-base.bb
@@ -29,3 +29,4 @@ IMAGE_PREINSTALL:append = "\
 "
 inherit image
 
+DEPENDS:class-sdk:append = " ${IMAGE_INSTALL}"


### PR DESCRIPTION
# Purpose of pull request

When building SDK without building normal system image, we may have some build errora related with self-built package. This pr fix this issue.

# Test
## How to test
added following line into conf/local.conf.
```
MACHINE` = "ls1046ardb"
```
Any machine setting is OK but rescipes for this target machine must be contain self-built package.

And type following command.
```
$ bitbake emlinux-image-base -c populate_sdk
```

Before typing above command, you shouldn't type following command.
```
$ bitbake emlinux-image-base
```
