### PR TITLE
Change wic image rootfs size by ROOTFS_EXTRA variable

### DIFF
--- a/conf/machine/generic-x86-64.conf
+++ b/conf/machine/generic-x86-64.conf
@@ -13,3 +13,5 @@ IMAGE_FSTYPES ?= "wic wic.xz"
 IMAGER_INSTALL += "${GRUB_BOOTLOADER_INSTALL}"
 
 KERNEL_DEFCONFIG = "generic-x86-64_defconfig"
+
+WKS_FILE ?= "generic-x86-64.wks.in"

--- a/conf/machine/raspberrypi-64.inc
+++ b/conf/machine/raspberrypi-64.inc
@@ -11,7 +11,7 @@ DISTRO_APT_SOURCES:append = " conf/distro/emlinux-bookworm-full.list"
 
 # wic file settings
 IMAGE_FSTYPES ?= "wic wic.xz"
-WKS_FILE ?= "emlinux-rpi-sdimg"
+WKS_FILE ?= "emlinux-rpi-sdimg.wks.in"
 
 IMAGE_PREINSTALL += "\
   firmware-brcm80211 \

--- a/scripts/lib/wic/canned-wks/emlinux-rpi-sdimg.wks
+++ b/scripts/lib/wic/canned-wks/emlinux-rpi-sdimg.wks
@@ -1,5 +1,0 @@
-part /boot --source bootimg-partition --fstype=vfat --label boot --active --align 4096 --size 10 --use-uuid
-
-part / --source rootfs --fstype=ext4 --mkfs-extraopts "-T default" --label root --align 4096 --exclude-path=boot --use-uuid
-
-bootloader

--- a/scripts/lib/wic/canned-wks/emlinux-rpi-sdimg.wks.in
+++ b/scripts/lib/wic/canned-wks/emlinux-rpi-sdimg.wks.in
@@ -1,0 +1,5 @@
+part /boot --source bootimg-partition --fstype=vfat --label boot --active --align 4096 --size 10 --use-uuid
+
+part / --source rootfs --fstype=ext4 --mkfs-extraopts "-T default" --label root --align 4096 --size=${ROOTFS_EXTRA} --exclude-path=boot --use-uuid
+
+bootloader

--- a/scripts/lib/wic/canned-wks/generic-x86-64.wks.in
+++ b/scripts/lib/wic/canned-wks/generic-x86-64.wks.in
@@ -10,7 +10,7 @@
 #
 part /boot --source bootimg-efi-isar --sourceparams "loader=grub-efi" --label efi --part-type EF00 --align 1024
 
-part / --source rootfs --fstype ext4 --mkfs-extraopts "-T default" --label platform --align 1024 --use-uuid
+part / --source rootfs --fstype ext4 --mkfs-extraopts "-T default" --label platform --size=${ROOTFS_EXTRA} --align 1024 --use-uuid
 
 bootloader --ptable gpt --timeout 2 --append "console=ttyS0,115200 console=tty0"
 


### PR DESCRIPTION
# Purpose of pull request

For building wic image, add --size option to change rootfs size. When user sets rootfs extra space size by ROOTFS_EXTRA variable in conf/local.conf,  the --size option use user given size to create rootfs. If ROOTFS_EXTRA is not set, this mean --size 0. When 0 is passed to size option, it uses default size to enough size to install rootfs plus some space.
The ROOTFS_EXTRA variable is able to change rootfs size for qemu image so that this variable can change qemu image and wic image size.

The ROOTFS_EXTRA use Mega bytes as unit so adding 2 Giga bytes extra space  is following setting.

```
ROOTFS_EXTRA = "2048"
```

## Test result

ROOTFS_EXTRA is not set

```
-rw-r--r-- 1 build build 912M Nov 16 00:24 tmp/deploy/images/generic-x86-64/emlinux-image-base-emlinux-bookworm-generic-x86-64.wic
-rw-r--r-- 1 build build 324M Nov 16 00:20 tmp/deploy/images/qemu-amd64/emlinux-image-base-emlinux-bookworm-qemu-amd64.ext4
-rw-r--r-- 1 build build 482M Nov 16 00:34 tmp/deploy/images/raspberrypi3bplus-64/emlinux-image-base-emlinux-bookworm-raspberrypi3bplus-64.wic
-rw-r--r-- 1 build build 484M Nov 16 01:39 emlinux-image-base-emlinux-bookworm-raspberrypi4b-64.wic
```

ROOTFS_EXTRA = "2048"

```
-rw-r--r-- 1 build build 2.7G Nov 16 00:43 tmp/deploy/images/generic-x86-64/emlinux-image-base-emlinux-bookworm-generic-x86-64.wic
-rw-r--r-- 1 build build 2.3G Nov 16 00:40 tmp/deploy/images/qemu-amd64/emlinux-image-base-emlinux-bookworm-qemu-amd64.ext4
-rw-r--r-- 1 build build 2.7G Nov 16 00:49 tmp/deploy/images/raspberrypi3bplus-64/emlinux-image-base-emlinux-bookworm-raspberrypi3bplus-64.wic
-rw-r--r-- 1 build build 2.7G Nov 16 01:31 emlinux-image-base-emlinux-bookworm-raspberrypi4b-64.wic
```
