### PR TITLE
cve-check: Backport the patches from Poky-dunfell

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -78,7 +78,7 @@ python cve_check_cleanup () {
 }
 
 addhandler cve_check_cleanup
-cve_check_cleanup[eventmask] = "bb.cooker.CookerExit"
+cve_check_cleanup[eventmask] = "bb.event.BuildCompleted"
 
 python cve_check_write_rootfs_manifest () {
     """
@@ -112,6 +112,7 @@ python cve_check_write_rootfs_manifest () {
 
 ROOTFS_POSTPROCESS_COMMAND_prepend = "${@'cve_check_write_rootfs_manifest; ' if d.getVar('CVE_CHECK_CREATE_MANIFEST') == '1' else ''}"
 do_rootfs[recrdeptask] += "${@'do_cve_check' if d.getVar('CVE_CHECK_CREATE_MANIFEST') == '1' else ''}"
+do_populate_sdk[recrdeptask] += "${@'do_cve_check' if d.getVar('CVE_CHECK_CREATE_MANIFEST') == '1' else ''}"
 
 def get_patches_cves(d):
     """
@@ -201,7 +202,8 @@ def check_cves(d, patched_cves):
             vendor = "%"
 
         # Find all relevant CVE IDs.
-        for cverow in conn.execute("SELECT DISTINCT ID FROM PRODUCTS WHERE PRODUCT IS ? AND VENDOR LIKE ?", (product, vendor)):
+        cve_cursor = conn.execute("SELECT DISTINCT ID FROM PRODUCTS WHERE PRODUCT IS ? AND VENDOR LIKE ?", (product, vendor))
+        for cverow in cve_cursor:
             cve = cverow[0]
 
             if cve in cve_whitelist:
@@ -214,7 +216,8 @@ def check_cves(d, patched_cves):
                 continue
 
             vulnerable = False
-            for row in conn.execute("SELECT * FROM PRODUCTS WHERE ID IS ? AND PRODUCT IS ? AND VENDOR LIKE ?", (cve, product, vendor)):
+            product_cursor = conn.execute("SELECT * FROM PRODUCTS WHERE ID IS ? AND PRODUCT IS ? AND VENDOR LIKE ?", (cve, product, vendor))
+            for row in product_cursor:
                 (_, _, _, version_start, operator_start, version_end, operator_end) = row
                 #bb.debug(2, "Evaluating row " + str(row))
 
@@ -252,11 +255,13 @@ def check_cves(d, patched_cves):
                     bb.note("%s-%s is vulnerable to %s" % (product, pv, cve))
                     cves_unpatched.append(cve)
                     break
+            product_cursor.close()
 
             if not vulnerable:
                 bb.note("%s-%s is not vulnerable to %s" % (product, pv, cve))
                 # TODO: not patched but not vulnerable
                 patched_cves.add(cve)
+        cve_cursor.close()
 
     conn.close()
 
@@ -273,14 +278,15 @@ def get_cve_info(d, cves):
     conn = sqlite3.connect(d.getVar("CVE_CHECK_DB_FILE"))
 
     for cve in cves:
-        for row in conn.execute("SELECT * FROM NVD WHERE ID IS ?", (cve,)):
+        cursor = conn.execute("SELECT * FROM NVD WHERE ID IS ?", (cve,))
+        for row in cursor:
             cve_data[row[0]] = {}
             cve_data[row[0]]["summary"] = row[1]
             cve_data[row[0]]["scorev2"] = row[2]
             cve_data[row[0]]["scorev3"] = row[3]
             cve_data[row[0]]["modified"] = row[4]
             cve_data[row[0]]["vector"] = row[5]
-
+        cursor.close()
     conn.close()
     return cve_data
 
@@ -291,7 +297,7 @@ def cve_write_data(d, patched, unpatched, cve_data):
     """
 
     cve_file = d.getVar("CVE_CHECK_LOG")
-    nvd_link = "https://web.nvd.nist.gov/view/vuln/detail?vulnId="
+    nvd_link = "https://nvd.nist.gov/vuln/detail/"
     write_string = ""
     unpatched_cves = []
     bb.utils.mkdirhier(os.path.dirname(cve_file))


### PR DESCRIPTION
# Purpose of pull request

Backport the patches fixed by Poky-dunfell.
- 555a75484d cve-check: update link to NVD website for CVE details
- 08fb6eb2e0 cve-check.bbclass: Added do_populate_sdk[recrdeptask].
- 1c38d0d3d6 cve-check: hook cleanup to the BuildCompleted event, not CookerExit
- 0bee2e95b7 cve-check: close cursors as soon as possible

# Test
## How to test
1. Build qemuarm64 image and do cve-check
   Add the following to local.conf and build qemuarm64 image.
   ```
   INHERIT += " cve-check debian-cve-check kernel-cve-check"
   EXTRA_IMAGE_FEATURES_append = " tools-sdk"
   BB_SERVER_TIMEOUT = "-1"
   ```
   ```
   $ bitbake core-image-weston
   ```

2. Check cve report URL
   Check the link URL is  `https://nvd.nist.gov/vuln/detail/`.
   ```
   $ tail ./tmp-glibc/deploy/images/qemuarm64/core-image-weston-qemuarm64.cve 
   ```

## Test result
### Build
Build succeeded.
```
$ bitbake core-image-weston
Parsing recipes: 100% |#################################################################################################| Time: 0:02:24
Parsing of 1362 .bb files complete (0 cached, 1362 parsed). 2382 targets, 80 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.8"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:c732ae02a4be26bf328da838f5481444fe44c1b5"
meta-debian-extended = "HEAD:6e885d4f6573fad165390bb8fcaa25b75b2659b0"
meta-emlinux         = "cve-check-add-patch-from-dunfell:4ca17d1c6cae1d472a8de38c203f79051876ebe1"
meta-emlinux-private = "HEAD:57280ae3191cc0bd391c6c71edcfe6ee5b0d2636"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:12
Sstate summary: Wanted 840 Found 0 Missed 840 Current 860 (0% match, 50% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: harfbuzz-native-2.3.1-r0 do_cve_check: Found unpatched CVE (CVE-2023-25193), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/harfbuzz-native/2.3.1-r0/temp/cve.log
WARNING: iptables-1.8.2-r0 do_cve_check: Found unpatched CVE (CVE-2019-11360), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/iptables/1.8.2-r0/temp/cve.log
WARNING: libcroco-native-0.6.12-r0 do_cve_check: Found unpatched CVE (CVE-2020-12825), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/libcroco-native/0.6.12-r0/temp/cve.log
WARNING: libcroco-0.6.12-r0 do_cve_check: Found unpatched CVE (CVE-2020-12825), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libcroco/0.6.12-r0/temp/cve.log
WARNING: libsndfile1-1.0.28-r0 do_cve_check: Found unpatched CVE (CVE-2022-33065), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libsndfile1/1.0.28-r0/temp/cve.log
WARNING: iproute2-4.20.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-20795), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/iproute2/4.20.0-r0/temp/cve.log
WARNING: procps-3.3.15-r0 do_cve_check: Found unpatched CVE (CVE-2018-1121 CVE-2023-4016), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/procps/3.3.15-r0/temp/cve.log
WARNING: unzip-6.0-r0 do_cve_check: Found unpatched CVE (CVE-2021-4217), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/unzip/6.0-r0/temp/cve.log
WARNING: mdadm-4.1-r0 do_cve_check: Found unpatched CVE (CVE-2023-28736 CVE-2023-28938), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/mdadm/4.1-r0/temp/cve.log
WARNING: tar-1.30-r0 do_cve_check: Found unpatched CVE (CVE-2019-9923 CVE-2021-20193 CVE-2022-48303), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/tar/1.30-r0/temp/cve.log
WARNING: ed-1.15-r0 do_cve_check: Found unpatched CVE (CVE-2015-2987), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/ed/1.15-r0/temp/cve.log
WARNING: patch-2.7.6-r0 do_cve_check: Found unpatched CVE (CVE-2019-20633), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/patch/2.7.6-r0/temp/cve.log
WARNING: gawk-4.2.1-r0 do_cve_check: Found unpatched CVE (CVE-2023-3164 CVE-2023-4156), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/gawk/4.2.1-r0/temp/cve.log
WARNING: zip-3.0-r0 do_cve_check: Found unpatched CVE (CVE-2018-13410 CVE-2018-13684), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/zip/3.0-r0/temp/cve.log
WARNING: flex-2.6.4-r0 do_cve_check: Found unpatched CVE (CVE-2015-1773 CVE-2019-6293), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/flex/2.6.4-r0/temp/cve.log
WARNING: bison-3.3.2-r0 do_cve_check: Found unpatched CVE (CVE-2020-14150), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/bison/3.3.2-r0/temp/cve.log
WARNING: librsvg-native-2.40.20-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000041 CVE-2019-20446 CVE-2023-38633), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/librsvg-native/2.40.20-r0/temp/cve.log
WARNING: sqlite3-3_3.27.2-r0 do_cve_check: Found unpatched CVE (CVE-2019-19645 CVE-2020-11656 CVE-2020-13631 CVE-2022-35737), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/sqlite3/3_3.27.2-r0/temp/cve.log
WARNING: libgcrypt-1.8.4-r0 do_cve_check: Found unpatched CVE (CVE-2021-33560), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libgcrypt/1.8.4-r0/temp/cve.log
WARNING: openssl-1.1.1n-r0 do_cve_check: Found unpatched CVE (CVE-2023-5678), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/openssl/1.1.1n-r0/temp/cve.log
WARNING: libidn2-2.0.5-r0 do_cve_check: Found unpatched CVE (CVE-2019-12290), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libidn2/2.0.5-r0/temp/cve.log
WARNING: re2c-native-1.1.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-21232), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/re2c-native/1.1.1-r0/temp/cve.log
WARNING: libpcre2-10.32-r0 do_cve_check: Found unpatched CVE (CVE-2022-41409), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libpcre2/10.32-r0/temp/cve.log
WARNING: libjpeg-turbo-native-1_1.5.2-r0 do_cve_check: Found unpatched CVE (CVE-2017-15232 CVE-2020-17541), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/libjpeg-turbo-native/1_1.5.2-r0/temp/cve.log
WARNING: libpng-native-1.6.36-r0 do_cve_check: Found unpatched CVE (CVE-2019-6129), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/libpng-native/1.6.36-r0/temp/cve.log
WARNING: libxml2-2.9.4-r0 do_cve_check: Found unpatched CVE (CVE-2016-3709 CVE-2016-9318 CVE-2017-16932 CVE-2023-45322), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libxml2/2.9.4-r0/temp/cve.log
WARNING: libpcre-8.39-r0 do_cve_check: Found unpatched CVE (CVE-2019-20838 CVE-2020-14155), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libpcre/8.39-r0/temp/cve.log
WARNING: harfbuzz-2.3.1-r0 do_cve_check: Found unpatched CVE (CVE-2023-25193), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/harfbuzz/2.3.1-r0/temp/cve.log
WARNING: libpcre-native-8.39-r0 do_cve_check: Found unpatched CVE (CVE-2019-20838 CVE-2020-14155), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/libpcre-native/8.39-r0/temp/cve.log
WARNING: ed-native-1.15-r0 do_cve_check: Found unpatched CVE (CVE-2015-2987), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/ed-native/1.15-r0/temp/cve.log
WARNING: gcc-source-8.3.0-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work-shared/gcc-8.3.0-r0/temp/cve.log
WARNING: flex-native-2.6.4-r0 do_cve_check: Found unpatched CVE (CVE-2015-1773 CVE-2019-6293), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/flex-native/2.6.4-r0/temp/cve.log
WARNING: nss-native-3.42.1-r0 do_cve_check: Found unpatched CVE (CVE-2006-5201), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/nss-native/3.42.1-r0/temp/cve.log
WARNING: gcc-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/gcc/8.3.0-r0/temp/cve.log
WARNING: libxslt-native-1.1.32-r0 do_cve_check: Found unpatched CVE (CVE-2022-29824), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/libxslt-native/1.1.32-r0/temp/cve.log
WARNING: libxml2-native-2.9.4-r0 do_cve_check: Found unpatched CVE (CVE-2016-3709 CVE-2016-9318 CVE-2017-16932 CVE-2023-45322), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/libxml2-native/2.9.4-r0/temp/cve.log
WARNING: util-linux-2.33.1-r0 do_cve_check: Found unpatched CVE (CVE-2021-37600 CVE-2022-0563), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/util-linux/2.33.1-r0/temp/cve.log
WARNING: binutils-2.31.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000876 CVE-2018-17358 CVE-2018-17359 CVE-2018-17360 CVE-2018-20623 CVE-2018-20651 CVE-2018-20657 CVE-2018-20671 CVE-2018-20673 CVE-2018-20712 CVE-2019-1010204 CVE-2020-19724 CVE-2020-21490 CVE-2020-35342 CVE-2020-35493 CVE-2020-35494 CVE-2020-35495 CVE-2020-35496 CVE-2020-35507 CVE-2021-20197 CVE-2021-45078 CVE-2021-46174 CVE-2022-38533 CVE-2022-44840 CVE-2022-45703 CVE-2022-47673 CVE-2022-47695 CVE-2022-47696 CVE-2022-48063 CVE-2022-48064 CVE-2022-48065 CVE-2023-25584), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/binutils/2.31.1-r0/temp/cve.log
WARNING: coreutils-8.30-r0 do_cve_check: Found unpatched CVE (CVE-2016-2781), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/coreutils/8.30-r0/temp/cve.log
WARNING: gcc-sanitizers-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/gcc-sanitizers/8.3.0-r0/temp/cve.log
WARNING: dropbear-2018.76-r0 do_cve_check: Found unpatched CVE (CVE-2020-36254), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/dropbear/2018.76-r0/temp/cve.log
WARNING: bash-5.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-18276), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/temp/cve.log
WARNING: bluez5-5.50-r0 do_cve_check: Found unpatched CVE (CVE-2020-24490), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/bluez5/5.50-r0/temp/cve.log
WARNING: avahi-0.7-r0 do_cve_check: Found unpatched CVE (CVE-2017-6519 CVE-2023-38469 CVE-2023-38470 CVE-2023-38471 CVE-2023-38472 CVE-2023-38473), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/avahi/0.7-r0/temp/cve.log
WARNING: wpa-supplicant-2.7+git20190128+0c1e29f-r0 do_cve_check: Found unpatched CVE (CVE-2022-23303 CVE-2022-23304), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/wpa-supplicant/2.7+git20190128+0c1e29f-r0/temp/cve.log
WARNING: libgcc-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libgcc/8.3.0-r0/temp/cve.log
WARNING: busybox-1.30.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000500 CVE-2021-42374 CVE-2021-42376 CVE-2021-42378 CVE-2021-42379 CVE-2021-42380 CVE-2021-42381 CVE-2021-42382 CVE-2021-42384 CVE-2021-42385 CVE-2021-42386 CVE-2022-28391 CVE-2022-48174 CVE-2023-39810), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/busybox/1.30.1-r0/temp/cve.log
WARNING: pixman-native-0.36.0-r0 do_cve_check: Found unpatched CVE (CVE-2023-37769), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/pixman-native/0.36.0-r0/temp/cve.log
WARNING: lz4-1_1.8.3-0 do_cve_check: Found unpatched CVE (CVE-2019-17543), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/lz4/1_1.8.3-0/temp/cve.log
WARNING: cmake-native-3.13.4-r0 do_cve_check: Found unpatched CVE (CVE-2016-10642), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/cmake-native/3.13.4-r0/temp/cve.log
WARNING: openssl-native-1.1.1n-r0 do_cve_check: Found unpatched CVE (CVE-2023-5678), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/openssl-native/1.1.1n-r0/temp/cve.log
WARNING: curl-7.64.0-r1 do_cve_check: Found unpatched CVE (CVE-2013-2617 CVE-2021-22922 CVE-2021-22923 CVE-2021-22926 CVE-2023-27534 CVE-2023-28320 CVE-2023-28322 CVE-2023-46218), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/curl/7.64.0-r1/temp/cve.log
WARNING: zlib-1.2.11-r0 do_cve_check: Found unpatched CVE (CVE-2023-45853), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/zlib/1.2.11-r0/temp/cve.log
WARNING: perl-5.28.1-r1 do_cve_check: Found unpatched CVE (CVE-2023-31484 CVE-2023-31486), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/perl/5.28.1-r1/temp/cve.log
WARNING: libpng-1.6.36-r0 do_cve_check: Found unpatched CVE (CVE-2019-6129), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libpng/1.6.36-r0/temp/cve.log
WARNING: wayland-1.16.0-r0 do_cve_check: Found unpatched CVE (CVE-2021-3782), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/wayland/1.16.0-r0/temp/cve.log
WARNING: wayland-native-1.16.0-r0 do_cve_check: Found unpatched CVE (CVE-2021-3782), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/wayland-native/1.16.0-r0/temp/cve.log
WARNING: pixman-0.36.0-r0 do_cve_check: Found unpatched CVE (CVE-2023-37769), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/pixman/0.36.0-r0/temp/cve.log
WARNING: libjpeg-turbo-1_1.5.2-r0 do_cve_check: Found unpatched CVE (CVE-2017-15232 CVE-2020-17541), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libjpeg-turbo/1_1.5.2-r0/temp/cve.log
WARNING: glib-2.0-2.58.3-r0 do_cve_check: Found unpatched CVE (CVE-2020-35457), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/glib-2.0/2.58.3-r0/temp/cve.log
WARNING: shadow-4.5-r0 do_cve_check: Found unpatched CVE (CVE-2013-4235 CVE-2018-7169), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/shadow/4.5-r0/temp/cve.log
WARNING: systemd-1_241-r0 do_cve_check: Found unpatched CVE (CVE-2019-20386 CVE-2019-3843 CVE-2019-3844 CVE-2021-3997), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/systemd/1_241-r0/temp/cve.log
WARNING: libinput-1.12.6-r0 do_cve_check: Found unpatched CVE (CVE-2022-1215), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libinput/1.12.6-r0/temp/cve.log
WARNING: shadow-native-4.5-r0 do_cve_check: Found unpatched CVE (CVE-2013-4235 CVE-2018-7169), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/shadow-native/4.5-r0/temp/cve.log
WARNING: gcc-runtime-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/gcc-runtime/8.3.0-r0/temp/cve.log
WARNING: util-linux-native-2.33.1-r0 do_cve_check: Found unpatched CVE (CVE-2021-37600 CVE-2022-0563), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/util-linux-native/2.33.1-r0/temp/cve.log
WARNING: glib-2.0-native-2.58.3-r0 do_cve_check: Found unpatched CVE (CVE-2020-35457), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/glib-2.0-native/2.58.3-r0/temp/cve.log
WARNING: curl-native-7.64.0-r1 do_cve_check: Found unpatched CVE (CVE-2013-2617 CVE-2021-22922 CVE-2021-22923 CVE-2021-22926 CVE-2023-27534 CVE-2023-28320 CVE-2023-28322 CVE-2023-46218), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/curl-native/7.64.0-r1/temp/cve.log
WARNING: zlib-native-1.2.11-r0 do_cve_check: Found unpatched CVE (CVE-2023-45853), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/zlib-native/1.2.11-r0/temp/cve.log
WARNING: perl-native-5.28.1-r1 do_cve_check: Found unpatched CVE (CVE-2023-31484 CVE-2023-31486), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/perl-native/5.28.1-r1/temp/cve.log
WARNING: binutils-native-2.31.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000876 CVE-2018-17358 CVE-2018-17359 CVE-2018-17360 CVE-2018-20623 CVE-2018-20651 CVE-2018-20657 CVE-2018-20671 CVE-2018-20673 CVE-2018-20712 CVE-2019-1010204 CVE-2020-19724 CVE-2020-21490 CVE-2020-35342 CVE-2020-35493 CVE-2020-35494 CVE-2020-35495 CVE-2020-35496 CVE-2020-35507 CVE-2021-20197 CVE-2021-45078 CVE-2021-46174 CVE-2022-38533 CVE-2022-44840 CVE-2022-45703 CVE-2022-47673 CVE-2022-47695 CVE-2022-47696 CVE-2022-48063 CVE-2022-48064 CVE-2022-48065 CVE-2023-25584), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/binutils-native/2.31.1-r0/temp/cve.log
WARNING: gcc-cross-aarch64-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/gcc-cross-aarch64/8.3.0-r0/temp/cve.log
WARNING: bison-native-3.3.2-r0 do_cve_check: Found unpatched CVE (CVE-2020-14150), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/bison-native/3.3.2-r0/temp/cve.log
WARNING: binutils-cross-aarch64-2.31.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000876 CVE-2018-17358 CVE-2018-17359 CVE-2018-17360 CVE-2018-20623 CVE-2018-20651 CVE-2018-20657 CVE-2018-20671 CVE-2018-20673 CVE-2018-20712 CVE-2019-1010204 CVE-2020-19724 CVE-2020-21490 CVE-2020-35342 CVE-2020-35493 CVE-2020-35494 CVE-2020-35495 CVE-2020-35496 CVE-2020-35507 CVE-2021-20197 CVE-2021-45078 CVE-2021-46174 CVE-2022-38533 CVE-2022-44840 CVE-2022-45703 CVE-2022-47673 CVE-2022-47695 CVE-2022-47696 CVE-2022-48063 CVE-2022-48064 CVE-2022-48065 CVE-2023-25584), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/binutils-cross-aarch64/2.31.1-r0/temp/cve.log
WARNING: rpm-native-4.14.2.1-r0 do_cve_check: Found unpatched CVE (CVE-2021-20266 CVE-2021-3421 CVE-2021-3521 CVE-2021-35937 CVE-2021-35938 CVE-2021-35939), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/rpm-native/4.14.2.1-r0/temp/cve.log
WARNING: glibc-2.28-r0 do_cve_check: Found unpatched CVE (CVE-2010-4756 CVE-2018-20796 CVE-2019-1010022 CVE-2019-1010023 CVE-2019-1010024 CVE-2019-1010025 CVE-2019-9192 CVE-2020-1751 CVE-2023-4813), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/glibc/2.28-r0/temp/cve.log
WARNING: sqlite3-native-3_3.27.2-r0 do_cve_check: Found unpatched CVE (CVE-2019-19645 CVE-2020-11656 CVE-2020-13631 CVE-2022-35737), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/sqlite3-native/3_3.27.2-r0/temp/cve.log
WARNING: apt-native-1.2.24-r0 do_cve_check: Found unpatched CVE (CVE-2020-3810), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/apt-native/1.2.24-r0/temp/cve.log
WARNING: libgcc-initial-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/aarch64-emlinux-linux/libgcc-initial/8.3.0-r0/temp/cve.log
WARNING: qemu-native-3.1-r0 do_cve_check: Found unpatched CVE (CVE-2007-0998 CVE-2018-20123 CVE-2018-20124 CVE-2018-20125 CVE-2018-20126 CVE-2018-20191 CVE-2018-20216 CVE-2019-12067 CVE-2019-12928 CVE-2019-12929 CVE-2019-20175 CVE-2019-8934 CVE-2020-25742 CVE-2020-25743 CVE-2020-35503 CVE-2021-20255 CVE-2021-3750 CVE-2022-36648 CVE-2022-3872 CVE-2022-4144 CVE-2023-1386 CVE-2023-1544 CVE-2023-2861 CVE-2023-3019 CVE-2023-3354 CVE-2023-42467 CVE-2023-5088), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/qemu-native/3.1-r0/temp/cve.log
WARNING: qemu-system-native-3.1-r0 do_cve_check: Found unpatched CVE (CVE-2007-0998 CVE-2018-20123 CVE-2018-20124 CVE-2018-20125 CVE-2018-20126 CVE-2018-20191 CVE-2018-20216 CVE-2019-12067 CVE-2019-12928 CVE-2019-12929 CVE-2019-20175 CVE-2019-8934 CVE-2020-25742 CVE-2020-25743 CVE-2020-35503 CVE-2021-20255 CVE-2021-3750 CVE-2022-36648 CVE-2022-3872 CVE-2022-4144 CVE-2023-1386 CVE-2023-1544 CVE-2023-2861 CVE-2023-3019 CVE-2023-3354 CVE-2023-42467 CVE-2023-5088), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/x86_64-linux/qemu-system-native/3.1-r0/temp/cve.log
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-1999-0656 CVE-2006-2932 CVE-2008-4609 CVE-2010-4563 CVE-2010-5321 CVE-2015-2877 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-14899 CVE-2019-16089 CVE-2019-19083 CVE-2019-20794 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-27820 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2020-36691 CVE-2020-36766 CVE-2021-32078 CVE-2021-3669 CVE-2021-3714 CVE-2021-3759 CVE-2021-3773 CVE-2021-3847 CVE-2021-3864 CVE-2021-3923 CVE-2021-4037 CVE-2022-0400 CVE-2022-0480 CVE-2022-1015 CVE-2022-1247 CVE-2022-25265 CVE-2022-2961 CVE-2022-3108 CVE-2022-3303 CVE-2022-3344 CVE-2022-3523 CVE-2022-3566 CVE-2022-3567 CVE-2022-36402 CVE-2022-39189 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-4543 CVE-2022-45884 CVE-2022-45885 CVE-2022-47520 CVE-2023-0590 CVE-2023-1249 CVE-2023-1476 CVE-2023-1582 CVE-2023-1611 CVE-2023-2124 CVE-2023-2177 CVE-2023-23000 CVE-2023-23039 CVE-2023-26242 CVE-2023-28466 CVE-2023-33288 CVE-2023-3397 CVE-2023-35827 CVE-2023-3640 CVE-2023-37453 CVE-2023-37454 CVE-2023-3863 CVE-2023-39198 CVE-2023-4010 CVE-2023-4133 CVE-2023-4244 CVE-2023-4622 CVE-2023-47233 CVE-2023-6606 CVE-2023-6610), for more information check /project/security-update/emlinux-test1/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
Image CVE report stored in: /project/security-update/emlinux-test1/build/tmp-glibc/deploy/images/qemuarm64/core-image-weston-qemuarm64-20231225045146.rootfs.cve
NOTE: Tasks Summary: Attempted 5921 tasks of which 2834 didn't need to be rerun and all succeeded.

Summary: There were 82 WARNING messages shown.
```

### Check cve report URL
The link URL is correct.
```
$ tail ./tmp-glibc/deploy/images/qemuarm64/core-image-weston-qemuarm64.cve 
The function nft_pipapo_walk did not skip inactive elements during set walk which could lead double deactivations of PIPAPO (Pile Packet Policies) elements, leading to use-after-free.

We recommend upgrading past commit 317eb9685095678f2c9f5a8189de698c5354316a.


CVSS v2 BASE SCORE: 0.0
CVSS v3 BASE SCORE: 7.8
VECTOR: LOCAL
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2023-6817
```
