### PR TITLE
core-image-sdk: Add nativesdk bc package

### DIFF
--- a/recipes-images/images/core-image-sdk.inc
+++ b/recipes-images/images/core-image-sdk.inc
@@ -1,4 +1,5 @@
 IMAGE_INSTALL_append = " kernel-devsrc "
+TOOLCHAIN_HOST_TASK_append = " nativesdk-bc "
 
 # Post process after installed sdk
 sdk_post_process () {


### PR DESCRIPTION
Building kernel module requires bc command, so it would be nice to install the bc package into the SDK rootfs in case bc command doesn't exist in user's workstation.

