### PR TITLE
classes/sdk-installer: Create sdk install target dir if it doesn't exist

### DIFF
--- a/classes/sdk-installer.bbclass
+++ b/classes/sdk-installer.bbclass
@@ -57,6 +57,10 @@ if [ "$answer" != "y" ] && [ "$answer" != "Y" ]; then
     exit 0
 fi
 
+if [ ! -d "${target_sdk_dir}" ]; then
+    mkdir -p "${target_sdk_dir}"
+fi
+
 sdk_install_target_dir=$(realpath ${target_sdk_dir})
 sdk_installed_dir="${sdk_install_target_dir}/${EMLINUX_SDK_BASE_NAME}"
 


### PR DESCRIPTION
Create sdk install target directory if it doesn't exist.

Even if sdktest directory doesn't exist,  script was able to install sdk to user specify path.


```
build@9ff01def6f02:~/work/build$ ls
bitbake-cookerdaemon.log  conf  downloads  sstate-cache  tmp
build@9ff01def6f02:~/work/build$ ./tmp/deploy/images/qemu-amd64/emlinux-image-base-sdk-emlinux-bookworm-qemu-amd64-sdk-installer.sh -y -d ./sdktest
Will you continue to install EMLinux SDK? [y/N]
Installing EMLinux SDK to /home/build/work/build/sdktest .
Adjusting path of SDK to '/home/build/work/build/sdktest/emlinux-image-base-sdk-emlinux-bookworm-qemu-amd64'... done
When you use the SDK in a new shell session, you need to run following command.
  $ source /home/build/work/build/sdktest/emlinux-image-base-sdk-emlinux-bookworm-qemu-amd64/environment-setup-qemu-amd64-emlinux-bookworm
```
