### PR TITLE
cve-check: Replace CVE database fetcher with one using NVD API 2.0

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -1,0 +1,330 @@
+# base recipe: meta/classes/cve-check.bbclass
+# base branch: warrior
+# base commit: 29b5805c629a3d73e4280adc7d109c2aa2b0bdd8
+
+# This class is used to check recipes against public CVEs.
+#
+# In order to use this class just inherit the class in the
+# local.conf file and it will add the cve_check task for
+# every recipe. The task can be used per recipe, per image,
+# or using the special cases "world" and "universe". The
+# cve_check task will print a warning for every unpatched
+# CVE found and generate a file in the recipe WORKDIR/cve
+# directory. If an image is build it will generate a report
+# in DEPLOY_DIR_IMAGE for all the packages used.
+#
+# Example:
+#   bitbake -c cve_check openssl
+#   bitbake core-image-sato
+#   bitbake -k -c cve_check universe
+#
+# DISCLAIMER
+#
+# This class/tool is meant to be used as support and not
+# the only method to check against CVEs. Running this tool
+# doesn't guarantee your packages are free of CVEs.
+
+# The product name that the CVE database uses.  Defaults to BPN, but may need to
+# be overriden per recipe (for example tiff.bb sets CVE_PRODUCT=libtiff).
+CVE_PRODUCT ??= "${BPN}"
+CVE_VERSION ??= "${PV}"
+
+CVE_CHECK_DB_DIR ?= "${DL_DIR}/CVE_CHECK"
+CVE_CHECK_DB_FILE ?= "${CVE_CHECK_DB_DIR}/nvdcve_1.1.db"
+
+CVE_CHECK_LOG ?= "${T}/cve.log"
+CVE_CHECK_TMP_FILE ?= "${TMPDIR}/cve_check"
+
+CVE_CHECK_DIR ??= "${DEPLOY_DIR}/cve"
+CVE_CHECK_MANIFEST ?= "${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.cve"
+CVE_CHECK_COPY_FILES ??= "1"
+CVE_CHECK_CREATE_MANIFEST ??= "1"
+
+# Whitelist for packages (PN)
+CVE_CHECK_PN_WHITELIST ?= ""
+
+# Whitelist for CVE. If a CVE is found, then it is considered patched.
+# The value is a string containing space separated CVE values:
+# 
+# CVE_CHECK_WHITELIST = 'CVE-2014-2524 CVE-2018-1234'
+# 
+CVE_CHECK_WHITELIST ?= ""
+
+python do_cve_check () {
+    """
+    Check recipe for patched and unpatched CVEs
+    """
+
+    if os.path.exists(d.getVar("CVE_CHECK_DB_FILE")):
+        patched_cves = get_patches_cves(d)
+        patched, unpatched = check_cves(d, patched_cves)
+        if patched or unpatched:
+            cve_data = get_cve_info(d, patched + unpatched)
+            cve_write_data(d, patched, unpatched, cve_data)
+    else:
+        bb.note("No CVE database found, skipping CVE check")
+
+}
+
+addtask cve_check before do_build
+do_cve_check[depends] = "cve-update-db-native:do_populate_cve_db"
+do_cve_check[nostamp] = "1"
+
+python cve_check_cleanup () {
+    """
+    Delete the file used to gather all the CVE information.
+    """
+    bb.utils.remove(e.data.getVar("CVE_CHECK_TMP_FILE"))
+}
+
+addhandler cve_check_cleanup
+cve_check_cleanup[eventmask] = "bb.cooker.CookerExit"
+
+python cve_check_write_rootfs_manifest () {
+    """
+    Create CVE manifest when building an image
+    """
+
+    import shutil
+
+    if d.getVar("CVE_CHECK_COPY_FILES") == "1":
+        deploy_file = os.path.join(d.getVar("CVE_CHECK_DIR"), d.getVar("PN"))
+        if os.path.exists(deploy_file):
+            bb.utils.remove(deploy_file)
+
+    if os.path.exists(d.getVar("CVE_CHECK_TMP_FILE")):
+        bb.note("Writing rootfs CVE manifest")
+        deploy_dir = d.getVar("DEPLOY_DIR_IMAGE")
+        link_name = d.getVar("IMAGE_LINK_NAME")
+        manifest_name = d.getVar("CVE_CHECK_MANIFEST")
+        cve_tmp_file = d.getVar("CVE_CHECK_TMP_FILE")
+
+        shutil.copyfile(cve_tmp_file, manifest_name)
+
+        if manifest_name and os.path.exists(manifest_name):
+            manifest_link = os.path.join(deploy_dir, "%s.cve" % link_name)
+            # If we already have another manifest, update symlinks
+            if os.path.exists(os.path.realpath(manifest_link)):
+                os.remove(manifest_link)
+            os.symlink(os.path.basename(manifest_name), manifest_link)
+            bb.plain("Image CVE report stored in: %s" % manifest_name)
+}
+
+ROOTFS_POSTPROCESS_COMMAND_prepend = "${@'cve_check_write_rootfs_manifest; ' if d.getVar('CVE_CHECK_CREATE_MANIFEST') == '1' else ''}"
+do_rootfs[recrdeptask] += "${@'do_cve_check' if d.getVar('CVE_CHECK_CREATE_MANIFEST') == '1' else ''}"
+
+def get_patches_cves(d):
+    """
+    Get patches that solve CVEs using the "CVE: " tag.
+    """
+
+    import re
+
+    pn = d.getVar("PN")
+    cve_match = re.compile("CVE:( CVE\-\d{4}\-\d+)+")
+
+    # Matches last CVE-1234-211432 in the file name, also if written
+    # with small letters. Not supporting multiple CVE id's in a single
+    # file name.
+    cve_file_name_match = re.compile(".*([Cc][Vv][Ee]\-\d{4}\-\d+)")
+
+    patched_cves = set()
+    bb.debug(2, "Looking for patches that solves CVEs for %s" % pn)
+    for url in src_patches(d):
+        patch_file = bb.fetch.decodeurl(url)[2]
+
+        # Check patch file name for CVE ID
+        fname_match = cve_file_name_match.search(patch_file)
+        if fname_match:
+            cve = fname_match.group(1).upper()
+            patched_cves.add(cve)
+            bb.debug(2, "Found CVE %s from patch file name %s" % (cve, patch_file))
+
+        with open(patch_file, "r", encoding="utf-8") as f:
+            try:
+                patch_text = f.read()
+            except UnicodeDecodeError:
+                bb.debug(1, "Failed to read patch %s using UTF-8 encoding"
+                        " trying with iso8859-1" %  patch_file)
+                f.close()
+                with open(patch_file, "r", encoding="iso8859-1") as f:
+                    patch_text = f.read()
+
+        # Search for one or more "CVE: " lines
+        text_match = False
+        for match in cve_match.finditer(patch_text):
+            # Get only the CVEs without the "CVE: " tag
+            cves = patch_text[match.start()+5:match.end()]
+            for cve in cves.split():
+                bb.debug(2, "Patch %s solves %s" % (patch_file, cve))
+                patched_cves.add(cve)
+                text_match = True
+
+        if not fname_match and not text_match:
+            bb.debug(2, "Patch %s doesn't solve CVEs" % patch_file)
+
+    return patched_cves
+
+def check_cves(d, patched_cves):
+    """
+    Connect to the NVD database and find unpatched cves.
+    """
+    from distutils.version import LooseVersion
+
+    cves_unpatched = []
+    # CVE_PRODUCT can contain more than one product (eg. curl/libcurl)
+    products = d.getVar("CVE_PRODUCT").split()
+    # If this has been unset then we're not scanning for CVEs here (for example, image recipes)
+    if not products:
+        return ([], [])
+    pv = d.getVar("CVE_VERSION").split("+git")[0]
+
+    # If the recipe has been whitlisted we return empty lists
+    if d.getVar("PN") in d.getVar("CVE_CHECK_PN_WHITELIST").split():
+        bb.note("Recipe has been whitelisted, skipping check")
+        return ([], [])
+
+    old_cve_whitelist =  d.getVar("CVE_CHECK_CVE_WHITELIST")
+    if old_cve_whitelist:
+        bb.warn("CVE_CHECK_CVE_WHITELIST is deprecated, please use CVE_CHECK_WHITELIST.")
+    cve_whitelist = d.getVar("CVE_CHECK_WHITELIST").split()
+
+    import sqlite3
+    db_file = d.expand("file:${CVE_CHECK_DB_FILE}?mode=ro")
+    conn = sqlite3.connect(db_file, uri=True)
+
+    # For each of the known product names (e.g. curl has CPEs using curl and libcurl)...
+    for product in products:
+        if ":" in product:
+            vendor, product = product.split(":", 1)
+        else:
+            vendor = "%"
+
+        # Find all relevant CVE IDs.
+        for cverow in conn.execute("SELECT DISTINCT ID FROM PRODUCTS WHERE PRODUCT IS ? AND VENDOR LIKE ?", (product, vendor)):
+            cve = cverow[0]
+
+            if cve in cve_whitelist:
+                bb.note("%s-%s has been whitelisted for %s" % (product, pv, cve))
+                # TODO: this should be in the report as 'whitelisted'
+                patched_cves.add(cve)
+                continue
+            elif cve in patched_cves:
+                bb.note("%s has been patched" % (cve))
+                continue
+
+            vulnerable = False
+            for row in conn.execute("SELECT * FROM PRODUCTS WHERE ID IS ? AND PRODUCT IS ? AND VENDOR LIKE ?", (cve, product, vendor)):
+                (_, _, _, version_start, operator_start, version_end, operator_end) = row
+                #bb.debug(2, "Evaluating row " + str(row))
+
+                if (operator_start == '=' and pv == version_start) or version_start == '-':
+                    vulnerable = True
+                else:
+                    if operator_start:
+                        try:
+                            vulnerable_start =  (operator_start == '>=' and LooseVersion(pv) >= LooseVersion(version_start))
+                            vulnerable_start |= (operator_start == '>' and LooseVersion(pv) > LooseVersion(version_start))
+                        except:
+                            bb.warn("%s: Failed to compare %s %s %s for %s" %
+                                    (product, pv, operator_start, version_start, cve))
+                            vulnerable_start = False
+                    else:
+                        vulnerable_start = False
+
+                    if operator_end:
+                        try:
+                            vulnerable_end  = (operator_end == '<=' and LooseVersion(pv) <= LooseVersion(version_end))
+                            vulnerable_end |= (operator_end == '<' and LooseVersion(pv) < LooseVersion(version_end))
+                        except:
+                            bb.warn("%s: Failed to compare %s %s %s for %s" %
+                                    (product, pv, operator_end, version_end, cve))
+                            vulnerable_end = False
+                    else:
+                        vulnerable_end = False
+
+                    if operator_start and operator_end:
+                        vulnerable = vulnerable_start and vulnerable_end
+                    else:
+                        vulnerable = vulnerable_start or vulnerable_end
+
+                if vulnerable:
+                    bb.note("%s-%s is vulnerable to %s" % (product, pv, cve))
+                    cves_unpatched.append(cve)
+                    break
+
+            if not vulnerable:
+                bb.note("%s-%s is not vulnerable to %s" % (product, pv, cve))
+                # TODO: not patched but not vulnerable
+                patched_cves.add(cve)
+
+    conn.close()
+
+    return (list(patched_cves), cves_unpatched)
+
+def get_cve_info(d, cves):
+    """
+    Get CVE information from the database.
+    """
+
+    import sqlite3
+
+    cve_data = {}
+    conn = sqlite3.connect(d.getVar("CVE_CHECK_DB_FILE"))
+
+    for cve in cves:
+        for row in conn.execute("SELECT * FROM NVD WHERE ID IS ?", (cve,)):
+            cve_data[row[0]] = {}
+            cve_data[row[0]]["summary"] = row[1]
+            cve_data[row[0]]["scorev2"] = row[2]
+            cve_data[row[0]]["scorev3"] = row[3]
+            cve_data[row[0]]["modified"] = row[4]
+            cve_data[row[0]]["vector"] = row[5]
+
+    conn.close()
+    return cve_data
+
+def cve_write_data(d, patched, unpatched, cve_data):
+    """
+    Write CVE information in WORKDIR; and to CVE_CHECK_DIR, and
+    CVE manifest if enabled.
+    """
+
+    cve_file = d.getVar("CVE_CHECK_LOG")
+    nvd_link = "https://web.nvd.nist.gov/view/vuln/detail?vulnId="
+    write_string = ""
+    unpatched_cves = []
+    bb.utils.mkdirhier(os.path.dirname(cve_file))
+
+    for cve in sorted(cve_data):
+        write_string += "PACKAGE NAME: %s\n" % d.getVar("PN")
+        write_string += "PACKAGE VERSION: %s\n" % d.getVar("PV")
+        write_string += "CVE: %s\n" % cve
+        if cve in patched:
+            write_string += "CVE STATUS: Patched\n"
+        else:
+            unpatched_cves.append(cve)
+            write_string += "CVE STATUS: Unpatched\n"
+        write_string += "CVE SUMMARY: %s\n" % cve_data[cve]["summary"]
+        write_string += "CVSS v2 BASE SCORE: %s\n" % cve_data[cve]["scorev2"]
+        write_string += "CVSS v3 BASE SCORE: %s\n" % cve_data[cve]["scorev3"]
+        write_string += "VECTOR: %s\n" % cve_data[cve]["vector"]
+        write_string += "MORE INFORMATION: %s%s\n\n" % (nvd_link, cve)
+
+    if unpatched_cves:
+        bb.warn("Found unpatched CVE (%s), for more information check %s" % (" ".join(unpatched_cves),cve_file))
+
+    with open(cve_file, "w") as f:
+        bb.note("Writing file %s with CVE information" % cve_file)
+        f.write(write_string)
+
+    if d.getVar("CVE_CHECK_COPY_FILES") == "1":
+        cve_dir = d.getVar("CVE_CHECK_DIR")
+        bb.utils.mkdirhier(cve_dir)
+        deploy_file = os.path.join(cve_dir, d.getVar("PN"))
+        with open(deploy_file, "w") as f:
+            f.write(write_string)
+
+    if d.getVar("CVE_CHECK_CREATE_MANIFEST") == "1":
+        with open(d.getVar("CVE_CHECK_TMP_FILE"), "a") as f:
+            f.write("%s" % write_string)

--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -30,7 +30,7 @@ CVE_PRODUCT ??= "${BPN}"
 CVE_VERSION ??= "${PV}"
 
 CVE_CHECK_DB_DIR ?= "${DL_DIR}/CVE_CHECK"
-CVE_CHECK_DB_FILE ?= "${CVE_CHECK_DB_DIR}/nvdcve_1.1.db"
+CVE_CHECK_DB_FILE ?= "${CVE_CHECK_DB_DIR}/nvdcve_2.db"
 
 CVE_CHECK_LOG ?= "${T}/cve.log"
 CVE_CHECK_TMP_FILE ?= "${TMPDIR}/cve_check"
@@ -67,7 +67,7 @@ python do_cve_check () {
 }
 
 addtask cve_check before do_build
-do_cve_check[depends] = "cve-update-db-native:do_populate_cve_db"
+do_cve_check[depends] = "cve-update-nvd2-native:do_populate_cve_db"
 do_cve_check[nostamp] = "1"
 
 python cve_check_cleanup () {

--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -1,0 +1,346 @@
+# base recipe: meta/recipes-core/meta/cve-update-nvd2-native.bb
+# base branch: dunfell
+# base commit: 959e7b1432994ade7a79b074d8de3070a69c494f
+
+SUMMARY = "Updates the NVD CVE database"
+LICENSE = "MIT"
+
+# Important note:
+# This product uses the NVD API but is not endorsed or certified by the NVD.
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+inherit native
+
+deltask do_unpack
+deltask do_patch
+deltask do_configure
+deltask do_compile
+deltask do_install
+deltask do_populate_sysroot
+
+NVDCVE_URL ?= "https://services.nvd.nist.gov/rest/json/cves/2.0"
+
+# If you have a NVD API key (https://nvd.nist.gov/developers/request-an-api-key)
+# then setting this to get higher rate limits.
+NVDCVE_API_KEY ?= ""
+
+# CVE database update interval, in seconds. By default: once a day (24*60*60).
+# Use 0 to force the update
+# Use a negative value to skip the update
+CVE_DB_UPDATE_INTERVAL ?= "86400"
+
+# Timeout for blocking socket operations, such as the connection attempt.
+CVE_SOCKET_TIMEOUT ?= "60"
+
+CVE_DB_TEMP_FILE ?= "${CVE_CHECK_DB_DIR}/temp_nvdcve_2.db"
+
+CVE_CHECK_DB_FILE ?= "${CVE_CHECK_DB_DIR}/nvdcve_2.db"
+
+python () {
+    if not bb.data.inherits_class("cve-check", d):
+        raise bb.parse.SkipRecipe("Skip recipe when cve-check class is not loaded.")
+}
+
+python do_fetch() {
+    """
+    Update NVD database with API 2.0
+    """
+    import bb.utils
+    import bb.progress
+    import shutil
+
+    bb.utils.export_proxies(d)
+
+    db_file = d.getVar("CVE_CHECK_DB_FILE")
+    db_dir = os.path.dirname(db_file)
+    db_tmp_file = d.getVar("CVE_DB_TEMP_FILE")
+
+    cleanup_db_download(db_file, db_tmp_file)
+    # By default let's update the whole database (since time 0)
+    database_time = 0
+
+    # The NVD database changes once a day, so no need to update more frequently
+    # Allow the user to force-update
+    try:
+        import time
+        update_interval = int(d.getVar("CVE_DB_UPDATE_INTERVAL"))
+        if update_interval < 0:
+            bb.note("CVE database update skipped")
+            return
+        if time.time() - os.path.getmtime(db_file) < update_interval:
+            bb.note("CVE database recently updated, skipping")
+            return
+        database_time = os.path.getmtime(db_file)
+
+    except OSError:
+        pass
+
+    bb.utils.mkdirhier(db_dir)
+    if os.path.exists(db_file):
+        shutil.copy2(db_file, db_tmp_file)
+
+    if update_db_file(db_tmp_file, d, database_time) == True:
+        # Update downloaded correctly, can swap files
+        shutil.move(db_tmp_file, db_file)
+    else:
+        # Update failed, do not modify the database
+        bb.warn("CVE database update failed")
+        os.remove(db_tmp_file)
+}
+
+do_fetch[lockfiles] += "${CVE_CHECK_DB_FILE_LOCK}"
+do_fetch[file-checksums] = ""
+do_fetch[vardeps] = ""
+
+def cleanup_db_download(db_file, db_tmp_file):
+    """
+    Cleanup the download space from possible failed downloads
+    """
+
+    # Clean up the updates done on the main file
+    # Remove it only if a journal file exists - it means a complete re-download
+    if os.path.exists("{0}-journal".format(db_file)):
+        # If a journal is present the last update might have been interrupted. In that case,
+        # just wipe any leftovers and force the DB to be recreated.
+        os.remove("{0}-journal".format(db_file))
+
+        if os.path.exists(db_file):
+            os.remove(db_file)
+
+    # Clean-up the temporary file downloads, we can remove both journal
+    # and the temporary database
+    if os.path.exists("{0}-journal".format(db_tmp_file)):
+        # If a journal is present the last update might have been interrupted. In that case,
+        # just wipe any leftovers and force the DB to be recreated.
+        os.remove("{0}-journal".format(db_tmp_file))
+
+    if os.path.exists(db_tmp_file):
+        os.remove(db_tmp_file)
+
+def nvd_request_next(url, api_key, args):
+    """
+    Request next part of the NVD dabase
+    """
+
+    import urllib.request
+    import urllib.parse
+    import gzip
+    import http
+    import time
+
+    request = urllib.request.Request(url + "?" + urllib.parse.urlencode(args))
+    if api_key:
+        request.add_header("apiKey", api_key)
+    bb.note("Requesting %s" % request.full_url)
+
+    for attempt in range(5):
+        try:
+            r = urllib.request.urlopen(request)
+
+            if (r.headers['content-encoding'] == 'gzip'):
+                buf = r.read()
+                raw_data = gzip.decompress(buf).decode("utf-8")
+            else:
+                raw_data = r.read().decode("utf-8")
+
+            r.close()
+
+        except Exception as e:
+            bb.note("CVE database: received error (%s), retrying" % (e))
+            time.sleep(6)
+            pass
+        else:
+            return raw_data
+    else:
+        # We failed at all attempts
+        return None
+
+def update_db_file(db_tmp_file, d, database_time):
+    """
+    Update the given database file
+    """
+    import bb.utils, bb.progress
+    import datetime
+    import sqlite3
+    import json
+
+    # Connect to database
+    conn = sqlite3.connect(db_tmp_file)
+    initialize_db(conn)
+
+    req_args = {'startIndex' : 0}
+
+    # The maximum range for time is 120 days
+    # Force a complete update if our range is longer
+    if (database_time != 0):
+        database_date = datetime.datetime.fromtimestamp(database_time, tz=datetime.timezone.utc)
+        today_date = datetime.datetime.now(tz=datetime.timezone.utc)
+        delta = today_date - database_date
+        if delta.days < 120:
+            bb.note("CVE database: performing partial update")
+            req_args['lastModStartDate'] = database_date.isoformat()
+            req_args['lastModEndDate'] = today_date.isoformat()
+        else:
+            bb.note("CVE database: file too old, forcing a full update")
+
+    with bb.progress.ProgressHandler(d) as ph, open(os.path.join(d.getVar("TMPDIR"), 'cve_check'), 'a') as cve_f:
+
+        bb.note("Updating entries")
+        index = 0
+        url = d.getVar("NVDCVE_URL")
+        api_key = d.getVar("NVDCVE_API_KEY") or None
+
+        while True:
+            req_args['startIndex'] = index
+            raw_data = nvd_request_next(url, api_key, req_args)
+            if raw_data is None:
+                # We haven't managed to download data
+                return False
+
+            data = json.loads(raw_data)
+
+            index = data["startIndex"]
+            total = data["totalResults"]
+            per_page = data["resultsPerPage"]
+            bb.note("Got %d entries" % per_page)
+            for cve in data["vulnerabilities"]:
+               update_db(conn, cve)
+
+            index += per_page
+            ph.update((float(index) / (total+1)) * 100)
+            if index >= total:
+               break
+
+            # Recommended by NVD
+            time.sleep(6)
+
+        # Update success, set the date to cve_check file.
+        cve_f.write('CVE database update : %s\n\n' % datetime.date.today())
+
+    conn.commit()
+    conn.close()
+    return True
+
+def initialize_db(conn):
+    with conn:
+        c = conn.cursor()
+
+        c.execute("CREATE TABLE IF NOT EXISTS META (YEAR INTEGER UNIQUE, DATE TEXT)")
+
+        c.execute("CREATE TABLE IF NOT EXISTS NVD (ID TEXT UNIQUE, SUMMARY TEXT, \
+            SCOREV2 TEXT, SCOREV3 TEXT, MODIFIED INTEGER, VECTOR TEXT)")
+
+        c.execute("CREATE TABLE IF NOT EXISTS PRODUCTS (ID TEXT, \
+            VENDOR TEXT, PRODUCT TEXT, VERSION_START TEXT, OPERATOR_START TEXT, \
+            VERSION_END TEXT, OPERATOR_END TEXT)")
+        c.execute("CREATE INDEX IF NOT EXISTS PRODUCT_ID_IDX on PRODUCTS(ID);")
+
+        c.close()
+
+def parse_node_and_insert(conn, node, cveId):
+
+    def cpe_generator():
+        for cpe in node.get('cpeMatch', ()):
+            if not cpe['vulnerable']:
+                return
+            cpe23 = cpe.get('criteria')
+            if not cpe23:
+                return
+            cpe23 = cpe23.split(':')
+            if len(cpe23) < 6:
+                return
+            vendor = cpe23[3]
+            product = cpe23[4]
+            version = cpe23[5]
+
+            if cpe23[6] == '*' or cpe23[6] == '-':
+                version_suffix = ""
+            else:
+                version_suffix = "_" + cpe23[6]
+
+            if version != '*' and version != '-':
+                # Version is defined, this is a '=' match
+                yield [cveId, vendor, product, version + version_suffix, '=', '', '']
+            elif version == '-':
+                # no version information is available
+                yield [cveId, vendor, product, version, '', '', '']
+            else:
+                # Parse start version, end version and operators
+                op_start = ''
+                op_end = ''
+                v_start = ''
+                v_end = ''
+
+                if 'versionStartIncluding' in cpe:
+                    op_start = '>='
+                    v_start = cpe['versionStartIncluding']
+
+                if 'versionStartExcluding' in cpe:
+                    op_start = '>'
+                    v_start = cpe['versionStartExcluding']
+
+                if 'versionEndIncluding' in cpe:
+                    op_end = '<='
+                    v_end = cpe['versionEndIncluding']
+
+                if 'versionEndExcluding' in cpe:
+                    op_end = '<'
+                    v_end = cpe['versionEndExcluding']
+
+                if op_start or op_end or v_start or v_end:
+                    yield [cveId, vendor, product, v_start, op_start, v_end, op_end]
+                else:
+                    # This is no version information, expressed differently.
+                    # Save processing by representing as -.
+                    yield [cveId, vendor, product, '-', '', '', '']
+
+    conn.executemany("insert into PRODUCTS values (?, ?, ?, ?, ?, ?, ?)", cpe_generator()).close()
+
+def update_db(conn, elt):
+    """
+    Update a single entry in the on-disk database
+    """
+
+    accessVector = None
+    cveId = elt['cve']['id']
+    if elt['cve']['vulnStatus'] ==  "Rejected":
+        return
+    cveDesc = ""
+    for desc in elt['cve']['descriptions']:
+        if desc['lang'] == 'en':
+            cveDesc = desc['value']
+    date = elt['cve']['lastModified']
+    try:
+        accessVector = elt['cve']['metrics']['cvssMetricV2'][0]['cvssData']['accessVector']
+        cvssv2 = elt['cve']['metrics']['cvssMetricV2'][0]['cvssData']['baseScore']
+    except KeyError:
+        cvssv2 = 0.0
+    cvssv3 = None
+    try:
+        accessVector = accessVector or elt['cve']['metrics']['cvssMetricV30'][0]['cvssData']['attackVector']
+        cvssv3 = elt['cve']['metrics']['cvssMetricV30'][0]['cvssData']['baseScore']
+    except KeyError:
+        pass
+    try:
+        accessVector = accessVector or elt['cve']['metrics']['cvssMetricV31'][0]['cvssData']['attackVector']
+        cvssv3 = cvssv3 or elt['cve']['metrics']['cvssMetricV31'][0]['cvssData']['baseScore']
+    except KeyError:
+        pass
+    accessVector = accessVector or "UNKNOWN"
+    cvssv3 = cvssv3 or 0.0
+
+    conn.execute("insert or replace into NVD values (?, ?, ?, ?, ?, ?)",
+                [cveId, cveDesc, cvssv2, cvssv3, date, accessVector]).close()
+
+    try:
+        for config in elt['cve']['configurations']:
+            # This is suboptimal as it doesn't handle AND/OR and negate, but is better than nothing
+            for node in config["nodes"]:
+                parse_node_and_insert(conn, node, cveId)
+    except KeyError:
+        bb.note("CVE %s has no configurations" % cveId)
+
+do_fetch[nostamp] = "1"
+
+EXCLUDE_FROM_WORLD = "1"

--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -42,7 +42,7 @@ python () {
         raise bb.parse.SkipRecipe("Skip recipe when cve-check class is not loaded.")
 }
 
-python do_fetch() {
+python do_populate_cve_db() {
     """
     Update NVD database with API 2.0
     """
@@ -88,10 +88,6 @@ python do_fetch() {
         bb.warn("CVE database update failed")
         os.remove(db_tmp_file)
 }
-
-do_fetch[lockfiles] += "${CVE_CHECK_DB_FILE_LOCK}"
-do_fetch[file-checksums] = ""
-do_fetch[vardeps] = ""
 
 def cleanup_db_download(db_file, db_tmp_file):
     """
@@ -184,7 +180,7 @@ def update_db_file(db_tmp_file, d, database_time):
         else:
             bb.note("CVE database: file too old, forcing a full update")
 
-    with bb.progress.ProgressHandler(d) as ph, open(os.path.join(d.getVar("TMPDIR"), 'cve_check'), 'a') as cve_f:
+    with open(os.path.join(d.getVar("TMPDIR"), 'cve_check'), 'a') as cve_f:
 
         bb.note("Updating entries")
         index = 0
@@ -208,7 +204,6 @@ def update_db_file(db_tmp_file, d, database_time):
                update_db(conn, cve)
 
             index += per_page
-            ph.update((float(index) / (total+1)) * 100)
             if index >= total:
                break
 
@@ -341,6 +336,8 @@ def update_db(conn, elt):
     except KeyError:
         bb.note("CVE %s has no configurations" % cveId)
 
-do_fetch[nostamp] = "1"
+
+addtask do_populate_cve_db before do_fetch
+do_populate_cve_db[nostamp] = "1"
 
 EXCLUDE_FROM_WORLD = "1"


### PR DESCRIPTION
# Purpose of pull request
After December 15, 2023, all legacy data feeds and the 1.0 APIs of CVE database provided by NVD are going to be retired, transition to the 2.0 APIs is necessary.

EMLinux is using the CVE database fetcher (access to NVD by legacy data feeds) provided by Poky-warrior, but Poky-warrior has already been EOL and the 2.0 APIs are not expected to be supported.

Therefore, we will replace the current CVE database fetcher with new one supporting the 2.0 APIs.

# Test
## How to test
1. Build qemuarm64 image
2. Check cve-check works

### Build qemuarm64 image
Add the following to local.conf and build qemuarm64 image.
```
MACHINE = "qemuarm64"
INHERIT += "cve-check debian-cve-check kernel-cve-check"
```
```
$ bitbake core-image-minimal
```

### Check cve-check works
Check items:
- Unpatched CVE report warnings is displayed during bitbake built
- The CVE database file is created
- The CVE logs is created for each package
- The CVE list for build image is created

## Test result
### Build image
Unpatched CVE report warnings was displayed.
```
build$ bitbake core-image-minimal 
Parsing recipes: 100% |################################################################################################################| Time: 0:00:53
Parsing of 1362 .bb files complete (0 cached, 1362 parsed). 2382 targets, 79 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.8"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:6bed30c0ef18d642386024df379cfb1df383e39b"
meta-debian-extended = "HEAD:1faec1396bc9871f46202287446757993c392468"
meta-emlinux         = "support-nvd-api-2.0:dca5ff8363b69af946c02c487f2c0b430711524b"
meta-emlinux-private = "HEAD:8207525289999d2c41983eb8155127b62621cdb1"

Initialising tasks: 100% |#############################################################################################################| Time: 0:00:02
Sstate summary: Wanted 867 Found 0 Missed 867 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: flex-2.6.4-r0 do_cve_check: Found unpatched CVE (CVE-2015-1773 CVE-2019-6293), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/flex/2.6.4-r0/temp/cve.log
WARNING: bison-3.3.2-r0 do_cve_check: Found unpatched CVE (CVE-2020-14150), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/bison/3.3.2-r0/temp/cve.log
WARNING: gawk-4.2.1-r0 do_cve_check: Found unpatched CVE (CVE-2023-4156), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/gawk/4.2.1-r0/temp/cve.log
WARNING: gcc-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/gcc/8.3.0-r0/temp/cve.log
WARNING: binutils-2.31.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000876 CVE-2018-17358 CVE-2018-17359 CVE-2018-17360 CVE-2018-20623 CVE-2018-20651 CVE-2018-20657 CVE-2018-20671 CVE-2018-20673 CVE-2018-20712 CVE-2019-1010204 CVE-2020-19724 CVE-2020-21490 CVE-2020-35342 CVE-2020-35493 CVE-2020-35494 CVE-2020-35495 CVE-2020-35496 CVE-2020-35507 CVE-2021-20197 CVE-2021-3487 CVE-2021-45078 CVE-2021-46174 CVE-2022-38533 CVE-2022-44840 CVE-2022-45703 CVE-2022-47673 CVE-2022-47695 CVE-2022-47696 CVE-2022-48063 CVE-2022-48064 CVE-2022-48065 CVE-2023-25584), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/binutils/2.31.1-r0/temp/cve.log
WARNING: unzip-6.0-r0 do_cve_check: Found unpatched CVE (CVE-2021-4217), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/unzip/6.0-r0/temp/cve.log
WARNING: libpcre-8.39-r0 do_cve_check: Found unpatched CVE (CVE-2019-20838 CVE-2020-14155), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/libpcre/8.39-r0/temp/cve.log
WARNING: iptables-1.8.2-r0 do_cve_check: Found unpatched CVE (CVE-2019-11360), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/iptables/1.8.2-r0/temp/cve.log
WARNING: sqlite3-3_3.27.2-r0 do_cve_check: Found unpatched CVE (CVE-2019-19645 CVE-2020-11656 CVE-2020-13631 CVE-2022-35737), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/sqlite3/3_3.27.2-r0/temp/cve.log
WARNING: re2c-native-1.1.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-21232), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/re2c-native/1.1.1-r0/temp/cve.log
WARNING: procps-3.3.15-r0 do_cve_check: Found unpatched CVE (CVE-2018-1121 CVE-2023-4016), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/procps/3.3.15-r0/temp/cve.log
WARNING: tar-1.30-r0 do_cve_check: Found unpatched CVE (CVE-2019-9923 CVE-2021-20193 CVE-2022-48303), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/tar/1.30-r0/temp/cve.log
WARNING: coreutils-8.30-r0 do_cve_check: Found unpatched CVE (CVE-2016-2781), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/coreutils/8.30-r0/temp/cve.log
WARNING: mdadm-4.1-r0 do_cve_check: Found unpatched CVE (CVE-2023-28736 CVE-2023-28938), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/mdadm/4.1-r0/temp/cve.log
WARNING: iproute2-4.20.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-20795), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/iproute2/4.20.0-r0/temp/cve.log
WARNING: perl-5.28.1-r1 do_cve_check: Found unpatched CVE (CVE-2023-31484 CVE-2023-31486), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/perl/5.28.1-r1/temp/cve.log
WARNING: bash-5.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-18276), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/temp/cve.log
WARNING: zip-3.0-r0 do_cve_check: Found unpatched CVE (CVE-2018-13410 CVE-2018-13684), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/zip/3.0-r0/temp/cve.log
WARNING: shadow-4.5-r0 do_cve_check: Found unpatched CVE (CVE-2013-4235 CVE-2018-7169), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/shadow/4.5-r0/temp/cve.log
WARNING: util-linux-2.33.1-r0 do_cve_check: Found unpatched CVE (CVE-2021-37600 CVE-2022-0563), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/util-linux/2.33.1-r0/temp/cve.log
WARNING: shadow-native-4.5-r0 do_cve_check: Found unpatched CVE (CVE-2013-4235 CVE-2018-7169), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/shadow-native/4.5-r0/temp/cve.log
WARNING: libpcre-native-8.39-r0 do_cve_check: Found unpatched CVE (CVE-2019-20838 CVE-2020-14155), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/libpcre-native/8.39-r0/temp/cve.log
WARNING: gcc-source-8.3.0-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/TEST-cve-check2/build/tmp-glibc/work-shared/gcc-8.3.0-r0/temp/cve.log
WARNING: ed-native-1.15-r0 do_cve_check: Found unpatched CVE (CVE-2015-2987), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/ed-native/1.15-r0/temp/cve.log
WARNING: nss-native-3.42.1-r0 do_cve_check: Found unpatched CVE (CVE-2006-5201), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/nss-native/3.42.1-r0/temp/cve.log
WARNING: libarchive-native-3.3.3-r0 do_cve_check: Found unpatched CVE (CVE-2023-30571), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/libarchive-native/3.3.3-r0/temp/cve.log
WARNING: flex-native-2.6.4-r0 do_cve_check: Found unpatched CVE (CVE-2015-1773 CVE-2019-6293), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/flex-native/2.6.4-r0/temp/cve.log
WARNING: libxslt-native-1.1.32-r0 do_cve_check: Found unpatched CVE (CVE-2022-29824), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/libxslt-native/1.1.32-r0/temp/cve.log
WARNING: libxml2-native-2.9.4-r0 do_cve_check: Found unpatched CVE (CVE-2016-3709 CVE-2016-9318 CVE-2017-16932), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/libxml2-native/2.9.4-r0/temp/cve.log
WARNING: systemd-1_241-r0 do_cve_check: Found unpatched CVE (CVE-2019-20386 CVE-2019-3843 CVE-2019-3844 CVE-2021-3997), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/systemd/1_241-r0/temp/cve.log
WARNING: busybox-1.30.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000500 CVE-2021-42374 CVE-2021-42376 CVE-2021-42378 CVE-2021-42379 CVE-2021-42380 CVE-2021-42381 CVE-2021-42382 CVE-2021-42384 CVE-2021-42385 CVE-2021-42386 CVE-2022-28391 CVE-2022-48174 CVE-2023-39810), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/busybox/1.30.1-r0/temp/cve.log
WARNING: libgcc-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/libgcc/8.3.0-r0/temp/cve.log
WARNING: ncurses-6.1+20181013-r0 do_cve_check: Found unpatched CVE (CVE-2020-19187 CVE-2020-19188 CVE-2020-19189 CVE-2020-19190 CVE-2021-39537 CVE-2023-29491), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/ncurses/6.1+20181013-r0/temp/cve.log
WARNING: util-linux-native-2.33.1-r0 do_cve_check: Found unpatched CVE (CVE-2021-37600 CVE-2022-0563), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/util-linux-native/2.33.1-r0/temp/cve.log
WARNING: gcc-runtime-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/gcc-runtime/8.3.0-r0/temp/cve.log
WARNING: glib-2.0-native-2.58.3-r0 do_cve_check: Found unpatched CVE (CVE-2020-35457 CVE-2023-29499 CVE-2023-32611 CVE-2023-32665), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/glib-2.0-native/2.58.3-r0/temp/cve.log
WARNING: glibc-2.28-r0 do_cve_check: Found unpatched CVE (CVE-2010-4756 CVE-2018-20796 CVE-2019-1010022 CVE-2019-1010023 CVE-2019-1010024 CVE-2019-1010025 CVE-2019-9192 CVE-2020-1751 CVE-2023-4813), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/glibc/2.28-r0/temp/cve.log
WARNING: binutils-native-2.31.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000876 CVE-2018-17358 CVE-2018-17359 CVE-2018-17360 CVE-2018-20623 CVE-2018-20651 CVE-2018-20657 CVE-2018-20671 CVE-2018-20673 CVE-2018-20712 CVE-2019-1010204 CVE-2020-19724 CVE-2020-21490 CVE-2020-35342 CVE-2020-35493 CVE-2020-35494 CVE-2020-35495 CVE-2020-35496 CVE-2020-35507 CVE-2021-20197 CVE-2021-3487 CVE-2021-45078 CVE-2021-46174 CVE-2022-38533 CVE-2022-44840 CVE-2022-45703 CVE-2022-47673 CVE-2022-47695 CVE-2022-47696 CVE-2022-48063 CVE-2022-48064 CVE-2022-48065 CVE-2023-25584), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/binutils-native/2.31.1-r0/temp/cve.log
WARNING: curl-native-7.64.0-r1 do_cve_check: Found unpatched CVE (CVE-2013-2617 CVE-2021-22922 CVE-2021-22923 CVE-2021-22926 CVE-2023-27534 CVE-2023-28320 CVE-2023-28321 CVE-2023-28322), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/curl-native/7.64.0-r1/temp/cve.log
WARNING: perl-native-5.28.1-r1 do_cve_check: Found unpatched CVE (CVE-2023-31484 CVE-2023-31486), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/perl-native/5.28.1-r1/temp/cve.log
WARNING: gcc-cross-aarch64-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/gcc-cross-aarch64/8.3.0-r0/temp/cve.log
WARNING: bison-native-3.3.2-r0 do_cve_check: Found unpatched CVE (CVE-2020-14150), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/bison-native/3.3.2-r0/temp/cve.log
WARNING: ncurses-native-6.1+20181013-r0 do_cve_check: Found unpatched CVE (CVE-2020-19187 CVE-2020-19188 CVE-2020-19189 CVE-2020-19190 CVE-2021-39537 CVE-2023-29491), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/ncurses-native/6.1+20181013-r0/temp/cve.log
WARNING: rpm-native-4.14.2.1-r0 do_cve_check: Found unpatched CVE (CVE-2021-20266 CVE-2021-3421 CVE-2021-3521 CVE-2021-35937 CVE-2021-35938 CVE-2021-35939), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/rpm-native/4.14.2.1-r0/temp/cve.log
WARNING: sqlite3-native-3_3.27.2-r0 do_cve_check: Found unpatched CVE (CVE-2019-19645 CVE-2020-11656 CVE-2020-13631 CVE-2022-35737), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/sqlite3-native/3_3.27.2-r0/temp/cve.log
WARNING: binutils-cross-aarch64-2.31.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000876 CVE-2018-17358 CVE-2018-17359 CVE-2018-17360 CVE-2018-20623 CVE-2018-20651 CVE-2018-20657 CVE-2018-20671 CVE-2018-20673 CVE-2018-20712 CVE-2019-1010204 CVE-2020-19724 CVE-2020-21490 CVE-2020-35342 CVE-2020-35493 CVE-2020-35494 CVE-2020-35495 CVE-2020-35496 CVE-2020-35507 CVE-2021-20197 CVE-2021-3487 CVE-2021-45078 CVE-2021-46174 CVE-2022-38533 CVE-2022-44840 CVE-2022-45703 CVE-2022-47673 CVE-2022-47695 CVE-2022-47696 CVE-2022-48063 CVE-2022-48064 CVE-2022-48065 CVE-2023-25584), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/binutils-cross-aarch64/2.31.1-r0/temp/cve.log
WARNING: apt-native-1.2.24-r0 do_cve_check: Found unpatched CVE (CVE-2020-3810), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/apt-native/1.2.24-r0/temp/cve.log
WARNING: qemu-native-3.1-r0 do_cve_check: Found unpatched CVE (CVE-2007-0998 CVE-2018-20123 CVE-2018-20124 CVE-2018-20125 CVE-2018-20126 CVE-2018-20191 CVE-2018-20216 CVE-2019-12067 CVE-2019-12928 CVE-2019-12929 CVE-2019-20175 CVE-2019-8934 CVE-2020-25742 CVE-2020-25743 CVE-2020-35503 CVE-2021-20255 CVE-2021-3750 CVE-2022-36648 CVE-2022-3872 CVE-2022-4144 CVE-2023-1386 CVE-2023-1544 CVE-2023-3019 CVE-2023-3180 CVE-2023-3354 CVE-2023-42467), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/qemu-native/3.1-r0/temp/cve.log
WARNING: libgcc-initial-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/aarch64-emlinux-linux/libgcc-initial/8.3.0-r0/temp/cve.log
WARNING: libpng-native-1.6.36-r0 do_cve_check: Found unpatched CVE (CVE-2019-6129), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/libpng-native/1.6.36-r0/temp/cve.log
WARNING: pixman-native-0.36.0-r0 do_cve_check: Found unpatched CVE (CVE-2023-37769), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/pixman-native/0.36.0-r0/temp/cve.log
WARNING: qemu-system-native-3.1-r0 do_cve_check: Found unpatched CVE (CVE-2007-0998 CVE-2018-20123 CVE-2018-20124 CVE-2018-20125 CVE-2018-20126 CVE-2018-20191 CVE-2018-20216 CVE-2019-12067 CVE-2019-12928 CVE-2019-12929 CVE-2019-20175 CVE-2019-8934 CVE-2020-25742 CVE-2020-25743 CVE-2020-35503 CVE-2021-20255 CVE-2021-3750 CVE-2022-36648 CVE-2022-3872 CVE-2022-4144 CVE-2023-1386 CVE-2023-1544 CVE-2023-3019 CVE-2023-3180 CVE-2023-3354 CVE-2023-42467), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/x86_64-linux/qemu-system-native/3.1-r0/temp/cve.log
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-1999-0524 CVE-1999-0656 CVE-2006-2932 CVE-2007-2764 CVE-2007-4998 CVE-2008-2544 CVE-2008-4609 CVE-2010-0298 CVE-2010-4563 CVE-2010-5321 CVE-2014-1737 CVE-2014-2648 CVE-2014-3153 CVE-2014-3534 CVE-2014-8171 CVE-2015-2877 CVE-2015-7312 CVE-2016-0774 CVE-2016-3699 CVE-2017-1000377 CVE-2017-6264 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-14899 CVE-2019-16089 CVE-2019-19083 CVE-2019-20794 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-27820 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2020-36691 CVE-2020-36766 CVE-2020-8834 CVE-2021-32078 CVE-2021-3669 CVE-2021-3714 CVE-2021-3759 CVE-2021-3773 CVE-2021-3847 CVE-2021-3864 CVE-2021-3923 CVE-2021-4037 CVE-2021-44879 CVE-2022-0400 CVE-2022-0480 CVE-2022-1015 CVE-2022-1247 CVE-2022-2327 CVE-2022-25265 CVE-2022-2961 CVE-2022-3108 CVE-2022-3303 CVE-2022-3344 CVE-2022-3523 CVE-2022-3534 CVE-2022-3566 CVE-2022-3567 CVE-2022-36402 CVE-2022-39189 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-4543 CVE-2022-45884 CVE-2022-45885 CVE-2022-47520 CVE-2023-0590 CVE-2023-1076 CVE-2023-1077 CVE-2023-1249 CVE-2023-1582 CVE-2023-1611 CVE-2023-2124 CVE-2023-2177 CVE-2023-23000 CVE-2023-23039 CVE-2023-26242 CVE-2023-28466 CVE-2023-33288 CVE-2023-35827 CVE-2023-3640 CVE-2023-37453 CVE-2023-37454 CVE-2023-3772 CVE-2023-3863 CVE-2023-4010 CVE-2023-4128 CVE-2023-4133 CVE-2023-4207 CVE-2023-4244 CVE-2023-42753 CVE-2023-4622 CVE-2023-4921), for more information check /project/TEST-cve-check2/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
Image CVE report stored in: /project/TEST-cve-check2/build/tmp-glibc/deploy/images/qemuarm64/core-image-minimal-qemuarm64-20230928083006.rootfs.cve
NOTE: Tasks Summary: Attempted 3317 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 53 WARNING messages shown.
```

### CVE database file
The cve-update-nvd2-native step worked, The CVE database file was created.
```
build$ ls -F ./tmp-glibc/work/x86_64-linux/cve-update-nvd2-native/1.0-r0/temp/
log.do_cve_check@               run.debian_cve_check.2822966    run.populate_lic_qa_checksum.2647388     run.sstate_task_prefunc.2647388
log.do_cve_check.2822966        run.do_cve_check@               run.sstate_create_package.2647388*       run.uninative_changeinterp.2647388
log.do_populate_cve_db@         run.do_cve_check.2822966        run.sstate_hardcode_path.2647388         run.update_cip_kernel_sec.2481897
log.do_populate_cve_db.2481897  run.do_populate_cve_db@         run.sstate_hardcode_path_unpack.2647388  run.update_dst.2481897
log.do_populate_lic@            run.do_populate_cve_db.2481897  run.sstate_report_unihash.2647388
log.do_populate_lic.2647388     run.do_populate_lic@            run.sstate_sign_package.2647388
log.task_order                  run.do_populate_lic.2647388     run.sstate_task_postfunc.2647388
build$ ls -F ../downloads/CVE_CHECK/
DEBIAN/  KERNEL/  nvdcve_2.db
build$ file ../downloads/CVE_CHECK/nvdcve_2.db
../downloads/CVE_CHECK/nvdcve_2.db: SQLite 3.x database, last written using SQLite version 3031001
```

### CVE logs for each package
A cve.log was created for each package.
```
build$ find . -name 'cve.log'
./tmp-glibc/work/x86_64-linux/libffi-native/3.2.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/pigz-native/2.4-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/qemu-native/3.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/groff-native/1.22.4-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/binutils-native/2.31.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libxdmcp-native/1.1.2-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libyaml-native/0.2.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/file-native/5.35-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libxrender-native/0.9.10-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/expat-native/2.2.6-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/nspr-native/4.20-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libxcb-native/1.13.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/rpm-native/4.14.2.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/dbus-native/1.12.24-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/apt-native/1.2.24-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libxslt-native/1.1.32-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/openssl-native/1.1.1n-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/nss-native/3.42.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/ncurses-native/6.1+20181013-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/ipxe-native/1.0.0+git-20190125.36a4c85-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/e2fsprogs-native/1.44.5-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/glib-2.0-native/2.58.3-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/qemu-system-native/3.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/lzo-native/2.10-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libarchive-native/3.3.3-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libtool-native/2.4.6-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/dpkg-native/1.19.8-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/sqlite3-native/3_3.27.2-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/ed-native/1.15-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libx11-native/1.6.7-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libtirpc-native/1.1.4-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/util-linux-native/2.33.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/elfutils-native/0.176-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/flex-native/2.6.4-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/pixman-native/0.36.0-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/gettext-native/0.19.8.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/zlib-native/1.2.11-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libxml2-native/2.9.4-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libxrandr-native/1.5.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libpcre-native/8.39-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/tcl-native/8.6.9-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/bzip2-native/1.0.6-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libxext-native/1.3.3-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/syslinux-native/6.04~git20190206.bf6db5b4-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/binutils-cross-aarch64/2.31.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/ninja-native/1.8.2-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/perl-native/5.28.1-r1/temp/cve.log
./tmp-glibc/work/x86_64-linux/gcc-cross-aarch64/8.3.0-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/re2c-native/1.1.1-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/gmp-native/6.1.2-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/shadow-native/4.5-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/readline-native/7.0-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/curl-native/7.64.0-r1/temp/cve.log
./tmp-glibc/work/x86_64-linux/alsa-lib-native/1.1.8-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/libpng-native/1.6.36-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/m4-native/1.4.18-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/xz-native/5.2.4-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/bison-native/3.3.2-r0/temp/cve.log
./tmp-glibc/work/x86_64-linux/cdrtools-native/3.01a31+really3.01-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/coreutils/8.30-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/zip/3.0-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/tar/1.30-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libx11/1.6.7-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/kbd/2.0.4-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/ncurses/6.1+20181013-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/elfutils/0.176-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/glibc/2.28-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/gcc-runtime/8.3.0-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/grep/3.3-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libice/1.0.9-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/bzip2/1.0.6-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/bison/3.3.2-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/busybox/1.30.1-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/binutils/2.31.1-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libgcc-initial/8.3.0-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libffi/3.2.1-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libxdmcp/1.1.2-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/flex/2.6.4-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/gawk/4.2.1-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/procps/3.3.15-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/sqlite3/3_3.27.2-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/shadow/4.5-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/e2fsprogs/1.44.5-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libpcre/8.39-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libtool/2.4.6-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/openssl/1.1.1n-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/dbus/1.12.24-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/xkeyboard-config/2.26-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/util-linux/2.33.1-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libtool-cross/2.4.6-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/perl/5.28.1-r1/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/iproute2/4.20.0-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/gmp/6.1.2-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/acl/2.2.53-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/readline/7.0-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/gcc/8.3.0-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libxkbcommon/0.8.2-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/lzo/2.10-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libcap/2.25-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/zlib/1.2.11-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/mdadm/4.1-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/xz/5.2.4-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libgcc/8.3.0-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/initscripts/1.0-r155/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libxcb/1.13.1-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/unzip/6.0-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/iptables/1.8.2-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/socat/1.7.3.2-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/expat/2.2.6-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/libtirpc/1.1.4-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/systemd/1_241-r0/temp/cve.log
./tmp-glibc/work/aarch64-emlinux-linux/m4/1.4.18-r0/temp/cve.log
./tmp-glibc/work/qemuarm64-emlinux-linux/base-files/3.0.14-r89/temp/cve.log
./tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
./tmp-glibc/work-shared/gcc-8.3.0-r0/temp/cve.log
build$ ls -F ./tmp-glibc/deploy/cve/
acl                     dbus-native        gettext-native     libgcc-initial   libxkbcommon       openssl             sqlite3-native
alsa-lib-native         dpkg-native        glib-2.0-native    libice           libxml2-native     openssl-native      syslinux-native
apt-native              e2fsprogs          glibc              libpcre          libxrandr-native   perl                systemd
base-files              e2fsprogs-native   gmp                libpcre-native   libxrender-native  perl-native         tar
bash                    ed-native          gmp-native         libpng-native    libxslt-native     pigz-native         tcl-native
binutils                elfutils           grep               libtirpc         libyaml-native     pixman-native       unzip
binutils-cross-aarch64  elfutils-native    groff-native       libtirpc-native  linux-base         procps              util-linux
binutils-native         expat              initscripts        libtool          lzo                qemu-native         util-linux-native
bison                   expat-native       iproute2           libtool-cross    lzo-native         qemu-system-native  xkeyboard-config
bison-native            file-native        iptables           libtool-native   m4                 re2c-native         xz
busybox                 flex               ipxe-native        libx11           m4-native          readline            xz-native
bzip2                   flex-native        kbd                libx11-native    mdadm              readline-native     zip
bzip2-native            gawk               libarchive-native  libxcb           ncurses            rpm-native          zlib
cdrtools-native         gcc                libcap             libxcb-native    ncurses-native     shadow              zlib-native
coreutils               gcc-cross-aarch64  libffi             libxdmcp         ninja-native       shadow-native
curl-native             gcc-runtime        libffi-native      libxdmcp-native  nspr-native        socat
dbus                    gcc-source-8.3.0   libgcc             libxext-native   nss-native         sqlite3
```

### CVE list for build image
A CVE list (core-image-minimal-qemuarm64.cve) for target machine image was created.
```
build$ ls -F ./tmp-glibc/deploy/images/qemuarm64/
Image@                                                       core-image-minimal-qemuarm64.cve@
Image--4.19-r0-qemuarm64-20230928083006.bin                  core-image-minimal-qemuarm64.ext4@
Image-qemuarm64.bin@                                         core-image-minimal-qemuarm64.manifest@
core-image-minimal-qemuarm64-20230928083006.qemuboot.conf    core-image-minimal-qemuarm64.qemuboot.conf@
core-image-minimal-qemuarm64-20230928083006.rootfs.cve       core-image-minimal-qemuarm64.tar.bz2@
core-image-minimal-qemuarm64-20230928083006.rootfs.ext4      core-image-minimal-qemuarm64.testdata.json@
core-image-minimal-qemuarm64-20230928083006.rootfs.manifest  modules--4.19-r0-qemuarm64-20230928083006.tgz
core-image-minimal-qemuarm64-20230928083006.rootfs.tar.bz2   modules-qemuarm64.tgz@
core-image-minimal-qemuarm64-20230928083006.testdata.json
```
