### PR TITLE
conf/distro: Add bc package to SDK_PREINSTALL.

### DIFF
--- a/conf/distro/emlinux-common.inc
+++ b/conf/distro/emlinux-common.inc
@@ -33,4 +33,5 @@ WKS_FILE ?= "${MACHINE}.wks"
 
 SDK_PREINSTALL += " \
     linux-headers-${KERNEL_NAME} \
+    bc \
 "


### PR DESCRIPTION
Building kernel module requires bc command, so it would be nice to install the bc package into the SDK rootfs in case bc command doesn't exist in user's workstation.