### PR TITLE
cve_check: Fix logger option in kernel_cve.py

### DIFF
--- a/scripts/lib/python/cve/kernel_cve.py
+++ b/scripts/lib/python/cve/kernel_cve.py
@@ -39,7 +39,7 @@ def run_cip_kernel_sec(kernel_src_dir, kver, cip_kernel_sec_dir):
         retcode = int(proc.returncode)
 
         if not retcode == 0:
-            logger.warning('Failed to run cip-kernel-sec', file=sys.stderr, flush=True)
+            logger.warning('Failed to run cip-kernel-sec')
             for s in proc.stderr:
                 logger.warning(s.decode())
         else:
@@ -63,7 +63,7 @@ def clone_cip_kernel_sec():
         retcode = int(proc.returncode)
 
         if not retcode == 0:
-            logger.warning('Failed to clone cip-kernel-sec', file=sys.stderr, flush=True)
+            logger.warning('Failed to clone cip-kernel-sec')
             return False
 
         remotes_path = "./cip-kernel-sec/conf/remotes.yml"
@@ -80,7 +80,7 @@ def update_cip_kernel_sec():
         retcode = int(proc.returncode)
 
         if not retcode == 0:
-            logger.warning('Failed to pull cip-kernel-sec', file=sys.stderr, flush=True)
+            logger.warning('Failed to pull cip-kernel-sec')
             return False
 
     return True


### PR DESCRIPTION
This commit fixes following error.

```
2024-02-29 00:08:35,870:INFO: Update cip-kernel-sec 2024-02-29 00:08:37,632:INFO: Checking CVEs ...
2024-02-29 00:08:37,632:INFO: Checking CVEs ...
Traceback (most recent call last):
  File "/home/build/work/./repos/meta-emlinux/scripts/cve_check.py", line 661, in <module>
    main(parse_options())
  File "/home/build/work/./repos/meta-emlinux/scripts/cve_check.py", line 617, in main
    cves = create_cves_info(db_file, debian_cve_list, uniq_installed_pkgs, installed_pkgs, args.debian_codename, cve_products, linux_kernel_src_dir, cip_kernel_sec_dir)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/./repos/meta-emlinux/scripts/cve_check.py", line 483, in create_cves_info
    cves = check_kernel_cves_by_cip_kernel_sec(uniq_installed_pkgs, cves, kernel_src_dir, cip_kernel_sec_dir, db_file)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/./repos/meta-emlinux/scripts/cve_check.py", line 459, in check_kernel_cves_by_cip_kernel_sec
    cip_kernel_sec_result = kernel_cve.run_cip_kernel_sec(kernel_src_dir, kver, cip_kernel_sec_dir)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/./repos/meta-emlinux/scripts/lib/python/cve/kernel_cve.py", line 42, in run_cip_kernel_sec
    logger.warning('Failed to run cip-kernel-sec', file=sys.stderr, flush=True)
  File "/usr/lib/python3.11/logging/__init__.py", line 1501, in warning
    self._log(WARNING, msg, args, **kwargs)
TypeError: Logger._log() got an unexpected keyword argument 'file'
```

Also, remove flush option.
