### PR TITLE
docker: Update base OS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ qemu-system-aarch64 \
  -device virtio-net-device,netdev=net0,mac=52:54:00:12:35:02 \
  -netdev user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::2323-:23,tftp=./tmp/deploy/images/qemuarm64 \
  -drive id=disk0,file=./tmp/deploy/images/qemu-arm64/emlinux-image-base-emlinux-bookworm-qemu-arm64.ext4,if=none,format=raw \
- -device virtio-blk-device,drive=disk0 -show-cursor -device VGA,edid=on \
+ -device virtio-blk-device,drive=disk0 -device VGA,edid=on \
  -device qemu-xhci \
  -device usb-tablet \
  -device usb-kbd \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 ARG uid
 ARG http_proxy
@@ -18,7 +18,6 @@ RUN apt-get install --fix-missing -y \
   parted \
   python3 \
   quilt \
-  qemu \
   qemu-system-x86 \
   qemu-system-arm \
   qemu-user-static \


### PR DESCRIPTION
# Purpose of pull request

Debian 12 has been released some months ago. So, use Debian 12 instead of old stable.

Building an image and a sdk both on qemu-arm64 and qemu-amd64 were successful. Also, qemu-system-x86_64 and qemu-system-aarch64 work fine.

