### PR TITLE
Convert WIC_IMAGER_INSTALL to IMAGER_INSTALL:wic

### DIFF
--- a/conf/distro/emlinux-common.inc
+++ b/conf/distro/emlinux-common.inc
@@ -18,7 +18,7 @@ KERNEL_NAME ?= "cip"
 
 DISTRO_APT_SOURCES = "conf/distro/emlinux-bookworm.list"
 
-WIC_IMAGER_INSTALL = "parted \
+IMAGER_INSTALL:wic = "parted \
   gdisk \
   util-linux \
   dosfstools \

--- a/conf/machine/raspberrypi-64.inc
+++ b/conf/machine/raspberrypi-64.inc
@@ -22,7 +22,7 @@ IMAGE_INSTALL += "\
   raspberrypi-bootfiles \
 "
 
-WIC_IMAGER_INSTALL = "\
+IMAGER_INSTALL:wic = "\
   parted \
   dosfstools \
   mtools \


### PR DESCRIPTION
WIC_IMAGER_INSTALL has been deprecated in Isar.