### PR TITLE
recipes-kernel/linux: Ignore CVE-2015-8955

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -15,8 +15,10 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2022-1508: This is io_uring issue. linux 4.19 doesn't have this feature.
 # CVE-2022-1789: This issue was introduced in 5.8-rc1. 4.19.y is not affected.
 # CVE-2023-1872: This is io_uring issue. linux 4.19 doesn't have this feature.
+# CVE-2015-8955: It's false positive because it was fixed in v4.1-rc1.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
     CVE-2022-1508 CVE-2022-1789 CVE-2023-1872 \
+    CVE-2015-8955 \
 "

--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -30,4 +30,7 @@ do_shared_workdir_prepend () {
 }
 
 # CVE-2021-43057: This issue was introduced in 5.13-rc1. 5.10.y is not affected.
-CVE_CHECK_WHITELIST = "CVE-2021-43057"
+# CVE-2015-8955: It's false positive because it was fixed in v4.1-rc1.
+CVE_CHECK_WHITELIST = "\
+    CVE-2021-43057 CVE-2015-8955 \
+"


### PR DESCRIPTION
# Purpose of pull request

The CVE-2015-8955 was fixed in v4.1-rc1. However, the cve-check task reported it is not fixed. This is false positive. So, we can ignore this CVE by using CVE_CHECK_WHITELIST variable.

# Test
## How to test

Run cve-check task for linux-base(distro is emlinux) and linux-k510(distro is emlinux-k510).

## Test result

linux-base(4.19)

```
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-2010-5321 CVE-2014-1737 CVE-2014-3153 CVE-2014-3534 CVE-2015-2877 CVE-2015-7312 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-16089 CVE-2019-19083 CVE-2019-20794 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2020-36691 CVE-2021-32078 CVE-2021-3773 CVE-2021-3847 CVE-2021-3923 CVE-2021-4037 CVE-2021-44879 CVE-2022-0480 CVE-2022-1015 CVE-2022-25265 CVE-2022-2961 CVE-2022-3108 CVE-2022-3303 CVE-2022-3344 CVE-2022-39189 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-45884 CVE-2022-45885 CVE-2022-47520 CVE-2023-0590 CVE-2023-1249 CVE-2023-1582 CVE-2023-1611 CVE-2023-2124 CVE-2023-2177 CVE-2023-23000 CVE-2023-23039 CVE-2023-26242 CVE-2023-28466 CVE-2023-33288 CVE-2023-35827 CVE-2023-37453 CVE-2023-37454 CVE-2023-3863 CVE-2023-4128 CVE-2023-4133), for more information check /home/build/work/emlinux/latest-dev/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log 
```

linux-510(5.10)

```
WARNING: linux-k510-5.10-r0 do_cve_check: Found unpatched CVE (CVE-2014-1737 CVE-2014-3153 CVE-2014-3534 CVE-2020-35501 CVE-2021-32078 CVE-2021-3773 CVE-2021-3847 CVE-2021-3923 CVE-2021-44879 CVE-2022-0480 CVE-2022-0500 CVE-2022-25265 CVE-2022-2961 CVE-2022-3108 CVE-2022-3114 CVE-2022-38096 CVE-2022-38457 CVE-2022-40133 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-45884 CVE-2022-45885 CVE-2023-22995 CVE-2023-23000 CVE-2023-23039 CVE-2023-26242 CVE-2023-35827 CVE-2023-37453 CVE-2023-37454 CVE-2023-4133), for more information check /home/build/work/emlinux/latest-dev/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-k510/5.10-r0/temp/cve.log
```

