### PR TITLE
Update kernel to v4.19.306-cip107 and v5.10.209-cip44

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "b445cc998c55d40197d601584361f73e1183d44f"
-LINUX_CVE_VERSION ??= "5.10.208"
-LINUX_CIP_VERSION ?= "v5.10.208-cip43"
+LINUX_GIT_SRCREV ?= "2fa4c25ee66abaa707e8d165c790bb96e883cca4"
+LINUX_CVE_VERSION ??= "5.10.209"
+LINUX_CIP_VERSION ?= "v5.10.209-cip44"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "6617f4528449a329abd3b2dab36052b341610d99"
-LINUX_CVE_VERSION ??= "4.19.304"
-LINUX_CIP_VERSION ??= "v4.19.304-cip106"
+LINUX_GIT_SRCREV ?= "800dfc28d1a90b195d50f75fa7711d00cc1825bf"
+LINUX_CVE_VERSION ??= "4.19.306"
+LINUX_CIP_VERSION ??= "v4.19.306-cip107"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.306-cip107 and v5.10.209-cip44

This pull request update the kernel to the following cip versions:
v4.19.306-cip107 with hash tag 800dfc28d1a90b195d50f75fa7711d00cc1825bf
v5.10.209-cip44 with hash tag 2fa4c25ee66abaa707e8d165c790bb96e883cca4
