### PR TITLE
README: add license and COPYING file

### DIFF
--- a/COPYING.MIT
+++ b/COPYING.MIT
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -179,3 +179,16 @@ This recipe downloads openssl source package using _apt://_. This recipe shows h
 This recipe downloads openssl source package using _http://_. This recipe shows how to change build option and how to add new patch for source code.
 - openssl-git  
 This recipe downloads openssl source package using _git://_. This recipe shows how to change build option.
+
+# License
+
+All metadata is MIT licensed unless otherwise stated.
+Source code included in tree for individual recipes is under the LICENSE stated in the associated recipe (.bb file) unless otherwise stated.
+
+See [COPYING.MIT](COPYING.MIT) for more details about MIT license.
+
+# Community Resources
+
+#### Project home
+
+* https://github.com/miraclelinux/meta-emlinux


### PR DESCRIPTION
# Purpose of pull request

- meta-emlinux is basically under MIT license.
- This PR makes the license clear based on the license file and the statement in "warrior" branch.




