### PR TITLE
raspberrypi-bootfiles: Keep the debian compatibility level as 10

### DIFF
--- a/recipes-bsp/raspberrypi-bootfiles/raspberrypi-bootfiles.bb
+++ b/recipes-bsp/raspberrypi-bootfiles/raspberrypi-bootfiles.bb
@@ -31,3 +31,8 @@ do_install() {
   install -d -m 0755 ${D}/usr/share/doc/${PN}/ 
   install -m 0644 ${WORKDIR}/copyright ${D}/usr/share/doc/${PN}/
 }
+
+# Keep a lower compatiblity level because file format recognition by dh_strip
+# during the dpkg build task has been added since v11 then it fails when
+# examining a particular bootloader file.
+DEBIAN_COMPAT = "10"


### PR DESCRIPTION
Since compatiblity level 11, dh_strip trys to open the files to be included in a deb package in order to indentify the file format during deb package building. It then aborts due to a recognition failure when examining a particular bootloder file.
