### PR TITLE
Add SBOM creation tool

### DIFF
--- a/conf/licenses/license-mapping.yml
+++ b/conf/licenses/license-mapping.yml
@@ -1,0 +1,105 @@
+# https://scancode-licensedb.aboutcode.org/
+
+# Apache
+"Apache-2": "Apache-2.0"
+
+# Artistic
+"Artistic-1": "Artistic-1.0"
+"Artistic-dist": "LicenseRef-scancode-artistic-1988-1.0"
+
+# Autoconf exception
+"GPL-2.0-or-later WITH Autoconf-exception": "Autoconf-exception-2.0"
+"GPL-3.0-or-later WITH Autoconf-exception": "Autoconf-exception-3.0"
+"GPL-3 WITH automake-exception": "Autoconf-exception-3.0"
+
+# BSL
+"BSL-1": "BSL-1.0"
+
+# BSD
+"BSLA": "BSD-4.3TAHOE"
+
+# BZIP
+"BZIP": "bzip2-1.0.6"
+"BZIP2": "bzip2-1.0.6"
+
+# CC
+"CC0": "CC0-1.0"
+
+# FSF
+"FSF-unlimited": "FSFULLRWD"
+"FSF-unlimited-permission": "FSFULLR"
+
+# GFDL
+"GFDL-1.1": "GFDL-1.1-only"
+"GFDL-1.1+": "GFDL-1.1-or-later"
+"GFDL-1.2": "GFDL-1.2-only"
+"GFDL-1.2+": "GFDL-1.2-or-later"
+"GFDL-1.3": "GFDL-1.3-only"
+"GFDL-1.3+": "GFDL-1.3-or-later"
+"GFDL-NIV": "GFDL-1.1-no-invariants-only"
+"GFDL-NIV-1.3": "GFDL-1.3-no-invariants-only"
+"GFDL-NIV-1.3+": "GFDL-1.3-no-invariants-or-later"
+"GFDL-1.3+-no-invariant": "GFDL-1.3-no-invariants-or-later"
+
+# GPL 1
+"GPL-1": "GPL-1.0-only"
+"GPL-1+": "GPL-1.0-or-later"
+
+# GPL 2
+"GPL-2": "GPL-2.0-only"
+"GPL-2+": "GPL-2.0-or-later"
+
+# GLP3
+"GPL-3": "GPL-3.0-only"
+"GPL-3+": "GPL-3.0-or-later"
+
+# GPL with Autoconf exception
+"GPL-2+ with Autoconf exception": "Autoconf-exception-2.0"
+
+# GPL with libtool exception
+"GPL-2+ with Libtool exception": "Libtool-exception"
+
+# GPL with OpenSSL exception
+"GPL-2+ WITH OpenSSL exception": "LicenseRef-scancode-openssl-exception-gpl-2.0-plus"
+
+# LGPL
+"LGPL-2": "LGPL-2.0-only"
+"LGPL-2+": "LGPL-2.0-or-later"
+"LGPL-2.1": "LGPL-2.1-only"
+"LGPL-2.1+": "LGPL-2.1-or-later"
+"LGPL-3": "LGPL-3.0-only"
+"LGPL-3+": "LGPL-3.0-or-later"
+
+# OpenLdap
+"OpenLDAP-2.0": "OLDAP-2.0"
+"OpenLDAP-2.1": "OLDAP-2.1"
+"OpenLDAP-2.2": "OLDAP-2.2"
+"OpenLDAP-2.3": "OLDAP-2.3"
+"OpenLDAP-2.4": "OLDAP-2.4"
+"OpenLDAP-2.5": "OLDAP-2.5"
+"OpenLDAP-2.6": "OLDAP-2.6"
+"OpenLDAP-2.7": "OLDAP-2.7"
+"OpenLDAP-2.8": "OLDAP-2.8"
+
+
+# pcre
+"pcre": "LicenseRef-scancode-pcre"
+
+# permissive
+"permissive-fsf": "FSFULLR"
+
+# public domain
+"public-domain": "LicenseRef-scancode-public-domain"
+"Public-Domain": "LicenseRef-scancode-public-domain"
+"PD": "LicenseRef-scancode-public-domain"
+"PD-debian": "LicenseRef-scancode-public-domain"
+
+# SMAIL-GPL
+"SMAIL-GPL": "LicenseRef-scancode-smail-gpl"
+
+# Unicode
+"Unicode": "LicenseRef-scancode-unicode"
+
+# Misc
+"Linux-syscall-note-exception": "Linux-syscall-note"
+

--- a/conf/licenses/licenses.yml
+++ b/conf/licenses/licenses.yml
@@ -1,0 +1,183 @@
+# format
+# debian binary package name:
+#   licenses: [
+#     "LICENSE A",
+#     "LICENSE B"
+#   ]
+base-files:
+  licenses: [
+    GPL-3,
+  ]
+debian-archive-keyring:
+  licenses: [
+    GPL-3,
+  ]
+emlinux-customization:
+  licenses: [
+    MIT,
+  ]
+gcc-12-base:
+  licenses: [
+    Artistic,
+    GFDL-1.2,
+    GPL,
+    GPL-2,
+    GPL-3,
+    LGPL
+  ]
+initramfs-tools:
+  licenses: [
+    GPL-2
+  ]
+initramfs-tools-core:
+  licenses: [
+    GPL-2
+  ]
+klibc-utils:
+  licenses: [
+    GPL-2
+  ]
+libasound2:
+  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1061276
+  licenses: [
+    LGPL-2.1+,
+  ]
+libasound2-data:
+  # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1061276
+  licenses: [
+    LGPL-2.1+,
+  ]
+libc-bin:
+  licenses: [
+    GPL-2,
+    LGPL-2.1
+  ]
+libc-l10n:
+  licenses: [
+    GPL-2,
+    LGPL-2.1
+  ]
+libc6:
+  licenses: [
+    GPL-2,
+    LGPL-2.1
+  ]
+libcairo-gobject2:
+  licenses: [
+    MPL-1.1,
+    LGPL-2.1-only,
+  ]
+libcairo2:
+  licenses: [
+    MPL-1.1,
+    LGPL-2.1-only,
+  ]
+libcrypt1:
+  licenses: [
+    public-domain
+  ]
+libgcc-s1:
+  licenses: [
+    Artistic,
+    GFDL-1.2,
+    GPL,
+    GPL-2,
+    GPL-3,
+    LGPL
+  ]
+libgcrypt20:
+  licenses: [
+    GPL-2,
+    LGPL
+  ]
+libgnutls30:
+  licenses: [
+    Apache-2.0,
+    GFDL-1.3,
+    GPL,
+    GPL-3,
+    LGPL,
+    LGPL-3
+  ]
+libgomp1:
+  licenses: [
+    GPL-3+,
+    gcc-exception-3.1,
+  ]
+libgssapi-krb5-2:
+  licenses: [
+    GPL-2
+  ]
+libk5crypto3:
+  licenses: [
+    GPL-2
+  ]
+libklibc:
+  licenses: [
+    GPL-2
+  ]
+libkrb5-3:
+  licenses: [
+    GPL-2
+  ]
+libkrb5support0:
+  licenses: [
+    GPL-2
+  ]
+libksba8:
+  licenses: [
+    GPL-3
+  ]
+linux-image-cip:
+  licenses: [
+    GPL-2
+  ]
+linux-image-cip-rt:
+  licenses: [
+    GPL-2
+  ]
+libselinux1:
+  licenses: [
+    GPL-2,
+    LGPL-2.1
+  ]
+libsemanage-common:
+  licenses: [
+    GPL,
+    LGPL
+  ]
+libsemanage2:
+  licenses: [
+    GPL,
+    LGPL
+  ]
+libstdc++6:
+  licenses: [
+    Artistic,
+    GFDL-1.2,
+    GPL,
+    GPL-2,
+    GPL-3,
+    LGPL
+  ]
+libtasn1-6:
+  licenses: [
+    LGPL-2.1,
+    GPL-3,
+    GFDL-1.3
+  ]
+libpangocairo-1.0-0:
+  licenses: [
+    MPL-1.1,
+    LGPL-2.1-only,
+  ]
+locales:
+  licenses: [
+    LGPL-2.1,
+    GPL-2
+  ]
+weston-init:
+  licenses: [
+    MIT,
+  ]
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get install --fix-missing -y \
   python3-distutils \
   python3-yaml \
   python3-html5lib \
+  python3-pip \
   vim \
   screen \
   socat \
@@ -67,6 +68,10 @@ RUN bash -c 'if test -n "$http_proxy"; then git config --global http.proxy "$htt
                                             git config --global core.gitproxy gitproxy; fi'
 RUN bash -c 'if test -n "$https_proxy"; then git config --global https.proxy "$https_proxy"; fi'
 RUN bash -c 'if test -n "$no_proxy"; then git config --global core.noproxy "$no_proxy"; fi'
+
+RUN pip install --user pip install cyclonedx-python-lib --break-system-packages
+RUN pip install --user pip install jsonschema --break-system-packages
+RUN pip install --user spdx-tools --break-system-packages
 
 RUN mkdir work
 WORKDIR /home/build/work

--- a/scripts/create_sbom.py
+++ b/scripts/create_sbom.py
@@ -1,0 +1,239 @@
+#!/usr/bin/python3
+
+import argparse
+import sys
+import os, os.path
+import io
+from debian import copyright
+import debian.debfile
+import json
+import yaml
+import glob
+import hashlib
+
+sys.path.append(os.path.join(os.path.dirname(__file__), 'lib/python'))
+sys.path.append(os.path.join(os.path.dirname(__file__), 'lib/python/sbom'))
+
+import logging
+logging.basicConfig(level = logging.INFO, format='%(asctime)s:%(levelname)s: %(message)s')
+logger = logging.getLogger("emlinux-sbom-creator")
+
+import bitbake_runner
+import sbom_cyclonedx
+import sbom_spdx
+
+# Only show critical error from debian copyright library
+copyright.logger.setLevel(logging.CRITICAL)
+
+def merge_package_data(installed_pkgs, packages_info):
+    for pkg in installed_pkgs:
+        if pkg in packages_info:
+            installed_pkgs[pkg]["sha256sum"] = packages_info[pkg]["sha256sum"]
+            installed_pkgs[pkg]["description"] = packages_info[pkg]["description"]
+
+    return installed_pkgs
+
+def find_deb_packages(dl_dir, repo_isar_dir, distro, image_distro):
+    targets  = [
+        f"{dl_dir}/deb/debian-{distro}/*.deb",
+        f"{repo_isar_dir}/{image_distro}/pool/**/*.deb",
+    ]
+
+    ret = []
+
+    for target in targets:
+        ret += glob.glob(target, recursive=True)
+
+    return ret
+
+def get_package_info_from_control(dl_dir, repo_isar_dir, distro, image_distro, distro_arch):
+    ret = {}
+
+    debs = find_deb_packages(dl_dir, repo_isar_dir, distro, image_distro)
+    for debfile in debs:
+        pkgname = None
+        with debian.debfile.DebFile(debfile) as deb:
+            control = deb.debcontrol()
+            pkgname = control.get("Package", "Unkown")
+            arch = control.get('Architecture', 'Unknown')
+            desc = control.get("Description", "")
+
+            if arch == distro_arch or arch == "all":
+                sha256sum = None
+                sha256hash = hashlib.sha256()
+                with open(debfile, "rb") as f:
+                    for block in iter(lambda: f.read(4096), b""):
+                        sha256hash.update(block)
+                        sha256sum = sha256hash.hexdigest()
+                ret[pkgname] = {
+                        "sha256sum": sha256sum,
+                        "description": desc,
+                }
+
+    return ret
+
+def parse_copyright_file(copyright_file):
+    licenses = []
+
+    with io.open(copyright_file, "rt", encoding='utf-8') as f:
+        try:
+            c = copyright.Copyright(f, strict=False)
+        except Exception as e:
+            logger.debug(f"Read copyright file error for {copyright_file}")
+            licenses.append("unknown")
+        else:
+            for p in c.all_files_paragraphs():
+                files = " ".join(p.files)
+                if p.license:
+                    licenses.append(p.license.synopsis)
+                else:
+                    if not "unkown" in licenses:
+                        licenses.append("unkown")
+
+    return sorted(licenses)
+
+def parse_dpkg_status(dpkgstatus):
+    ret = {}
+
+    with open(dpkgstatus, "r") as f:
+        lines = f.readlines()
+        d = {}
+        for line in lines:
+            line = line.strip()
+            if line.startswith("Package:"):
+                d["package"] = line.split(":")[1].strip()
+            elif line.startswith("Source:"):
+                # some package contain version number so remove it.
+                # util-linux (2.38.1-5)
+                d["source"] = line.split(":")[1].strip().split(" ")[0].strip()
+            elif line.startswith("Version:"):
+                d["version"] = line.split(" ")[1].strip()
+            elif line.startswith("Maintainer:"):
+                d["maintainer"] = " ".join(line.split(" ")[1:]).strip()
+            elif line.startswith("Section:"):
+                d["section"] = line.split(":")[1].strip()
+            elif line.startswith("Homepage:"):
+                d["homepage"] = "".join(line.split(":")[1:]).strip()
+            elif line.startswith("Architecture:"):
+                d["arch"] = line.split(":")[1].strip()
+            elif len(line) == 0:
+                if not "source" in d:
+                    # If source is not found in data, source package name should
+                    # be same as binary package name
+                    d["source"] = d["package"]
+
+                ret[d["package"]] = d
+                d = {}
+
+    return ret
+
+def find_copyright_files(rootfs, installed_pkgs, user_defined_licenses):
+    
+    for pkg in installed_pkgs:
+        if pkg in user_defined_licenses:
+            installed_pkgs[pkg]["licenses"] = user_defined_licenses[pkg]["licenses"]
+        else:
+            path = f"{rootfs}/usr/share/doc/{installed_pkgs[pkg]['package']}/copyright"
+
+            if os.path.exists(path):
+                installed_pkgs[pkg]["licenses"] = parse_copyright_file(path)
+            else:
+                installed_pkgs[pkg]["licenses"] = ["unkown"]
+
+def read_user_defined_license_file(user_defined_licenses):
+    name = os.path.join(os.path.dirname(__file__), "../conf/licenses/licenses.yml")
+
+    data = None
+    with open(name, "r") as f:
+        data = yaml.safe_load(f)
+
+    if user_defined_licenses:
+        with open(user_defined_licenses, "r") as f:
+            tmp = yaml.safe_load(f)
+            if tmp:
+                data.update(tmp)
+
+    return data
+
+def read_license_mapping_file(user_defined_license_mapping):
+    name = os.path.join(os.path.dirname(__file__), "../conf/licenses/license-mapping.yml")
+    data = None
+    with open(name, "r") as f:
+        data = yaml.safe_load(f)
+
+    if user_defined_license_mapping:
+        with open(user_defined_license_mapping, "r") as f:
+            tmp = yaml.safe_load(f)
+            if tmp:
+                data.update(tmp)
+    return data
+
+def write_sbom_json(output_filepath, sbom_data):
+
+    with open(output_filepath, "w") as f:
+        json.dump(sbom_data, f, indent=4, sort_keys=True)
+
+def main(args):
+    if args.verbose_output:
+        logging.basicConfig(level = logging.DEBUG)
+
+    bitbakeinfo = bitbake_runner.get_bitbake_information(args.image)
+    rootfs = bitbakeinfo["rootfs_dir"]
+    dpkg_status = bitbakeinfo["dpkg_status"]
+
+    installed_pkgs = parse_dpkg_status(dpkg_status)
+    
+    user_defined_licenses = read_user_defined_license_file(args.user_defined_licenses)
+    license_mapping = read_license_mapping_file(args.user_defined_license_mapping)
+
+    packages_info = get_package_info_from_control(bitbakeinfo["dl_dir"], bitbakeinfo["repo_isar_dir"],
+            args.distro, bitbakeinfo["image_distro"], bitbakeinfo["distro_arch"])
+
+    installed_pkgs = merge_package_data(installed_pkgs, packages_info)
+
+    find_copyright_files(rootfs, installed_pkgs, user_defined_licenses)
+
+    output_dir = f"{bitbakeinfo['deploy_dir']}/sbom/{bitbakeinfo['image_full_name']}"
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    output_filepath = f"{output_dir}/{args.image}-{args.sbom_format}.json"
+
+    sbom_data = None
+
+    logger.info(f"Create {args.sbom_format} format sbom for {args.image}")
+
+    if args.sbom_format == "cyclonedx":
+        sbom_data = sbom_cyclonedx.create_cyclonedx_sbom(args.product, args.image, args.distro, installed_pkgs, args.supplier, license_mapping)
+    else:
+        sbom_data = sbom_spdx.create_spdx_sbom(args.product, args.image, args.distro, installed_pkgs, args.supplier, license_mapping)
+
+    if sbom_data:
+        write_sbom_json(output_filepath, sbom_data)
+        logger.info(f"sbom was created to {output_filepath}")
+    else:
+        logger.critical("Failed to create SBOM.")
+
+def parse_options():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--image", dest="image", help="EMLinux image name",
+            metavar="IMAGENAME", required=True)
+    parser.add_argument("--sbom-format", dest="sbom_format", help="spdx or cyclonedx",
+            metavar="SBOMFORMAT", required=True)
+    parser.add_argument("--distro", dest="distro", help="debian distro name(e.g. bookworm)",
+            default="bookworm", metavar="DISTRO")
+    parser.add_argument("--licenses", dest="user_defined_licenses", help="license yaml file",
+            metavar="LICENSES")
+    parser.add_argument("--license-mapping", dest="user_defined_license_mapping", help="license mapping yaml file",
+            metavar="LICENSESMAPPING")
+    parser.add_argument("--supplier", dest="supplier", help="Supplier name(e.g. company name)",
+            metavar="SUPPLIER", required=True)
+    parser.add_argument("--product", dest="product", help="Product name",
+            metavar="PRODUCT", required=True)
+    parser.add_argument("--verbose", dest="verbose_output", help="Enable verbose output",
+            action="store_true")
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    main(parse_options())

--- a/scripts/lib/python/bitbake_runner.py
+++ b/scripts/lib/python/bitbake_runner.py
@@ -33,7 +33,7 @@ def get_bitbake_information(image):
         exit(1)
 
     if not process.returncode == 0:
-        print(f"Please check image name {image}")
+        print(f"Cannot find image name {image} in build artifacts.")
         exit(1)
 
     pattern_deploy_image_dir = r'\nDEPLOY_DIR_IMAGE="([^"]*)"'
@@ -41,6 +41,10 @@ def get_bitbake_information(image):
     pattern_image_full_name = r'\nIMAGE_FULLNAME="([^"]*)"'
     pattern_dl_dir = r'\nDL_DIR="([^"]*)"'
     pattern_kernel_name = r'\nKERNEL_NAME="([^"]*)"'
+    pattern_rootfsdir = r'\nROOTFSDIR="([^"]*)"'
+    pattern_distro_arch = r'\nDISTRO_ARCH="([^"]*)"'
+    pattern_repo_isar_dir = r'\nREPO_ISAR_DIR="([^"]*)"'
+    pattern_image_distro = r'\nDISTRO="([^"]*)"'
 
     deploy_image_dir = re.findall(pattern_deploy_image_dir, output)[0]
     deploy_dir = re.findall(pattern_deploy_dir, output)[0]
@@ -48,6 +52,10 @@ def get_bitbake_information(image):
     dl_dir = re.findall(pattern_dl_dir, output)[0]
     kernel_name = re.findall(pattern_kernel_name, output)[0]
     kernel_srcdir = get_linux_source_dir(kernel_name)
+    rootfs_dir = re.findall(pattern_rootfsdir, output)[0]
+    distro_arch = re.findall(pattern_distro_arch, output)[0]
+    repo_isar_dir = re.findall(pattern_repo_isar_dir, output)[0]
+    image_distro = re.findall(pattern_image_distro, output)[0]
 
     dpkg_status = f"{deploy_image_dir}/{image_full_name}.dpkg_status"
     return {
@@ -56,4 +64,8 @@ def get_bitbake_information(image):
         "dl_dir": dl_dir,
         "dpkg_status": dpkg_status,
         "kernel_srcdir": kernel_srcdir,
+        "rootfs_dir": rootfs_dir,
+        "distro_arch": distro_arch,
+        "repo_isar_dir": repo_isar_dir,
+        "image_distro": image_distro,
     }

--- a/scripts/lib/python/sbom/licensing.py
+++ b/scripts/lib/python/sbom/licensing.py
@@ -1,0 +1,101 @@
+def normalize_licenses(lics, license_mapping):
+    new_licenses = []
+
+    for lic in lics:
+        if lic in license_mapping:
+            new_licenses.append(license_mapping[lic])
+        else:
+            new_licenses.append(lic)
+    return new_licenses
+
+def split_licenses(lic, sep):
+    arr = []
+
+    lics = lic.split(sep)
+    for l in lics:
+        arr.append(l.strip())
+
+    return arr
+
+
+def split_licesense_and_normalize(lic, license_mapping):
+    """
+    Normalize license string based on https://scancode-licensedb.aboutcode.org/
+    """
+    lics = []
+    
+    if lic in license_mapping:
+        return [license_mapping[lic]]
+
+    if "~" in lic:
+        lic = lic.replace("~", "")
+
+    if " exception" in lic:
+        lic = lic.replace(" exception", "-exception")
+
+    if ", and " in lic:
+        lics += normalize_licenses(split_licenses(lic, ", and "), license_mapping)
+    elif "/" in lic:
+        tmp = normalize_licenses(split_licenses(lic, "/"), license_mapping)
+        lics.append("-".join(tmp))
+    elif " with " in lic:
+        tmp = normalize_licenses(split_licenses(lic, " with "), license_mapping)
+        lics.append(" WITH ".join(tmp))
+    elif "-WITH-" in lic:
+        tmp = normalize_licenses(split_licenses(lic, "-WITH-"), license_mapping)
+        lics.append(" WITH ".join(tmp))
+    elif " and/or " in lic:
+        tmp = normalize_licenses(split_licenses(lic, "and/or"), license_mapping)
+        lics.append("-and-or-".join(" and-or ", "-and-or-"))
+    elif " and-or " in lic:
+        tmp = normalize_licenses(split_licenses(lic, " and-or "), license_mapping)
+        lics.append("-and-or-".join(tmp))
+    else:
+        lics += normalize_licenses([lic], license_mapping)
+
+    return lics
+
+def split_licenses_simple(licenses):
+    ret = []
+    splited = False
+
+    for lic in licenses:
+        if ", and " in lic:
+            ret += lic.split(", and ")
+            splited = True
+        elif " and " in lic:
+            ret += lic.split(" and ")
+            splited = True
+        elif " or " in lic:
+            ret += lic.split(" or ")
+            splited = True
+        elif " OR " in lic:
+            ret += lic.split(" OR ")
+            splited = True
+        else:
+            ret.append(lic)
+
+    if splited:
+        return split_licenses_simple(ret)
+    
+    return ret
+
+def normalize_for_spdx(licenses, license_mapping):
+    tmp = []
+    normalized = []
+
+    lics = split_licenses_simple(licenses)
+    for lic in lics:
+        tmp += split_licesense_and_normalize(lic, license_mapping)
+
+    for lic in tmp:
+        if " " in lic:
+            normalized.append(lic.replace(" ", "-"))
+        else:
+            normalized.append(lic)
+
+    return list(set(normalized))
+
+def normalize_for_cyclonedx(licenses):
+    return split_licenses_simple(licenses)
+

--- a/scripts/lib/python/sbom/sbom_common.py
+++ b/scripts/lib/python/sbom/sbom_common.py
@@ -1,0 +1,12 @@
+import hashlib
+import uuid
+
+def package_name_hash(name, version):
+    s = f"{name}@{version}".encode("utf-8")
+    sha256sum = None
+    sha256hash = hashlib.sha256()
+    sha256hash.update(s)
+    sha256sum = sha256hash.hexdigest()
+
+    return sha256sum
+

--- a/scripts/lib/python/sbom/sbom_cyclonedx.py
+++ b/scripts/lib/python/sbom/sbom_cyclonedx.py
@@ -1,0 +1,146 @@
+from packageurl import PackageURL
+
+from cyclonedx.exception import MissingOptionalDependencyException
+from cyclonedx.factory.license import LicenseFactory
+from cyclonedx.model import OrganizationalEntity, HashType
+from cyclonedx.model.bom import Bom
+from cyclonedx.model.component import Component, ComponentType
+from cyclonedx.model.bom_ref import BomRef
+from cyclonedx.output.json import JsonV1Dot5
+from cyclonedx.schema import SchemaVersion
+from cyclonedx.validation.json import JsonStrictValidator
+from cyclonedx.model.license import LicenseExpression
+
+import json
+
+import os.path
+import sys
+sys.path.append(os.path.dirname(__file__))
+import sbom_common
+import licensing
+
+import logging
+logger = logging.getLogger("emlinux-sbom-creator")
+
+def debian_section_to_component_type(section):
+    """
+    ComponentType is defined in following url.
+    https://cyclonedx-python-library.readthedocs.io/en/latest/autoapi/cyclonedx/model/component/index.html#cyclonedx.model.component.ComponentType.APPLICATION
+
+    Debian's package categories is in following url.
+    https://packages.debian.org/stable/
+    """
+    if section == "libs" or section == "oldlibs":
+        return ComponentType.LIBRARY
+    elif section == "fonts":
+        return ComponentType.DATA
+    elif section == "doc":
+        return ComponentType.FILE
+    elif section == "kernel":
+        return ComponentType.OPERATING_SYSTEM
+
+    return ComponentType.APPLICATION 
+
+def make_license_info(factory, licenses, license_mapping):
+    ret = []
+
+    uniq_licenses = licensing.normalize_for_cyclonedx(licenses)
+    for lic in uniq_licenses:
+        tmp = factory["lc_factory"].make_with_name(lic)
+        ret.append(tmp)
+
+    return ret
+
+def create_organization_entity(pkg):
+    return OrganizationalEntity(
+        name = pkg["maintainer"],
+    )
+
+def create_package_url(distro, pkg):
+    return PackageURL("deb/debian",
+            "",
+            pkg["package"],
+            pkg["version"], 
+            {
+                "arch": pkg["arch"], 
+                "distro": distro,
+            }
+        )
+
+def create_hashes_data(pkg):
+    return [HashType.from_composite_str(f"sha256:{pkg['sha256sum']}")]
+
+def create_component(factory, distro, pkg, license_mapping):
+    # https://cyclonedx.org/docs/1.5/json/#components
+    # https://github.com/package-url/purl-spec
+
+    purl_info = create_package_url(distro, pkg)
+    pkgname_hash = sbom_common.package_name_hash(pkg['package'], pkg['source'])
+
+    return Component(
+        type = debian_section_to_component_type(pkg["section"]),
+        name = pkg["package"],
+        group = pkg["source"],
+        version = pkg["version"],
+        licenses = make_license_info(factory, pkg["licenses"], license_mapping),
+        supplier = create_organization_entity(pkg),
+        bom_ref = BomRef(f"{pkg['package']}@{pkg['version']}-{pkgname_hash}"),
+        purl = purl_info,
+        hashes = create_hashes_data(pkg),
+        description = pkg["description"],
+    )
+
+def create_meta(factory, product, image, supplier):
+    license = factory["lc_factory"].make_from_string('MIT')
+    
+    product_name_hash = sbom_common.package_name_hash(product, "")
+
+    factory["bom"].metadata.component = root_component = Component(
+        name = image,
+        type = ComponentType.OPERATING_SYSTEM,
+        licenses = [ license ],
+        bom_ref = BomRef(f"{product}-{product_name_hash}"),
+        supplier = OrganizationalEntity(name = supplier),
+    )
+
+    return root_component
+
+def create_sbom_json(bom):
+    outputter = JsonV1Dot5(bom)
+    serialized_json = outputter.output_as_string(indent = 2)
+    validator = JsonStrictValidator(SchemaVersion.V1_5)
+
+    try:
+        validation_errors = validator.validate_str(serialized_json)
+        if validation_errors:
+            logger.debug('JSON invalid', 'ValidationError:', repr(validation_errors), sep='\n', file=sys.stderr)
+            return None
+
+        return json.loads(serialized_json)
+    except MissingOptionalDependencyException as error:
+        logger.debug('JSON-validation was skipped due to', error)
+        return None
+
+    return None
+
+def init_bom():
+    return {
+        "lc_factory": LicenseFactory(),
+        "bom": Bom(),
+    }
+
+def create_cyclonedx_sbom(product, image, distro, packages, supplier, license_mapping):
+    factory = init_bom()
+
+    root = create_meta(factory, product, image, supplier)
+    components = []
+
+    for name in packages:
+        component = create_component(factory, distro, packages[name], license_mapping)
+        factory["bom"].components.add(component)
+        components.append(component)
+
+    factory["bom"].register_dependency(root, components)
+
+    return create_sbom_json(factory["bom"])
+

--- a/scripts/lib/python/sbom/sbom_spdx.py
+++ b/scripts/lib/python/sbom/sbom_spdx.py
@@ -1,0 +1,164 @@
+from datetime import datetime
+from typing import List
+
+from spdx_tools.spdx.constants import DOCUMENT_SPDX_ID
+from spdx_tools.common.spdx_licensing import spdx_licensing
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    CreationInfo,
+    Document,
+    ExternalPackageRef,
+    ExternalPackageRefCategory,
+    Package,
+    PackagePurpose,
+    Relationship,
+    RelationshipType,
+)
+from spdx_tools.spdx.validation.document_validator import validate_full_spdx_document
+from spdx_tools.spdx.validation.validation_message import ValidationMessage
+from spdx_tools.spdx.writer.write_anything import write_file
+from spdx_tools.spdx.model.spdx_none import SpdxNone
+
+import re
+import json
+import tempfile
+from urllib.parse import quote
+import uuid
+
+import logging
+logger = logging.getLogger("emlinux-sbom-creator")
+
+import os.path
+import sys
+sys.path.append(os.path.dirname(__file__))
+import sbom_common
+import licensing
+
+def debian_section_to_component_type(section):
+    if section == "libs" or section == "oldlibs":
+        return PackagePurpose.LIBRARY
+    elif section == "fonts":
+        return PackagePurpose.OTHER
+    elif section == "doc":
+        return PackagePurpose.FILE
+    elif section == "kernel":
+        return PackagePurpose.OPERATING_SYSTEM
+
+    return PackagePurpose.APPLICATION
+
+def get_maintainer_name_and_email(pkg):
+    s = pkg["maintainer"]
+
+    email_pattern = r"<([^>]+)>"
+    email_match = re.search(email_pattern, s)
+    email = ""
+
+    if email_match:
+        email = email_match.group(1)
+
+    name_pattern = r"^(.*?)\s+\S+@\S+$"
+    name_match = re.search(name_pattern, s)
+    name = ""
+
+    if name_match:
+        name = name_match.group(1)
+
+    return email, name
+
+def create_uniq_list(data):
+    return list(set(data))
+
+def split_licenses(lic, sep):
+    arr = []
+
+    lics = lic.split(sep)
+    for l in lics:
+        arr.append(l.strip())
+
+    return arr
+
+def create_license_string(pkg, license_mapping):
+    arr = []
+    s = ""
+
+    licenses = licensing.normalize_for_spdx(create_uniq_list(pkg["licenses"]), license_mapping)
+
+    s = " AND ".join(licenses)
+    return spdx_licensing.parse(s)
+
+def create_package_info(pkg, distro, license_mapping):
+    email, name = get_maintainer_name_and_email(pkg)
+
+    licenses = create_license_string(pkg, license_mapping)
+    purl_str = quote(f"pkg:deb/debian/{pkg['package']}@{pkg['version']}?arch={pkg['arch']}&distro={distro}", safe = "@=&/:?")
+
+    pkg_name_hash = sbom_common.package_name_hash(pkg["package"], pkg["version"])
+
+    spdxid = f"SPDXRef-Package-{pkg_name_hash}"
+
+    package = Package(
+        name = pkg["package"],
+        spdx_id = spdxid,
+        download_location = SpdxNone(),
+        version = pkg["version"],
+        source_info = f"build from: {pkg['source']} {pkg['version']}",
+        supplier = Actor(ActorType.ORGANIZATION, name, email),
+        license_concluded = licenses,
+        license_declared = licenses,
+        primary_package_purpose = debian_section_to_component_type(pkg["section"]),
+        external_references = [
+            ExternalPackageRef(
+                category = ExternalPackageRefCategory.PACKAGE_MANAGER,
+                reference_type = "purl",
+                locator = purl_str,
+            )
+        ],
+        files_analyzed = False,
+        attribution_texts = [ f"PkgID: {pkg['package']}@{pkg['version']}" ],
+        description = pkg["description"],
+    )
+
+    return spdxid, package
+
+def create_meta(product, image, supplier):
+    today = datetime.now()
+    spdxid = DOCUMENT_SPDX_ID
+    doc_name = f"{product}"
+
+    ci = CreationInfo(
+        spdx_version = "SPDX-2.3",
+        spdx_id = spdxid,
+        name = doc_name,
+        data_license = "CC0-1.0",
+        # see https://spdx.github.io/spdx-spec/v2.3/document-creation-information/#65-spdx-document-namespace-field
+        document_namespace = f"https://github.com/miraclelinux/meta-emlinux/spdx/{doc_name}-{uuid.uuid4()}",
+        creators = [Actor(ActorType.ORGANIZATION, supplier)],
+        created = datetime(today.year, today.month, today.day, today.hour, today.minute, today.second),
+    )
+
+    return spdxid, Document(ci)
+
+def create_spdx_sbom(product, image, distro, packages, supplier, license_mapping):
+    doc_spdxid, doc = create_meta(product, image, supplier)
+
+    for name in packages:
+        pkg_spdxid, package = create_package_info(packages[name], distro, license_mapping)
+        doc.packages.append(package)
+        doc.relationships.append(Relationship(doc_spdxid, RelationshipType.DESCRIBES, pkg_spdxid))
+    
+    validation_messages = validate_full_spdx_document(doc)
+
+    if validation_messages:
+        logger.debug("SPDX Validation message")
+        for vm in validation_messages:
+            logger.debug(f"- {vm.validation_message}")
+    
+    tempname = f"{tempfile.mktemp()}.json"
+
+    write_file(doc, tempname, False)
+    sbom_data = None
+    with open(tempname, "r") as f:
+        sbom_data = json.loads(f.read())
+
+    return sbom_data

--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -17,6 +17,9 @@ fi
 
 EML_HOOKS="${PWD}/setup-hooks"
 REPOS="${PWD}/repos"
+# Add meta-emlinux/scripts to command search path.
+SCRIPT_DIR="${REPOS}/meta-emlinux/scripts"
+export PATH=$PATH:$SCRIPT_DIR:
 
 ENV_BUILD_SETUP="false"
 if [ ! -f "${ENV_BUILDDIR}/conf/local.conf" ]; then


### PR DESCRIPTION
Add SBOM creation script that supports CycloneDx and SPDX formats.
We currently support CycloneDx v1.5 and SPDX 2.3 formats.
To create an SBOM for target image, this script uses the official libraries cyclonedx-python-lib
and spdx-tools provided by the CycloneDx and SPDX projects, respectively.

Creating SBOM
-------------

1. Run source setup-emlinux <bulid directory> to setup emlinux build
environment
2. Run create_sbom.py with the following options (all options are required).

* --image IMAGE_NAME
  * Image name whose components are described by SBOM(e.g. emlinux-image-base)
* --sbom-format SBOM_FORMAT
  * SBOM format(e.g. cyclonedx or spdx)
* --supplier SUPPLIER_NAME
  * Organization name who provides the SBOM
* --product PRODUCT_NAME
  * Product name for the SBOM

SBOM output will be stored in the following path.<build directory>/tmp/deploy/sbom/<IMAGE_NAME>/<IMAGE_NAME>-<SBOM_FORMAT>.json

Example
-------------

Following command line creates a cyclonedx format sbom.

```
../repos/meta-emlinux/scripts/create_sbom.py \
 --image emlinux-image-base \
 --supplier "Cybertrust Japan Co., Ltd." \
 --product EMLinux3 \
 --sbom-format cyclonedx
```
Following command line creates an spdx format sbom.

```
../repos/meta-emlinux/scripts/create_sbom.py \
 --image emlinux-image-base \
 --supplier "Cybertrust Japan Co., Ltd." \
 --product EMLinux3 \
 --sbom-format spdx
```

Gathering license information
-------------

This tool gathers license information from copyright file from
/usr/share/doc/<package name>/copyright.

Lincense name normalization

The SPDX project uses a license identifier called Identifier to identify licenses.
License identifiers are defined at https://spdx.org/licenses/. The license name
listed in the Debian package copyright file may not match the SPDX license identifier
and may not be able to properly identify the license. For example, the copyright file
of a Debian package may include GPL-3+, which indicates GNU General Public License or a
later version, but this notation cannot be recognized by SPDX. Therefore, it is
necessary to convert the Debian license name to an SPDX license identifier so that
it can be recognized by SPDX.

Define license information
-------------

EMLinux uses conf/licenses/license-mapping.yml as a file to map Debian license names
and SPDX license identifiers. If you need to map licenses that are not in this mapping
file, you can extend the mapping information by creating your own mapping file. When
using a user-defined mapping file, use --license-mapping as a command line parameter.
e.g. --license-mapping <user-defined mapping file>

The format of the mapping file is as follows.

```
"Debian license notation": "SPDX license identifier"
```

e.g.
```
"GPL-3+": "GPL-3.0-or-later"
```

Define license
-------------

If this tool can't find the license name from the copyright file,
"unknown" will be set as the package's license name. To reduce
such cases, the conf/licenses/licenses.yml is provided to supplement
the package's license information. This file can also be extended by
the user-defined file passed via the "--licenses" parameter.
e.g. --licenses <user-defined license file>

The format of the license file is as follows.

```
binary package name:
   licenses: [
     LICENSE A,
     LICENSE B,
   ]
```

e.g.

```
libpangocairo-1.0-0:
  licenses: [
    MPL-1.1,
    LGPL-2.1-only,
  ]
```
