### PR TITLE
Add CVE-1999-0524 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -24,6 +24,7 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2007-4998: It's false positive due to a coreutils issue.
 # CVE-2008-2544: It's false positive because the replication way is not proper.
 # CVE-2016-3699: It's false positive because it's not a mainline flaw.
+# CVE-1999-0524: This issue is that ICMP exists, can be filewalled if required.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
@@ -31,4 +32,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2015-8955 CVE-2022-2327 CVE-2020-8834 \
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
     CVE-2007-4998 CVE-2008-2544 CVE-2016-3699 \
+    CVE-1999-0524 \
 "

--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -38,8 +38,10 @@ do_shared_workdir_prepend () {
 # CVE-2007-4998: It's false positive due to a coreutils issue.
 # CVE-2008-2544: It's false positive because the replication way is not proper.
 # CVE-2016-3699: It's false positive because it's not a mainline flaw.
+# CVE-1999-0524: This issue is that ICMP exists, can be filewalled if required.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-43057 CVE-2015-8955 CVE-2020-8834 \
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
     CVE-2007-4998 CVE-2008-2544 CVE-2016-3699 \
+    CVE-1999-0524 \
 "


### PR DESCRIPTION
The CVE-1999-0524 issue is that ICMP exists, can be filewalled if required.

- https://nvd.nist.gov/vuln/detail/CVE-1999-0524




