### PR TITLE
Show unfixed kernel CVEs where CPE information is not given

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -58,6 +58,15 @@ python do_cve_check () {
     if os.path.exists(d.getVar("CVE_CHECK_DB_FILE")):
         patched_cves = get_patches_cves(d)
         patched, unpatched = check_cves(d, patched_cves)
+
+        if d.getVar("PN") == d.getVar("KERNEL_PN"):
+            cip_sec_reported_cves = d.getVar("CIP_KERNEL_SEC_REPORTED_CVES")
+            if len(cip_sec_reported_cves) > 0:
+                tmp = cip_sec_reported_cves.split(" ")
+                for cve in tmp:
+                    if not cve in unpatched:
+                        unpatched.append(cve)
+
         if patched or unpatched:
             cve_data = get_cve_info(d, patched + unpatched)
             cve_write_data(d, patched, unpatched, cve_data)

--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -139,6 +139,8 @@ python kernel_cve_check () {
 
     bb.debug(2, "Whitelisted by cip-kernel-sec:\n    %s" % "\n    ".join(whitelist))
     d.appendVar("CVE_CHECK_WHITELIST", ' ' + ' '.join(whitelist))
+
+    d.setVar("CIP_KERNEL_SEC_REPORTED_CVES", " ".join(affect_cves))
 }
 
 do_cve_check[prefuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'kernel_cve_check', '', d)}"


### PR DESCRIPTION
# Purpose of pull request

Some CVEs in the linux kernel don't have CPE information. In this case we cannot get CVE information from NVD database because the cve_check task uses CPE to search CVE IDs from NVD database. 
Therefore, use affected_report.py result to find unfixed CVEs.

The cve_check searches CVEs following order.
1. Find CVE IDs by CPE from PRODUCTS table
2. Get CVE information by CVE ID from NVD table

So, we can get CVE information by  CVE ID even if  CPE information is not found in PRODUCTS table.

# Test
## How to test

Run CVE check for linux-base/linux-k510.

## Test result

### Before the change.

Run cve-check for linux-k510.

```
WARNING: linux-k510-5.10-r0 do_cve_check: Found unpatched CVE (CVE-2008-4609 CVE-2010-4563 CVE-2013-2094 CVE-2013-6381 CVE-2014-0069 CVE-2014-3185 CVE-2015-5157 CVE-2019-14899 CVE-2020-35501 CVE-2021-32078 CVE-2021-3669 CVE-2021-3714 CVE-2021-3773 CVE-2021-3847 CVE-2021-3864 CVE-2021-3923 CVE-2021-46926 CVE-2022-0400 CVE-2022-0480 CVE-2022-0500 CVE-2022-1247 CVE-2022-25265 CVE-2022-2961 CVE-2022-3108 CVE-2022-3114 CVE-2022-3523 CVE-2022-3566 CVE-2022-3567 CVE-2022-38096 CVE-2022-38457 CVE-2022-40133 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-4543 CVE-2022-45884 CVE-2022-45885 CVE-2023-1075 CVE-2023-22995 CVE-2023-23000 CVE-2023-23039 CVE-2023-26242 CVE-2023-3397 CVE-2023-3640 CVE-2023-37454 CVE-2023-4010 CVE-2023-4133 CVE-2023-4622 CVE-2023-46813 CVE-2023-47233 CVE-2023-52429 CVE-2023-52434 CVE-2023-52435 CVE-2023-52447 CVE-2023-6240 CVE-2023-6270 CVE-2023-6531 CVE-2023-6535 CVE-2023-6610 CVE-2023-7042 CVE-2024-0340 CVE-2024-0565 CVE-2024-0607 CVE-2024-0841 CVE-2024-1086 CVE-2024-21803 CVE-2024-23307 CVE-2024-23848 CVE-2024-23849 CVE-2024-23850 CVE-2024-23851 CVE-2024-25739 CVE-2024-25740 CVE-2024-26583 CVE-2024-26585 CVE-2024-26589), for more information check /home/build/work/emlinux/latest-dev/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-k510/5.10-r0/temp/cve.log
```

Run cve-check for linux-base.

```
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-2008-4609 CVE-2010-4563 CVE-2010-5321 CVE-2013-2094 CVE-2013-6381 CVE-2014-0069 CVE-2014-3185 CVE-2015-2877 CVE-2015-5157 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-14899 CVE-2019-16089 CVE-2019-19083 CVE-2019-20794 CVE-2020-11725 CVE-2020-16120 CVE-2020-26541 CVE-2020-27820 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2020-36691 CVE-2020-36766 CVE-2021-32078 CVE-2021-3669 CVE-2021-3714 CVE-2021-3759 CVE-2021-3773 CVE-2021-3847 CVE-2021-3864 CVE-2021-3923 CVE-2021-4037 CVE-2021-46925 CVE-2021-46926 CVE-2021-46928 CVE-2021-46941 CVE-2022-0400 CVE-2022-0480 CVE-2022-1015 CVE-2022-1247 CVE-2022-25265 CVE-2022-2961 CVE-2022-3108 CVE-2022-3303 CVE-2022-3344 CVE-2022-3523 CVE-2022-3566 CVE-2022-3567 CVE-2022-36402 CVE-2022-39189 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-4543 CVE-2022-45884 CVE-2022-45885 CVE-2022-47520 CVE-2023-1249 CVE-2023-1582 CVE-2023-1611 CVE-2023-2124 CVE-2023-2177 CVE-2023-23000 CVE-2023-23039 CVE-2023-26242 CVE-2023-28466 CVE-2023-33288 CVE-2023-3397 CVE-2023-35827 CVE-2023-3640 CVE-2023-37453 CVE-2023-37454 CVE-2023-3863 CVE-2023-39197 CVE-2023-39198 CVE-2023-4010 CVE-2023-4133 CVE-2023-4244 CVE-2023-4622 CVE-2023-47233 CVE-2023-52429 CVE-2023-52435 CVE-2023-6240 CVE-2023-6270 CVE-2023-6535 CVE-2023-6610 CVE-2023-7042 CVE-2024-0340 CVE-2024-0565 CVE-2024-0607 CVE-2024-1086 CVE-2024-21803 CVE-2024-23307 CVE-2024-23848 CVE-2024-23849 CVE-2024-23851 CVE-2024-25739 CVE-2024-25740 CVE-2024-26586), for more information check /home/build/work/emlinux/latest-dev/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
```

### Apply the change

Run cve-check for linux-k510.

```
WARNING: linux-k510-5.10-r0 do_cve_check: Found unpatched CVE (CVE-2008-4609 CVE-2010-4563 CVE-2013-2094 CVE-2013-6381 CVE-2014-0069 CVE-2014-3185 CVE-2015-5157 CVE-2018-1121 CVE-2018-3615 CVE-2018-9056 CVE-2019-0157 CVE-2019-14899 CVE-2020-0347 CVE-2020-0551 CVE-2020-12362 CVE-2020-12363 CVE-2020-12364 CVE-2020-15802 CVE-2020-24502 CVE-2020-24503 CVE-2020-24504 CVE-2020-26140 CVE-2020-26142 CVE-2020-26143 CVE-2020-26144 CVE-2020-26146 CVE-2020-26556 CVE-2020-26557 CVE-2020-26559 CVE-2020-26560 CVE-2020-35501 CVE-2021-0399 CVE-2021-0961 CVE-2021-1076 CVE-2021-1077 CVE-2021-29256 CVE-2021-31615 CVE-2021-32078 CVE-2021-33061 CVE-2021-33096 CVE-2021-3492 CVE-2021-3669 CVE-2021-3714 CVE-2021-3773 CVE-2021-3847 CVE-2021-3864 CVE-2021-3923 CVE-2021-39800 CVE-2021-39801 CVE-2021-39802 CVE-2021-46926 CVE-2021-46987 CVE-2021-47014 CVE-2021-47028 CVE-2021-47036 CVE-2021-47037 CVE-2021-47070 CVE-2021-47076 CVE-2021-47094 CVE-2021-47101 CVE-2021-47105 CVE-2021-47182 CVE-2021-47188 CVE-2021-47193 CVE-2021-47199 CVE-2021-47200 CVE-2021-47205 CVE-2021-47212 CVE-2022-0400 CVE-2022-0480 CVE-2022-0500 CVE-2022-1247 CVE-2022-20158 CVE-2022-23825 CVE-2022-25265 CVE-2022-25836 CVE-2022-25837 CVE-2022-26047 CVE-2022-27672 CVE-2022-28667 CVE-2022-2961 CVE-2022-3108 CVE-2022-3114 CVE-2022-3523 CVE-2022-3566 CVE-2022-3567 CVE-2022-36397 CVE-2022-38096 CVE-2022-38457 CVE-2022-40133 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-4543 CVE-2022-45884 CVE-2022-45885 CVE-2022-48628 CVE-2023-1075 CVE-2023-20569 CVE-2023-20593 CVE-2023-20937 CVE-2023-20941 CVE-2023-21400 CVE-2023-22995 CVE-2023-23000 CVE-2023-23039 CVE-2023-24023 CVE-2023-26242 CVE-2023-28746 CVE-2023-32629 CVE-2023-33053 CVE-2023-3397 CVE-2023-3640 CVE-2023-37454 CVE-2023-4010 CVE-2023-4133 CVE-2023-4622 CVE-2023-46813 CVE-2023-47233 CVE-2023-52429 CVE-2023-52434 CVE-2023-52435 CVE-2023-52442 CVE-2023-52447 CVE-2023-52458 CVE-2023-52476 CVE-2023-52479 CVE-2023-52480 CVE-2023-52481 CVE-2023-52482 CVE-2023-52484 CVE-2023-52485 CVE-2023-52486 CVE-2023-52488 CVE-2023-52489 CVE-2023-52491 CVE-2023-52492 CVE-2023-52493 CVE-2023-52494 CVE-2023-52497 CVE-2023-52498 CVE-2023-52506 CVE-2023-52508 CVE-2023-52511 CVE-2023-52517 CVE-2023-52530 CVE-2023-52531 CVE-2023-52561 CVE-2023-52569 CVE-2023-52572 CVE-2023-52583 CVE-2023-52586 CVE-2023-52587 CVE-2023-52588 CVE-2023-52589 CVE-2023-52590 CVE-2023-52591 CVE-2023-52593 CVE-2023-52594 CVE-2023-52595 CVE-2023-52596 CVE-2023-52597 CVE-2023-52598 CVE-2023-52599 CVE-2023-52600 CVE-2023-52601 CVE-2023-52602 CVE-2023-52603 CVE-2023-52604 CVE-2023-52606 CVE-2023-52607 CVE-2023-52608 CVE-2023-52610 CVE-2023-52614 CVE-2023-52615 CVE-2023-52616 CVE-2023-52617 CVE-2023-52618 CVE-2023-52619 CVE-2023-52620 CVE-2023-52621 CVE-2023-52622 CVE-2023-52623 CVE-2023-52624 CVE-2023-52625 CVE-2023-52627 CVE-2023-52629 CVE-2023-52630 CVE-2023-52633 CVE-2023-52635 CVE-2023-52637 CVE-2023-52638 CVE-2023-52639 CVE-2023-52640 CVE-2023-6240 CVE-2023-6270 CVE-2023-6531 CVE-2023-6535 CVE-2023-6610 CVE-2023-7042 CVE-2024-0340 CVE-2024-0565 CVE-2024-0607 CVE-2024-0841 CVE-2024-1086 CVE-2024-1151 CVE-2024-21803 CVE-2024-2193 CVE-2024-23307 CVE-2024-23848 CVE-2024-23849 CVE-2024-23850 CVE-2024-23851 CVE-2024-25739 CVE-2024-25740 CVE-2024-25741 CVE-2024-26581 CVE-2024-26583 CVE-2024-26584 CVE-2024-26585 CVE-2024-26589 CVE-2024-26592 CVE-2024-26593 CVE-2024-26594 CVE-2024-26595 CVE-2024-26600 CVE-2024-26601 CVE-2024-26602 CVE-2024-26606 CVE-2024-26607 CVE-2024-26610 CVE-2024-26614 CVE-2024-26615 CVE-2024-26622 CVE-2024-26625 CVE-2024-26627 CVE-2024-26629 CVE-2024-26635 CVE-2024-26636 CVE-2024-26639 CVE-2024-26640 CVE-2024-26641 CVE-2024-26642 CVE-2024-26643 CVE-2024-26644 CVE-2024-26645 CVE-2024-26646 CVE-2024-26647 CVE-2024-26648 CVE-2024-26651 CVE-2024-26654 CVE-2024-26656 CVE-2024-26659 CVE-2024-26661 CVE-2024-26662 CVE-2024-26663 CVE-2024-26664 CVE-2024-26665 CVE-2024-26668 CVE-2024-26669 CVE-2024-26671 CVE-2024-26673 CVE-2024-26675 CVE-2024-26677 CVE-2024-26679 CVE-2024-26680 CVE-2024-26684 CVE-2024-26685 CVE-2024-26686 CVE-2024-26687 CVE-2024-26688 CVE-2024-26689 CVE-2024-26691 CVE-2024-26695 CVE-2024-26696 CVE-2024-26697 CVE-2024-26698 CVE-2024-26699 CVE-2024-26700 CVE-2024-26702 CVE-2024-26704 CVE-2024-26706 CVE-2024-26707 CVE-2024-26712 CVE-2024-26715 CVE-2024-26718 CVE-2024-26719 CVE-2024-26720 CVE-2024-26722 CVE-2024-26726 CVE-2024-26727 CVE-2024-26733 CVE-2024-26735 CVE-2024-26736 CVE-2024-26739 CVE-2024-26740 CVE-2024-26743 CVE-2024-26744 CVE-2024-26747 CVE-2024-26748 CVE-2024-26749 CVE-2024-26751 CVE-2024-26752 CVE-2024-26753 CVE-2024-26754 CVE-2024-26756 CVE-2024-26757 CVE-2024-26758 CVE-2024-26759 CVE-2024-26763 CVE-2024-26764 CVE-2024-26765 CVE-2024-26766 CVE-2024-26767 CVE-2024-26768 CVE-2024-26769 CVE-2024-26771 CVE-2024-26772 CVE-2024-26773 CVE-2024-26775 CVE-2024-26776 CVE-2024-26777 CVE-2024-26778 CVE-2024-26779 CVE-2024-26781 CVE-2024-26782 CVE-2024-26787 CVE-2024-26788 CVE-2024-26790 CVE-2024-26791 CVE-2024-26792 CVE-2024-26793 CVE-2024-26795 CVE-2024-26801 CVE-2024-26804 CVE-2024-26805 CVE-2024-26807 CVE-2024-26808 CVE-2024-26809 CVE-2024-26810 CVE-2024-26811 CVE-2024-26812 CVE-2024-26813 CVE-2024-26814 CVE-2024-26816 CVE-2024-26817 CVE-2024-27297 CVE-2024-27437), for more information check /home/build/work/emlinux/latest-dev/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-k510/5.10-r0/temp/cve.log
```

Run cve-check for linux-base.

```
WARNING: linux-base-4.19-r0 do_cve_check: Found unpatched CVE (CVE-2008-4609 CVE-2010-4563 CVE-2010-5321 CVE-2013-2094 CVE-2013-6381 CVE-2014-0069 CVE-2014-3185 CVE-2015-2877 CVE-2015-5157 CVE-2018-1121 CVE-2018-3615 CVE-2018-9056 CVE-2019-0149 CVE-2019-0157 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-14899 CVE-2019-16089 CVE-2019-19083 CVE-2019-20794 CVE-2020-0347 CVE-2020-0551 CVE-2020-11725 CVE-2020-12362 CVE-2020-12363 CVE-2020-12364 CVE-2020-15802 CVE-2020-16120 CVE-2020-24502 CVE-2020-24503 CVE-2020-24504 CVE-2020-26140 CVE-2020-26141 CVE-2020-26142 CVE-2020-26143 CVE-2020-26144 CVE-2020-26145 CVE-2020-26146 CVE-2020-26541 CVE-2020-26556 CVE-2020-26557 CVE-2020-26559 CVE-2020-26560 CVE-2020-27820 CVE-2020-27835 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2020-36691 CVE-2020-36766 CVE-2020-36775 CVE-2020-36780 CVE-2020-36782 CVE-2020-36783 CVE-2020-36784 CVE-2020-4788 CVE-2021-0399 CVE-2021-0929 CVE-2021-0961 CVE-2021-1076 CVE-2021-1077 CVE-2021-29256 CVE-2021-31615 CVE-2021-32078 CVE-2021-33061 CVE-2021-33096 CVE-2021-33630 CVE-2021-3492 CVE-2021-3669 CVE-2021-3714 CVE-2021-3759 CVE-2021-3773 CVE-2021-3847 CVE-2021-3864 CVE-2021-3923 CVE-2021-39686 CVE-2021-39800 CVE-2021-39801 CVE-2021-39802 CVE-2021-4037 CVE-2021-46925 CVE-2021-46926 CVE-2021-46928 CVE-2021-46941 CVE-2021-46981 CVE-2021-46984 CVE-2021-47005 CVE-2021-47015 CVE-2021-47024 CVE-2021-47049 CVE-2021-47050 CVE-2021-47060 CVE-2021-47061 CVE-2021-47063 CVE-2021-47074 CVE-2021-47076 CVE-2021-47077 CVE-2021-47083 CVE-2021-47101 CVE-2021-47110 CVE-2021-47112 CVE-2021-47113 CVE-2021-47119 CVE-2021-47131 CVE-2021-47143 CVE-2021-47163 CVE-2021-47167 CVE-2021-47182 CVE-2021-47188 CVE-2021-47191 CVE-2021-47201 CVE-2021-47202 CVE-2021-47204 CVE-2021-47205 CVE-2021-47219 CVE-2022-0400 CVE-2022-0480 CVE-2022-1015 CVE-2022-1247 CVE-2022-20158 CVE-2022-21499 CVE-2022-23825 CVE-2022-25265 CVE-2022-25836 CVE-2022-25837 CVE-2022-26047 CVE-2022-27672 CVE-2022-28667 CVE-2022-2961 CVE-2022-29900 CVE-2022-29901 CVE-2022-3108 CVE-2022-3303 CVE-2022-3344 CVE-2022-3523 CVE-2022-3566 CVE-2022-3567 CVE-2022-36397 CVE-2022-36402 CVE-2022-39189 CVE-2022-4129 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-4543 CVE-2022-45884 CVE-2022-45885 CVE-2022-47520 CVE-2022-48627 CVE-2022-48628 CVE-2023-1249 CVE-2023-1582 CVE-2023-1611 CVE-2023-20569 CVE-2023-20588 CVE-2023-20593 CVE-2023-20928 CVE-2023-20937 CVE-2023-20938 CVE-2023-20941 CVE-2023-21102 CVE-2023-2124 CVE-2023-2177 CVE-2023-23000 CVE-2023-23039 CVE-2023-24023 CVE-2023-26242 CVE-2023-28466 CVE-2023-28746 CVE-2023-32629 CVE-2023-33288 CVE-2023-3397 CVE-2023-35827 CVE-2023-3640 CVE-2023-37453 CVE-2023-37454 CVE-2023-3863 CVE-2023-39197 CVE-2023-39198 CVE-2023-4010 CVE-2023-4133 CVE-2023-4244 CVE-2023-4622 CVE-2023-47233 CVE-2023-51779 CVE-2023-52429 CVE-2023-52435 CVE-2023-52442 CVE-2023-52458 CVE-2023-52474 CVE-2023-52476 CVE-2023-52479 CVE-2023-52480 CVE-2023-52481 CVE-2023-52482 CVE-2023-52484 CVE-2023-52485 CVE-2023-52486 CVE-2023-52488 CVE-2023-52491 CVE-2023-52498 CVE-2023-52500 CVE-2023-52501 CVE-2023-52506 CVE-2023-52508 CVE-2023-52509 CVE-2023-52511 CVE-2023-52515 CVE-2023-52516 CVE-2023-52517 CVE-2023-52522 CVE-2023-52530 CVE-2023-52531 CVE-2023-52561 CVE-2023-52569 CVE-2023-52572 CVE-2023-52583 CVE-2023-52586 CVE-2023-52587 CVE-2023-52588 CVE-2023-52589 CVE-2023-52590 CVE-2023-52591 CVE-2023-52594 CVE-2023-52595 CVE-2023-52596 CVE-2023-52597 CVE-2023-52598 CVE-2023-52599 CVE-2023-52600 CVE-2023-52601 CVE-2023-52602 CVE-2023-52603 CVE-2023-52604 CVE-2023-52606 CVE-2023-52607 CVE-2023-52614 CVE-2023-52615 CVE-2023-52617 CVE-2023-52619 CVE-2023-52620 CVE-2023-52621 CVE-2023-52622 CVE-2023-52623 CVE-2023-52624 CVE-2023-52625 CVE-2023-52628 CVE-2023-52629 CVE-2023-52638 CVE-2023-52639 CVE-2023-52640 CVE-2023-6121 CVE-2023-6240 CVE-2023-6270 CVE-2023-6535 CVE-2023-6610 CVE-2023-7042 CVE-2024-0340 CVE-2024-0565 CVE-2024-0607 CVE-2024-1086 CVE-2024-1151 CVE-2024-21803 CVE-2024-2193 CVE-2024-23307 CVE-2024-23848 CVE-2024-23849 CVE-2024-23851 CVE-2024-25739 CVE-2024-25740 CVE-2024-25741 CVE-2024-26584 CVE-2024-26586 CVE-2024-26592 CVE-2024-26594 CVE-2024-26595 CVE-2024-26600 CVE-2024-26602 CVE-2024-26606 CVE-2024-26614 CVE-2024-26615 CVE-2024-26622 CVE-2024-26625 CVE-2024-26629 CVE-2024-26635 CVE-2024-26636 CVE-2024-26640 CVE-2024-26641 CVE-2024-26642 CVE-2024-26644 CVE-2024-26645 CVE-2024-26646 CVE-2024-26647 CVE-2024-26648 CVE-2024-26651 CVE-2024-26654 CVE-2024-26656 CVE-2024-26659 CVE-2024-26663 CVE-2024-26664 CVE-2024-26668 CVE-2024-26671 CVE-2024-26675 CVE-2024-26677 CVE-2024-26679 CVE-2024-26685 CVE-2024-26686 CVE-2024-26687 CVE-2024-26691 CVE-2024-26696 CVE-2024-26697 CVE-2024-26699 CVE-2024-26700 CVE-2024-26704 CVE-2024-26706 CVE-2024-26715 CVE-2024-26719 CVE-2024-26720 CVE-2024-26722 CVE-2024-26726 CVE-2024-26733 CVE-2024-26735 CVE-2024-26736 CVE-2024-26739 CVE-2024-26740 CVE-2024-26743 CVE-2024-26744 CVE-2024-26747 CVE-2024-26751 CVE-2024-26752 CVE-2024-26754 CVE-2024-26756 CVE-2024-26757 CVE-2024-26758 CVE-2024-26759 CVE-2024-26763 CVE-2024-26764 CVE-2024-26765 CVE-2024-26766 CVE-2024-26767 CVE-2024-26768 CVE-2024-26769 CVE-2024-26771 CVE-2024-26772 CVE-2024-26773 CVE-2024-26775 CVE-2024-26777 CVE-2024-26778 CVE-2024-26779 CVE-2024-26791 CVE-2024-26793 CVE-2024-26801 CVE-2024-26804 CVE-2024-26805 CVE-2024-26807 CVE-2024-26810 CVE-2024-26811 CVE-2024-26812 CVE-2024-26813 CVE-2024-26816 CVE-2024-26817 CVE-2024-27297 CVE-2024-27437), for more information check /home/build/work/emlinux/latest-dev/build/tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log
```

For instance, tmp-glibc/deploy/cve/linux-k510 and tmp-glibc/deploy/cve/linux-base contain CVE-2024-27437 which is not reported before.

```
PACKAGE NAME: linux-k510
PACKAGE VERSION: 5.10
CVE: CVE-2024-27437
CVE STATUS: Unpatched
CVE SUMMARY: In the Linux kernel, the following vulnerability has been resolved:

vfio/pci: Disable auto-enable of exclusive INTx IRQ

Currently for devices requiring masking at the irqchip for INTx, ie.
devices without DisINTx support, the IRQ is enabled in request_irq()
and subsequently disabled as necessary to align with the masked status
flag.  This presents a window where the interrupt could fire between
these events, resulting in the IRQ incrementing the disable depth twice.
This would be unrecoverable for a user since the masked flag prevents
nested enables through vfio.

Instead, invert the logic using IRQF_NO_AUTOEN such that exclusive INTx
is never auto-enabled, then unmask as required.
CVSS v2 BASE SCORE: 0.0
CVSS v3 BASE SCORE: 0.0
VECTOR: UNKNOWN
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2024-27437
```

```
PACKAGE NAME: linux-base
PACKAGE VERSION: 4.19
CVE: CVE-2024-27437
CVE STATUS: Unpatched
CVE SUMMARY: In the Linux kernel, the following vulnerability has been resolved:

vfio/pci: Disable auto-enable of exclusive INTx IRQ

Currently for devices requiring masking at the irqchip for INTx, ie.
devices without DisINTx support, the IRQ is enabled in request_irq()
and subsequently disabled as necessary to align with the masked status
flag.  This presents a window where the interrupt could fire between
these events, resulting in the IRQ incrementing the disable depth twice.
This would be unrecoverable for a user since the masked flag prevents
nested enables through vfio.

Instead, invert the logic using IRQF_NO_AUTOEN such that exclusive INTx
is never auto-enabled, then unmask as required.
CVSS v2 BASE SCORE: 0.0
CVSS v3 BASE SCORE: 0.0
VECTOR: UNKNOWN
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2024-27437
```