### PR TITLE
linux: Support RT Kernel for raspberrypi3bplus-64

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_git.bb
+++ b/recipes-kernel/linux/linux-cip-rt_git.bb
@@ -20,6 +20,7 @@ SRC_URI += " \
 "
 
 SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
+SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 
 SRCREV = "b24e2a62dde025ade5db3ed51d07425f14a67e49"
 


### PR DESCRIPTION
This allows for the RT Kernel utilization on the Raspberry Pi 3b+ board.