### PR TITLE
cve-update-nvd2-native: Backport patche from Poky-master

### DIFF
--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -187,6 +187,11 @@ def update_db_file(db_tmp_file, d, database_time):
         url = d.getVar("NVDCVE_URL")
         api_key = d.getVar("NVDCVE_API_KEY") or None
 
+        # Recommended by NVD
+        wait_time = 6
+        if api_key:
+            wait_time = 2
+
         while True:
             req_args['startIndex'] = index
             raw_data = nvd_request_next(url, api_key, req_args)
@@ -208,7 +213,7 @@ def update_db_file(db_tmp_file, d, database_time):
                break
 
             # Recommended by NVD
-            time.sleep(6)
+            time.sleep(wait_time)
 
         # Update success, set the date to cve_check file.
         cve_f.write('CVE database update : %s\n\n' % datetime.date.today())


### PR DESCRIPTION
# Purpose of pull request
Backport from Poky-dunfell rev: ef371d1cb3b777d64b73d819b745f8ae8814017c  

```
cve-update-nvd2-native: faster requests with API keys

    As per NVD, the public rate limit is 5 requests in 30s (6s delay).
    Using an API key increases the limit to 50 requests in 30s (0.6s delay).
    However, NVD still recommends sleeping for several seconds so that the
    other legitimate requests are serviced without denial or interruption.
    Keeping the default sleep at 6 seconds and 2 seconds with an API key.

    For failures, the wait time is unchanged (6 seconds).

    Reference: https://nvd.nist.gov/developers/start-here#RateLimits
```

# Test
## How to test
1. Configuring the local.conf file
   Add the following to local.conf.
   ```
   INHERIT += " cve-check debian-cve-check kernel-cve-check"
   NVDCVE_API_KEY="<api-key>"
   ```
2. Run command for create CVE database file
   ```
   $ rm ../downloads/CVE_CHECK/nvdcve_2.db
   $ time bitbake cve-update-nvd2-native -c do_populate_cve_db
   ```

## Test result
CVE database creation time has been reduced.
- Before this patch: `24m59.217s`
- After this patch:  `17m24.089s`
- Reduced time: `7m35.128s`

```
$ time bitbake cve-update-nvd2-native -c do_populate_cve_db
Loading cache: 100% |###################################################################################################| Time: 0:00:00
Loaded 2384 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux-k510"
DISTRO_VERSION       = "2.8"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:1a52e264d5434fd23f907f6d01d3458f5512a595"
meta-debian-extended = "HEAD:e2553f2641c01487d5f8bf0d91d5baadd983b5c5"
meta-emlinux         = "faster-requests-with-api-keys:95cc28b4a7d2e39d97263174cf64c561f7a461a6"
meta-emlinux-private = "HEAD:57280ae3191cc0bd391c6c71edcfe6ee5b0d2636"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1 tasks of which 0 didn't need to be rerun and all succeeded.

real	17m24.089s
user	0m1.104s
sys	0m0.156s
```
