### PR TITLE
conf/distro: Add missing DISTRO_APT_SOURCES in emlinux distro

### DIFF
--- a/conf/distro/emlinux-common.inc
+++ b/conf/distro/emlinux-common.inc
@@ -10,6 +10,8 @@
 #
 INHERIT += "sdk-installer"
 
+DISTRO_APT_SOURCES += "conf/distro/emlinux-bookworm.list"
+
 DISTRO_KERNELS ?= "linux-cip"
 KERNEL_NAME ?= "cip"
 


### PR DESCRIPTION
A distro needs to define DISTRO_APT_SOURCES[1].

1:
https://github.com/ilbers/isar/blob/master/doc/user_manual.md#add-a-new-distro
