### PR TITLE
Update kernel to v6.1.72-cip13

### DIFF
--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.67-cip12"
-PV = "6.1.67-cip12"
+LINUX_CIP_VERSION = "v6.1.72-cip13"
+PV = "6.1.72-cip13"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip;destsuffix=${P};protocol=https \
 "
@@ -26,6 +26,6 @@ SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
-SRCREV = "33a81955d654c80f6f9626f5bd3def02b8e85b3a"
+SRCREV = "847d28968b6f4ca12f696d32771f7309efb14c83"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
This change updates the standard CIP kernel version to v6.1.72-cip13. The RT kernel stays the same version because it has not been updated in upstream since the previous EMLinux release.
