### PR TITLE
classes/cve-check: Fix getting affected package name logic

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -90,15 +90,21 @@ def cve_check_report_cves(d):
         pkgs = []
         for affect in cve['affects']:
             ref = affect['ref']
-            tmp = re.search(r'(\w+:\w+/\w+/)(\w+)(@\w*)', ref)
-            if not tmp is None:
-                pkgs.append(tmp.groups()[1])
-                version = affect['versions'][0]['version']
-        
+            tmp = ref.split('/')
+            if len(tmp) >= 2:
+                tmp = tmp[2].split('@')[0]
+                if not tmp is None:
+                    pkgs.append(tmp)
+                    version = affect['versions'][0]['version']
+            else:
+                msg = f"unknown binary package name. Please check https://security-tracker.debian.org/tracker/{id}"
+                if not msg in pkgs:
+                    pkgs.append(msg)       
+                    version = affect['versions'][0]['version']
         if len(pkgs) > 0:
             msg = f'CVE ({id}) is found in version {version} of {" ".join(pkgs)}'
             bb.warn(msg)
-   
+
 python do_cve_check() {
     import os
     result_dir = f'{d.getVar("DEPLOY_DIR")}/cve'


### PR DESCRIPTION
Affected package name can get from following line.

```
"ref": "pkg:deb/debian/libssl3@3.0.9-1?distro=debian-12.1",
```

So, use .split() instead of regex.

However, some cve doesn't contain ref data in the json file.

```
        {
          "ref": "",
          "versions": [
            {
              "version": "1:4.13+dfsg1-1",
              "status": "affected"
            }
          ]
        },
```

If ref doesn't contain package name, we show warning message with debian security-tracker url.
