### PR TITLE
Kernel update to 6.1.46

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_git.bb
+++ b/recipes-kernel/linux/linux-cip-rt_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.38-cip1-rt1"
-PV = "6.1.38-cip1-rt1"
+LINUX_CIP_VERSION = "v6.1.46-cip4-rt2"
+PV = "6.1.46-cip4-rt2"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip-rt;destsuffix=${P};protocol=https \
     file://preempt-rt.cfg \
@@ -22,6 +22,6 @@ SRC_URI += " \
 SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 
-SRCREV = "b24e2a62dde025ade5db3ed51d07425f14a67e49"
+SRCREV = "c4800588c47085de12fb82c4790e49fdee561258"
 
 KBUILD_DEPENDS:append = ", zstd"

--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.42-cip2"
-PV = "6.1.42-cip2"
+LINUX_CIP_VERSION = "v6.1.46-cip4"
+PV = "6.1.46-cip4"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip;destsuffix=${P};protocol=https \
 "
@@ -24,6 +24,6 @@ SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
-SRCREV = "0d2ec524c820bab8eabc0f1b34aa41ff55d4e9b1"
+SRCREV = "58f7d1bf36cb697e7cab922b71d04f7d925e3b1f"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Both the standard and RT kernels are updated to the CIP 6.1.46 versions.