### PR TITLE
Update kernel to v4.19.312-cip109 and v5.10.214-cip46

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "6d03567cbcdc99d0c6372154f02172276261f851"
-LINUX_CVE_VERSION ??= "5.10.212"
-LINUX_CIP_VERSION ?= "v5.10.212-cip45"
+LINUX_GIT_SRCREV ?= "d1b399d941d4ab1d2107fef7a680deac88ccbc38"
+LINUX_CVE_VERSION ??= "5.10.214"
+LINUX_CIP_VERSION ?= "v5.10.214-cip46"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "b39bba29c35ca19fc6eec7baed1210cfa4c70c44"
-LINUX_CVE_VERSION ??= "4.19.310"
-LINUX_CIP_VERSION ??= "v4.19.310-cip108"
+LINUX_GIT_SRCREV ?= "959de52810ed02ef75efb3d00ed0b01718396700"
+LINUX_CVE_VERSION ??= "4.19.312"
+LINUX_CIP_VERSION ??= "v4.19.312-cip109"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.312-cip109 and v5.10.214-cip46

This pull request update the kernel to the following cip versions:
v4.19.312-cip109 with hash tag 959de52810ed02ef75efb3d00ed0b01718396700
v5.10.214-cip46 with hash tag d1b399d941d4ab1d2107fef7a680deac88ccbc38
