### PR TITLE
linux-base: Add CVE-2023-6915 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -30,6 +30,7 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-1999-0656: This issue is that specific to ugidd, part of the old user-mode NFS server.
 # CVE-2006-2932: Specific to RHEL. 4.19.y is not affected.
 # CVE-2023-1476: Specific to RHEL. 4.19.y is not affected.
+# CVE-2023-6915: This is false positive because 4.19.y is not affected.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
@@ -39,4 +40,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2007-4998 CVE-2008-2544 CVE-2016-3699 \
     CVE-1999-0524 CVE-2023-1076 CVE-2015-7312 \
     CVE-1999-0656 CVE-2006-2932 CVE-2023-1476 \
+    CVE-2023-6915 \
 "


### PR DESCRIPTION
Add CVE-2023-6915 to CVE_CHECK_WHITELIST because this vulnerable code is not exist In kernel-4.19.x.

# Purpose of pull request

This pr adds CVE-2023-6915 to CVE_CHECK_WHITELIST of linux-base recipe, becase kernel 4.19.x has no vulnerable code which this cve has pointed.

# Test
## How to test

Add following line into conf/local.conf
```
INHERIT += "cve-check"
```

And then run following command.
```
$ bitbake linux-base
```

## Test result

Before applying this pr, we can see "CVE-2023-6915" in command output.
After applying this pr, we can't see "CVE-2023-6915" in command output.




