### PR TITLE
Add CVEs to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -27,6 +27,9 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-1999-0524: This issue is that ICMP exists, can be filewalled if required.
 # CVE-2023-1076: It's false positive because 4.19.y is not affected.
 # CVE-2015-7312: It's false positive because aufs is not merged into mainline.
+# CVE-1999-0656: This issue is that specific to ugidd, part of the old user-mode NFS server.
+# CVE-2006-2932: Specific to RHEL. 4.19.y is not affected.
+# CVE-2023-1476: Specific to RHEL. 4.19.y is not affected.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
@@ -35,4 +38,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
     CVE-2007-4998 CVE-2008-2544 CVE-2016-3699 \
     CVE-1999-0524 CVE-2023-1076 CVE-2015-7312 \
+    CVE-1999-0656 CVE-2006-2932 CVE-2023-1476 \
 "

--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -39,9 +39,13 @@ do_shared_workdir_prepend () {
 # CVE-2008-2544: It's false positive because the replication way is not proper.
 # CVE-2016-3699: It's false positive because it's not a mainline flaw.
 # CVE-1999-0524: This issue is that ICMP exists, can be filewalled if required.
+# CVE-1999-0656: This issue is that specific to ugidd, part of the old user-mode NFS server.
+# CVE-2006-2932: Specific to RHEL. 5.10.y is not affected.
+# CVE-2023-1476: Specific to RHEL. 5.10.y is not affected.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-43057 CVE-2015-8955 CVE-2020-8834 \
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
     CVE-2007-4998 CVE-2008-2544 CVE-2016-3699 \
-    CVE-1999-0524 \
+    CVE-1999-0524 CVE-1999-0656 CVE-2006-2932 \
+    CVE-2023-1476 \
 "


### PR DESCRIPTION
Add the following CVEs to CVE_CHECK_WHITELIST for linux-base and linux-k510.
- https://nvd.nist.gov/vuln/detail/CVE-1999-0656
- https://nvd.nist.gov/vuln/detail/CVE-2006-2932
- https://nvd.nist.gov/vuln/detail/CVE-2023-1476
