### PR TITLE
Update kernel to v4.19.310-cip108 and v5.10.212-cip45

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "2fa4c25ee66abaa707e8d165c790bb96e883cca4"
-LINUX_CVE_VERSION ??= "5.10.209"
-LINUX_CIP_VERSION ?= "v5.10.209-cip44"
+LINUX_GIT_SRCREV ?= "6d03567cbcdc99d0c6372154f02172276261f851"
+LINUX_CVE_VERSION ??= "5.10.212"
+LINUX_CIP_VERSION ?= "v5.10.212-cip45"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "800dfc28d1a90b195d50f75fa7711d00cc1825bf"
-LINUX_CVE_VERSION ??= "4.19.306"
-LINUX_CIP_VERSION ??= "v4.19.306-cip107"
+LINUX_GIT_SRCREV ?= "b39bba29c35ca19fc6eec7baed1210cfa4c70c44"
+LINUX_CVE_VERSION ??= "4.19.310"
+LINUX_CIP_VERSION ??= "v4.19.310-cip108"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.310-cip108 and v5.10.212-cip45

This pull request update the kernel to the following cip versions:
v4.19.310-cip108 with hash tag b39bba29c35ca19fc6eec7baed1210cfa4c70c44
v5.10.212-cip45 with hash tag 6d03567cbcdc99d0c6372154f02172276261f851
