### PR TITLE
Update kernel to v4.19.288-cip101 and v5.10.186-cip37

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "f34f3ecd0387c3ad8b34bf65ac19ec84a38f2333"
-LINUX_CVE_VERSION ??= "5.10.184"
-LINUX_CIP_VERSION ?= "v5.10.184-cip36"
+LINUX_GIT_SRCREV ?= "34d052461016f3c0015b6ea2363ff54ee247caf2"
+LINUX_CVE_VERSION ??= "5.10.186"
+LINUX_CIP_VERSION ?= "v5.10.186-cip37"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "843423b3724d762d5593ab9aaeb68ac695871b44"
-LINUX_CVE_VERSION ??= "4.19.287"
-LINUX_CIP_VERSION ??= "v4.19.287-cip100"
+LINUX_GIT_SRCREV ?= "9c3f27ca919fea575a3a1c378bd95bcbf2c33ca7"
+LINUX_CVE_VERSION ??= "4.19.288"
+LINUX_CIP_VERSION ??= "v4.19.288-cip101"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.288-cip101 and v5.10.186-cip37

This pull request update the kernel to the following cip versions:
v4.19.288-cip101 with hash tag 9c3f27ca919fea575a3a1c378bd95bcbf2c33ca7
v5.10.186-cip37 with hash tag 34d052461016f3c0015b6ea2363ff54ee247caf2
