### PR TITLE
Add CVEs to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -16,9 +16,14 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2022-1789: This issue was introduced in 5.8-rc1. 4.19.y is not affected.
 # CVE-2023-1872: This is io_uring issue. linux 4.19 doesn't have this feature.
 # CVE-2015-8955: It's false positive because it was fixed in v4.1-rc1.
+# CVE-2022-2327: It's false positive because 4.19.y is not affected.
+# CVE-2020-8834: It's false positive because 4.19.y is not affected.
+# CVE-2017-6264: It's false positive because it's not a mainline flaw.
+# CVE-2017-1000377: It's false positive because it's not a mainline flaw.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
     CVE-2022-1508 CVE-2022-1789 CVE-2023-1872 \
-    CVE-2015-8955 \
+    CVE-2015-8955 CVE-2022-2327 CVE-2020-8834 \
+    CVE-2017-6264 CVE-2017-1000377 \
 "

--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -31,6 +31,10 @@ do_shared_workdir_prepend () {
 
 # CVE-2021-43057: This issue was introduced in 5.13-rc1. 5.10.y is not affected.
 # CVE-2015-8955: It's false positive because it was fixed in v4.1-rc1.
+# CVE-2020-8834: It's false positive because 5.10.y is not affected.
+# CVE-2017-6264: It's false positive because it's not a mainline flaw.
+# CVE-2017-1000377: It's false positive because it's not a mainline flaw.
 CVE_CHECK_WHITELIST = "\
-    CVE-2021-43057 CVE-2015-8955 \
+    CVE-2021-43057 CVE-2015-8955 CVE-2020-8834 \
+    CVE-2017-6264 CVE-2017-1000377 \
 "


### PR DESCRIPTION
Mitigates unpatched CVE messages printed for linux-base and linux-k510 due to false possible issues.