### PR TITLE
Get packages for debug

### DIFF
--- a/classes/dl-dbgpkg.bbclass
+++ b/classes/dl-dbgpkg.bbclass
@@ -1,0 +1,18 @@
+#
+# This class gets debug symbol packages for SDK.
+#
+# Copyright (C) Cybertrust Japan Co., Ltd.
+#
+# SPDX-License-Identifier: MIT
+#
+
+#
+# [How to use]
+# Add following line into the local.conf.
+# INHERIT += "dl-dbgpkg"
+#
+# If you want to get debian patched source tree, add following line too.
+# PREPARE_PATCHED_SRC = "1"
+#
+
+require classes/dl-dbgpkg.inc

--- a/classes/dl-dbgpkg.inc
+++ b/classes/dl-dbgpkg.inc
@@ -1,0 +1,151 @@
+#
+# This class gets debug symbol packages for SDK.
+#
+# Copyright (C) Cybertrust Japan Co., Ltd.
+#
+# SPDX-License-Identifier: MIT
+#
+
+#
+# [How to use]
+# Add following line into the local.conf.
+# INHERIT += "dl-dbgpkg"
+#
+# If you want to get debian patched source tree, add following line too.
+# PREPARE_PATCHED_SRC = "1"
+#
+
+inherit dl-srcpkg
+
+python sdk_virtclass_handler_for_dbgpkg() {
+    pn = e.data.getVar('PN')
+    if pn.endswith('-sdk'):
+        e.data.setVar('BPN', pn[:-len('-sdk')])
+        e.data.appendVar('OVERRIDES', ':class-sdk')
+        # install_debug_symbol deploy only for sdk image
+        bb.build.addtask('install_debug_symbol', 'do_image_tar', 'do_rootfs', d)
+}
+addhandler sdk_virtclass_handler_for_dbgpkg
+sdk_virtclass_handler_for_dbgpkg[eventmask] = "bb.event.RecipePreFinalise"
+
+#
+# for self build packages
+#
+EML_SELF_BUILD="eml-apt"
+LOCAL_APT_DIR="tmp/${EML_SELF_BUILD}/${DISTRO}-${DISTRO_ARCH}/apt/${DISTRO}"
+
+prepare_local_isarapt() {
+    # Make a local copy of isar-apt repo
+    rm -rf "${ROOTFSDIR}/tmp/${EML_SELF_BUILD}/${DISTRO}-${DISTRO_ARCH}/*"
+    mkdir -p "${ROOTFSDIR}/${LOCAL_APT_DIR}"
+    cp -Rf "${REPO_ISAR_DIR}/${DISTRO}/dists" "${ROOTFSDIR}/${LOCAL_APT_DIR}/"
+    if [ -d "${REPO_ISAR_DIR}/${DISTRO}/pool" ]; then
+        cp -Rf "${REPO_ISAR_DIR}/${DISTRO}/pool" "${ROOTFSDIR}/${LOCAL_APT_DIR}/"
+    fi
+    # change repository name
+    mv ${ROOTFSDIR}/${LOCAL_APT_DIR}/dists/${DEBDISTRONAME} ${ROOTFSDIR}/${LOCAL_APT_DIR}/dists/${EML_SELF_BUILD}
+    sed -i -e "s/Codename\:\ isar/Codename\:\ ${EML_SELF_BUILD}/g" ${ROOTFSDIR}/${LOCAL_APT_DIR}/dists/${EML_SELF_BUILD}/Release
+}
+
+cleanup_local_isarapt() {
+    rm -fr /tmp/${EML_SELF_BUILD}
+}
+
+SDKTARGETROOTFSDEPS = ""
+SDKTARGETROOTFSDEPS:class-sdk = "${BPN}:do_install_source_package"
+do_install_debug_symbol[depends] += "${SDKTARGETROOTFSDEPS}"
+do_install_debug_symbol[network] = "${TASK_USE_SUDO}"
+
+TARGET_ROOTFS_MANIFEST="${BPN}-${DISTRO}-${MACHINE}"
+
+DBG_SYMBOL="dbgsym-apt"
+DEBIAN_DBG_REPO = "http://deb.debian.org/debian-debug"
+
+do_install_debug_symbol() {
+    local not_exist_resolvconf=`file '${ROOTFSDIR}'/etc/resolv.conf 2>&1 | grep "cannot open" | wc -c`
+
+    ### prepare directory for chroot environment
+    sudo -E mount --bind /tmp ${ROOTFSDIR}/tmp
+    sudo -E mount --bind /dev ${ROOTFSDIR}/dev
+    sudo -E mount --bind /dev/pts ${ROOTFSDIR}/dev/pts
+    sudo -E mount -t proc none ${ROOTFSDIR}/proc
+
+    cp "${DEPLOY_DIR}/images/${MACHINE}/${TARGET_ROOTFS_MANIFEST}".manifest /tmp
+
+    ### setup network & apt environment
+    if [ ${not_exist_resolvconf} -ne 0 ]; then
+        sudo cp /etc/resolv.conf ${ROOTFSDIR}/etc/resolv.conf
+    else
+        sudo mv ${ROOTFSDIR}/etc/resolv.conf ${ROOTFSDIR}/etc/resolv.conf.orig
+        sudo cp /etc/resolv.conf ${ROOTFSDIR}/etc/resolv.conf
+    fi
+
+    ### for self-build packages
+    prepare_local_isarapt
+    sudo sh -c "echo 'deb [trusted=yes] copy:///${LOCAL_APT_DIR} ${EML_SELF_BUILD} main' > ${ROOTFSDIR}/etc/apt/sources.list.d/${EML_SELF_BUILD}.list"
+    sudo sh -c "echo 'deb-src [trusted=yes] copy:///${LOCAL_APT_DIR} ${EML_SELF_BUILD} main' >> ${ROOTFSDIR}/etc/apt/sources.list.d/${EML_SELF_BUILD}.list"
+    sudo sh -c "echo \"Package: *\nPin: release n=${EML_SELF_BUILD}\nPin-Priority: 2000\" > ${ROOTFSDIR}/etc/apt/preferences.d/${EML_SELF_BUILD}"
+    sudo sh -c "echo \"APT::Get::allow-downgrades 1;\" > ${ROOTFSDIR}/etc/apt/apt.conf.d/50${EML_SELF_BUILD}"
+
+    ### for pre-build packages
+    sudo sh -c "echo 'deb [arch=${DISTRO_ARCH}] ${DEBIAN_DBG_REPO} ${BASE_DISTRO_CODENAME}-debug main' > ${ROOTFSDIR}/etc/apt/sources.list.d/${DBG_SYMBOL}.list"
+    sudo sh -c "echo 'deb [arch=${DISTRO_ARCH}] ${DEBIAN_DBG_REPO} ${BASE_DISTRO_CODENAME}-proposed-updates-debug main' >> ${ROOTFSDIR}/etc/apt/sources.list.d/${DBG_SYMBOL}.list"
+    sudo sh -c "echo \"Package: *\nPin: release n=${DBG_SYMBOL}\nPin-Priority: 1000\" > ${ROOTFSDIR}/etc/apt/preferences.d/${DBG_SYMBOL}"
+    sudo sh -c "echo \"APT::Get::allow-downgrades 1;\" > ${ROOTFSDIR}/etc/apt/apt.conf.d/60${DBG_SYMBOL}"
+
+    sudo -E chroot ${ROOTFSDIR} sh -c "rm /var/lib/dpkg/status; touch /var/lib/dpkg/status; apt-get -y -q update"
+
+    ### download debug symbol packages
+    cat << 'EOS' > /tmp/dl_dbgsym.sh
+while read line
+do
+    tmpName=`echo ${line} | cut -d'|' -f3`
+    pkgName=${tmpName%%\:${DISTRO_ARCH}}
+    # echo "PKG: ${pkgName}" >> /etc/pkg-list.txt
+    pkgVer=`echo ${line} | cut -d'|' -f4`
+    dbgsym_pkg=`apt-cache search "^${pkgName}-dbgsym" | cut -d' ' -f1`
+    if [ -z "${dbgsym_pkg}" ]; then
+        dbgsym_pkg=`apt-cache search "^${pkgName}-dbg" | cut -d' ' -f1`
+    fi
+    if [ -n "${dbgsym_pkg}" ]; then
+        _chk_ver=`apt-cache show ${dbgsym_pkg} | grep "^Version"`
+	chk_ver=${_chk_ver##Version\:\ }
+	if [ "${chk_ver}" = "${pkgVer}" ]; then
+            apt-get install ${pkgName}=${pkgVer} -y
+            apt-get install ${dbgsym_pkg}=${pkgVer} -y
+	else
+	    echo "[INFO]: Found debug symbol package but package version is not match. pkg: ${dbgsym_pkg} , pkgVer: ${pkgVer} , getVer:${chk_ver}"
+	fi
+    else
+        echo "[INFO]: Can't find debug symbol package for ${pkgName}"
+    fi
+done < ${TARGET_ROOTFS_MANIFEST}.manifest
+EOS
+    sudo -E chroot ${ROOTFSDIR} sh -c "(cd /tmp && bash ./dl_dbgsym.sh)"
+
+    ### prepare patched source
+    if [ "${PREPARE_PATCHED_SRC}" = "1" ]; then
+	sudo mkdir -p ${ROOTFSDIR}/usr/src/pkg_src
+        cd ${DEPLOY_DIR}/sources/${MACHINE}
+        for dir in *
+        do
+            if [ -d ${dir} ]; then
+                (cd ${dir} && sudo dpkg-source --no-copy -x *.dsc ${ROOTFSDIR}/usr/src/pkg_src/${dir})
+            fi
+        done
+    fi
+
+    ### clean up and umount output directory
+    sudo -E rm ${ROOTFSDIR}/etc/apt/apt.conf.d/50${EML_SELF_BUILD} ${ROOTFSDIR}/etc/apt/preferences.d/${EML_SELF_BUILD} ${ROOTFSDIR}/etc/apt/sources.list.d/${EML_SELF_BUILD}.list
+    rm ${ROOTFSDIR}/tmp/${TARGET_ROOTFS_MANIFEST}.manifest
+    sudo -E umount ${ROOTFSDIR}/proc
+    sudo -E umount ${ROOTFSDIR}/dev/pts
+    sudo -E umount ${ROOTFSDIR}/dev
+    sudo -E umount ${ROOTFSDIR}/tmp
+    cleanup_local_isarapt
+    if [ ${not_exist_resolvconf} -ne 0 ]; then
+        sudo -E rm ${ROOTFSDIR}/etc/resolv.conf
+    else
+        sudo mv ${ROOTFSDIR}/etc/resolv.conf.orig ${ROOTFSDIR}/etc/resolv.conf
+    fi
+}

--- a/classes/dl-srcpkg.bbclass
+++ b/classes/dl-srcpkg.bbclass
@@ -17,6 +17,7 @@ LOCAL_APT_DIR="tmp/${EML_SELF_BUILD}/${DISTRO}-${DISTRO_ARCH}/apt/${DISTRO}"
 
 prepare_local_isarapt() {
     # Make a local copy of isar-apt repo
+    rm -rf /tmp/${EML_SELF_BUILD}
     rm -rf "${ROOTFSDIR}/tmp/${EML_SELF_BUILD}/${DISTRO}-${DISTRO_ARCH}/*"
     mkdir -p "${ROOTFSDIR}/${LOCAL_APT_DIR}"
     cp -Rf "${REPO_ISAR_DIR}/${DISTRO}/dists" "${ROOTFSDIR}/${LOCAL_APT_DIR}/"
@@ -32,13 +33,23 @@ cleanup_local_isarapt() {
     rm -fr /tmp/${EML_SELF_BUILD}
 }
 
-rootfs_generate_manifest:append () {
+do_install_source_package[network] = "${TASK_USE_SUDO}"
+
+do_install_source_package() {
+    if [ ! "`echo ${ROOTFS_FEATURES} | grep generate-manifest`" ]; then
+        exit
+    fi
+
     local not_exist_resolvconf=`file '${ROOTFSDIR}'/etc/resolv.conf 2>&1 | grep "cannot open" | wc -c`
 
     ### backup apt status
     sudo sh -c "(cd ${ROOTFSDIR} && tar zcpf apt_status.tar.gz var/cache/apt var/lib/apt)"
 
     ### prepare directory for output
+    if [ -d ${DEPLOY_DIR}/sources/${MACHINE} ]; then
+        # clean-up old directory if exist
+        rm -fr ${DEPLOY_DIR}/sources/${MACHINE}
+    fi
     mkdir -p ${DEPLOY_DIR}/sources/${MACHINE}
     sudo -E mount --bind /tmp ${ROOTFSDIR}/tmp
     mkdir -p ${ROOTFSDIR}/tmp/source_dir
@@ -79,3 +90,5 @@ rootfs_generate_manifest:append () {
     sudo sh -c "(cd ${ROOTFSDIR} && rm -fr var/cache/apt var/lib/apt; tar zxpf apt_status.tar.gz)"
     sudo rm ${ROOTFSDIR}/apt_status.tar.gz
 }
+
+addtask install_source_package before do_rootfs after do_rootfs_postprocess


### PR DESCRIPTION
# Purpose of pull request

1. Move source package download function to new task to prevent conflict with debug symbol download function.

2. Add class file to downloads debug symbol packages which are included in rootfs.

# Test
## How to test

To download source packages, add following line into the local.conf.
(same manner as last time)
```
INHERIT += "dl-srcpkg"
```

And then type following build command.
```
$ bitbake emlinux-image-base
```

To download debug symbol packages, add following line into the local.conf.
Note: This setting also enables source package download function.
```
INHERIT += "dl-dbgpkg"
```

If you want to get Debian patched source as well as debug symbol packages, add following line into the local.conf too.
```
PREPARE_PATCHED_SRC = "1"
```

And then type following build command.
```
$ bitbake emlinux-image-base -c populate_sdk
```


After building SDK, please install this SDK.

## Test result

All debian source package files are located under the following directory.
```
tmp/deploy/sources/xxxxx
```

All debug symbol packages are located under the following directory.
- kernel
```
[SDK install directory]/emlinux-image-base-sdk-emlinux-bookworm-ls1046ardb/usr/lib/debug/
```

- other packages
```
[SDK install directory]/emlinux-image-base-sdk-emlinux-bookworm-ls1046ardb/usr/lib/debug/.build-id/
```

If you use PREPARE_PATCHED_SRC option, Debian patched source are located under the following directory.
```
[SDK install directory]/emlinux-image-base-sdk-emlinux-bookworm-ls1046ardb/usr/src/pkg_src/
```
