### PR TITLE
Update generic x86-64 doc

### DIFF
--- a/doc/generic-x86-64.md
+++ b/doc/generic-x86-64.md
@@ -28,7 +28,7 @@ $ source repos/meta-emlinux/scripts/setup-emlinux build
 In the build directory, you need to set "generic-x86-64" to MACHINE variable.
 
 ```
-$ echo 'MACHINE = "genericx-86-64"' >> conf/local.conf
+$ echo 'MACHINE = "generic-x86-64"' >> conf/local.conf
 $ bitbake emlinux-image-base
 ```
 


### PR DESCRIPTION
Use machine name for file name.
Fix typo in the doc.
