### PR TITLE
Update kernel to v4.19.297-cip104 and v5.10.200-cip40

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "ecda23c2ad8c5eae1f19054d0b67a7904546b7f4"
-LINUX_CVE_VERSION ??= "5.10.194"
-LINUX_CIP_VERSION ?= "v5.10.194-cip39"
+LINUX_GIT_SRCREV ?= "166400a23a22e665f5d880a99149b73abede402d"
+LINUX_CVE_VERSION ??= "5.10.200"
+LINUX_CIP_VERSION ?= "v5.10.200-cip40"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "f0bb9fab6f834f73d3a71af029f5bda19d99b33c"
-LINUX_CVE_VERSION ??= "4.19.295"
-LINUX_CIP_VERSION ??= "v4.19.295-cip103"
+LINUX_GIT_SRCREV ?= "1de13c21df07c83dd4c4d46225a226e5cd9b1a13"
+LINUX_CVE_VERSION ??= "4.19.297"
+LINUX_CIP_VERSION ??= "v4.19.297-cip104"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.297-cip104 and v5.10.200-cip40

This pull request update the kernel to the following cip versions:
v4.19.297-cip104 with hash tag 1de13c21df07c83dd4c4d46225a226e5cd9b1a13
v5.10.200-cip40 with hash tag 166400a23a22e665f5d880a99149b73abede402d
