### PR TITLE
docker: use "docker compose" as default

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-which docker-compose >/dev/null
+docker_compose_cmd="docker compose"
+docker compose version >/dev/null
 if [ $? != 0 ]; then
-  echo "[*] docker-compose command is not found. Please install it."
-  exit 1
-fi  
+    docker-compose version >/dev/null
+    if [ $? != 0 ]; then
+	echo "[*] docker compose or docker-compose command is not found. Please install newer version of docker engine (or docker-compose)."
+	exit 1
+    fi
+    docker_compose_cmd="docker-compose"
+fi
 
 mode="run"
 if [ $# = 1 ]; then
@@ -15,7 +20,7 @@ host_user_id=$(id -u)
 export host_user_id="${host_user_id}"
 
 if [ "${mode}" = "build" ]; then
-  docker-compose build --no-cache
+  $docker_compose_cmd build --no-cache
 elif [ "${mode}" = "run" ]; then
-  docker-compose run --rm emlinux3-build
+  $docker_compose_cmd run --rm emlinux3-build
 fi


### PR DESCRIPTION
# Purpose of pull request

To make the run.sh available even without docker-compose.
Recent docker engine includes the "compose" sub-command, which can satisfy our use cases.
As a result, we don't have to install the additional docker-compose package.

# Test
## How to test

Run following commands from console on Ubuntu 22.04 (without docker-compose installed).

```
$ docker-compose version
Command 'docker-compose' not found, but can be installed with:
snap install docker          # version 20.10.24, or
apt  install docker-compose  # version 1.29.2-1
See 'snap info docker' for additional versions.

$ docker compose version
Docker Compose version v2.20.2

$ cd docker/
$ ./run.sh
```

If the above command succeeds, we can enter to the container.

## Test result

```
$ ./run.sh 
build@af01779c8adb:~/work$ 
```
