### PR TITLE
conf: Set DISTRO_APT_SOURCES for emlinux distribution

### DIFF
--- a/conf/distro/emlinux-common.inc
+++ b/conf/distro/emlinux-common.inc
@@ -13,6 +13,8 @@ INHERIT += "sdk-installer"
 DISTRO_KERNELS ?= "linux-cip"
 KERNEL_NAME ?= "cip"
 
+DISTRO_APT_SOURCES = "conf/distro/emlinux-bookworm.list"
+
 WIC_IMAGER_INSTALL = "parted \
   gdisk \
   util-linux \

--- a/conf/machine/raspberrypi3-64.inc
+++ b/conf/machine/raspberrypi3-64.inc
@@ -7,7 +7,7 @@
 DISTRO_ARCH ?= "arm64"
 
 # Raspberry Pi needs non-free-firmware repository.
-DISTRO_APT_SOURCES += "conf/distro/emlinux-bookworm-full.list"
+DISTRO_APT_SOURCES:append = " conf/distro/emlinux-bookworm-full.list"
 
 # wic file settings
 IMAGE_FSTYPES ?= "wic wic.xz"


### PR DESCRIPTION
Set DISTRO_APT_SOURCES for emlinux to not use isar default apt source. The emlinux only use conf/distro/emlinux-bookworm.list by default. If machine is raspberrypi3b series, adds
conf/distro/emlinux-bookworm-full.list.

qemu-arm64

```
build@0e74e9f35f07:~/work/build$ bitbake emlinux-image-base -e | grep
^DISTRO_APT_SOURCES
DISTRO_APT_SOURCES="conf/distro/emlinux-bookworm.list"
```

raspberrypi3bplus-64

```
build@0e74e9f35f07:~/work/build$ bitbake emlinux-image-base -e | grep
^DISTRO_APT_SOURCES
DISTRO_APT_SOURCES="conf/distro/emlinux-bookworm.list
conf/distro/emlinux-bookworm-full.list"
```
