### PR TITLE
Migration to CIP kernel

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_git.bb
+++ b/recipes-kernel/linux/linux-cip-rt_git.bb
@@ -12,15 +12,15 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.38"
-PV = "6.1.38"
+LINUX_CIP_VERSION = "v6.1.38-cip1-rt1"
+PV = "6.1.38-cip1-rt1"
 SRC_URI += " \
-    git://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git;branch=v6.1-rt;destsuffix=${P};protocol=https \
+    git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip-rt;destsuffix=${P};protocol=https \
     file://preempt-rt.cfg \
 "
 
 SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 
-SRCREV = "7c574e2eb052aa39ba796334bf95c0baa9479411"
+SRCREV = "b24e2a62dde025ade5db3ed51d07425f14a67e49"
 
 KBUILD_DEPENDS:append = ", zstd"

--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,10 +12,10 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.38"
-PV = "6.1.38"
+LINUX_CIP_VERSION = "v6.1.42-cip2"
+PV = "6.1.42-cip2"
 SRC_URI += " \
-    git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;branch=linux-6.1.y;destsuffix=${P};protocol=https \
+    git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip;destsuffix=${P};protocol=https \
 "
 
 SRC_URI:append:qemu-arm64 = " file://qemu-arm64_defconfig"
@@ -24,6 +24,6 @@ SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
-SRCREV = "61fd484b2cf6bc8022e8e5ea6f693a9991740ac2"
+SRCREV = "0d2ec524c820bab8eabc0f1b34aa41ff55d4e9b1"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Both the standard and RT Linux kernels migrate to the CIP kernels.