### PR TITLE
image: fix for openssh-server installation (v2)

### DIFF
--- a/recipes-core/images/emlinux-image-base.bb
+++ b/recipes-core/images/emlinux-image-base.bb
@@ -9,6 +9,7 @@
 # SPDX-License-Identifier: MIT
 #
 
+require emlinux-image-common.inc
 
 DESCRIPTION = "EMLinux target filesystem"
 

--- a/recipes-core/images/emlinux-image-common.inc
+++ b/recipes-core/images/emlinux-image-common.inc
@@ -1,0 +1,13 @@
+#
+# Copyright (c) Cybertrust Japan Co., Ltd.
+#
+# SPDX-License-Identifier: MIT
+#
+
+python() {
+    if bb.utils.contains('IMAGE_INSTALL', 'sshd-regen-keys', True, False, d):
+        return
+    if bb.utils.contains('IMAGE_PREINSTALL', 'openssh-server', True, False, d) or \
+       bb.utils.contains('IMAGE_INSTALL', 'openssh-server', True, False, d):
+        d.appendVar('IMAGE_INSTALL', ' sshd-regen-keys')
+}


### PR DESCRIPTION
Previous PR #272

- change v1->v2:
  - Modified to add `sshd-regen-keys` if openssh-server is included in either `IMAGE_PREINSTALL` or `IMAGE_INSTALL`.

# Purpose of pull request

This commit fixes a build warning/error that occurs when installing openssh-server. The build warning/error is below.

```
WARNING: emlinux-image-base-1.0-r0 do_rootfs_postprocess: Looks like you have ssh host keys in the image but did  not install "sshd-regen-keys". This image should not be  deployed more than once.
ERROR: emlinux-image-base-1.0-r0 do_rootfs_postprocess: Install the package or forcefully remove this check!
```

The warning and error are caused by a function in isar's commit [0f7ce73b1bf30da52b0cf7a8c9b1ebb7828b2684](https://github.com/ilbers/isar/commit/0f7ce73b1bf30da52b0cf7a8c9b1ebb7828b2684). To resolve them, it is necesarry to install `sshd-regen-keys` manually.
This commit will install it automatically when openssh-server is installed.


# Build Test

added following line into conf/local.conf.

```
MACHINE = 'qemu-arm64'
IMAGE_PREINSTALL:append = " openssh-server"
```

and build by bitbake.

```
$ bitbake emlinux-image-base
```
