### PR TITLE
linux: linux-base: Add CVEs to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -25,6 +25,8 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2008-2544: It's false positive because the replication way is not proper.
 # CVE-2016-3699: It's false positive because it's not a mainline flaw.
 # CVE-1999-0524: This issue is that ICMP exists, can be filewalled if required.
+# CVE-2023-1076: It's false positive because 4.19.y is not affected.
+# CVE-2015-7312: It's false positive because aufs is not merged into mainline.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
@@ -32,5 +34,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2015-8955 CVE-2022-2327 CVE-2020-8834 \
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
     CVE-2007-4998 CVE-2008-2544 CVE-2016-3699 \
-    CVE-1999-0524 \
+    CVE-1999-0524 CVE-2023-1076 CVE-2015-7312 \
 "


### PR DESCRIPTION
This adds CVE-2023-1076 and CVE-2015-7312 to CVE_CHECK_WHITELIST.