### PR TITLE
Fix cyclonedx library import

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,9 +69,9 @@ RUN bash -c 'if test -n "$http_proxy"; then git config --global http.proxy "$htt
 RUN bash -c 'if test -n "$https_proxy"; then git config --global https.proxy "$https_proxy"; fi'
 RUN bash -c 'if test -n "$no_proxy"; then git config --global core.noproxy "$no_proxy"; fi'
 
-RUN pip install --user pip install cyclonedx-python-lib --break-system-packages
-RUN pip install --user pip install jsonschema --break-system-packages
-RUN pip install --user spdx-tools --break-system-packages
+RUN pip install --user pip install cyclonedx-python-lib==7.3.1 --break-system-packages
+RUN pip install --user pip install jsonschema==4.21.1 --break-system-packages
+RUN pip install --user spdx-tools==0.8.2 --break-system-packages
 
 RUN mkdir work
 WORKDIR /home/build/work

--- a/scripts/lib/python/sbom/sbom_cyclonedx.py
+++ b/scripts/lib/python/sbom/sbom_cyclonedx.py
@@ -2,9 +2,10 @@ from packageurl import PackageURL
 
 from cyclonedx.exception import MissingOptionalDependencyException
 from cyclonedx.factory.license import LicenseFactory
-from cyclonedx.model import OrganizationalEntity, HashType
+from cyclonedx.model import HashType
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component, ComponentType
+from cyclonedx.model.contact import OrganizationalEntity
 from cyclonedx.model.bom_ref import BomRef
 from cyclonedx.output.json import JsonV1Dot5
 from cyclonedx.schema import SchemaVersion


### PR DESCRIPTION
# Purpose of pull request

This pr fixes importing OrganizationalEntity module problem because latest cyclonedx-python-lib changed OrganizationalEntity module path.

Also, set version to install target for pip modules to avoid library update problem.

# Test
## How to test

Create spdx and cyclonedx sboms.

## Test result

spdx

```
build@7c2ae7d8fca2:~/work/build$ create_sbom.py --image emlinux-image-base --supplier "Cybertrust Japan Co., Ltd." --product EMLinux3 --sbom-format spdx
2024-04-23 02:38:28,328:INFO: Create spdx format sbom for emlinux-image-base
2024-04-23 02:38:28,419:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-spdx.json
```

cyclonedx

```
build@7c2ae7d8fca2:~/work/build$ create_sbom.py --image emlinux-image-base --supplier "Cybertrust Japan Co., Ltd." --product EMLinux3 --sbom-format cyclonedx
2024-04-23 02:38:53,310:INFO: Create cyclonedx format sbom for emlinux-image-base
2024-04-23 02:38:53,504:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-cyclonedx.json
```



