### PR TITLE
Update kernel to v4.19.295-cip103 and v5.10.194-cip39

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "78bddf33c2b7d94fc34e09bc56638615095ddc28"
-LINUX_CVE_VERSION ??= "5.10.191"
-LINUX_CIP_VERSION ?= "v5.10.191-cip38"
+LINUX_GIT_SRCREV ?= "ecda23c2ad8c5eae1f19054d0b67a7904546b7f4"
+LINUX_CVE_VERSION ??= "5.10.194"
+LINUX_CIP_VERSION ?= "v5.10.194-cip39"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "372689399d20f850142c3d734cb4365cd8a31242"
-LINUX_CVE_VERSION ??= "4.19.292"
-LINUX_CIP_VERSION ??= "v4.19.292-cip102"
+LINUX_GIT_SRCREV ?= "f0bb9fab6f834f73d3a71af029f5bda19d99b33c"
+LINUX_CVE_VERSION ??= "4.19.295"
+LINUX_CIP_VERSION ??= "v4.19.295-cip103"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.295-cip103 and v5.10.194-cip39

This pull request update the kernel to the following cip versions:
v4.19.295-cip103 with hash tag f0bb9fab6f834f73d3a71af029f5bda19d99b33c
v5.10.194-cip39 with hash tag ecda23c2ad8c5eae1f19054d0b67a7904546b7f4
