### PR TITLE
Add missing SRCREV updates to v6.1.67-cip12

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_git.bb
+++ b/recipes-kernel/linux/linux-cip-rt_git.bb
@@ -23,6 +23,6 @@ SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
-SRCREV = "65bd536c294e2f5356dabd805e63516e90d72628"
+SRCREV = "38253b8903b46da162814048c6f555bba4399ca8"
 
 KBUILD_DEPENDS:append = ", zstd"

--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -26,6 +26,6 @@ SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
-SRCREV = "5ae5d9581f44f65bc79fe7323153483f8f02a1ea"
+SRCREV = "33a81955d654c80f6f9626f5bd3def02b8e85b3a"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Updating SRCREV to v6.1.67-cip12 for the standard and RT CIP kernels was missed in the previous kernel update.