### PR TITLE
machine: add support for RaspberryPi 400

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ EMLinux currently supports following machines.
 - qemu-arm
 - generic-x86-64
 - raspberrypi3bplus-64
+- raspberrypi4b-64
+- raspberrypi400-64
 
 ## Sample Recipe
 

--- a/conf/machine/raspberrypi400-64.conf
+++ b/conf/machine/raspberrypi400-64.conf
@@ -1,0 +1,17 @@
+# Raspberry Pi profile
+# Copyright (c) Cybertrust Japan Co., Ltd.
+#
+# Authors:
+#  Masahiko Kimoto <masahiko.kimoto@cybertrust.co.jp>
+#
+# SPDX-License-Identifier: MIT
+#
+
+include conf/machine/raspberrypi4-64.inc
+
+IMAGE_INSTALL += "u-boot-raspberrypi400-64"
+
+PREFERRED_PROVIDER_u-boot-raspberrypi400-64 = "u-boot-raspberrypi4-64"
+U_BOOT_CONFIG:raspberrypi400-64 = "rpi_4_defconfig"
+
+DTB_FILES = "bcm2711-rpi-400.dtb"

--- a/doc/raspberrypi-64.md
+++ b/doc/raspberrypi-64.md
@@ -39,6 +39,11 @@ Building for Raspberry Pi 4B:
 $ echo 'MACHINE = "raspberrypi4b-64"' >> conf/local.conf
 ```
 
+Building for Raspberry Pi 400:
+```
+$ echo 'MACHINE = "raspberrypi400-64"' >> conf/local.conf
+```
+
 Start the image creation as below.
 
 ```
@@ -57,6 +62,10 @@ For Raspberry Pi 4B:
 ```
 $ xz -d tmp/deploy/images/raspberrypi4b-64/emlinux-image-base-emlinux-bookworm-raspberrypi4b-64.wic.xz
 ```
+For Raspberry Pi 400:
+```
+$ xz -d tmp/deploy/images/raspberrypi400-64/emlinux-image-base-emlinux-bookworm-raspberrypi400-64.wic.xz
+```
 
 Then, a wic image will be output to the following location.
 
@@ -68,6 +77,10 @@ For Raspberry Pi 4B:
 ```
 tmp/deploy/images/raspberrypi4b-64/emlinux-image-base-emlinux-bookworm-raspberrypi4b-64.wic
 ```
+For Raspberry Pi 400:
+```
+tmp/deploy/images/raspberrypi400-64/emlinux-image-base-emlinux-bookworm-raspberrypi400-64.wic
+```
 
 Write the wic image to a SD card with the dd command.
 
@@ -78,6 +91,10 @@ $ sudo dd if=emlinux-image-base-emlinux-bookworm-raspberrypi3bplus-64.wic of=/de
 For Raspberry Pi 4B:
 ```
 $ sudo dd if=emlinux-image-base-emlinux-bookworm-raspberrypi4b-64.wic of=/dev/sdX bs=4k conv=fsync
+```
+For Raspberry Pi 400:
+```
+$ sudo dd if=emlinux-image-base-emlinux-bookworm-raspberrypi400-64.wic of=/dev/sdX bs=4k conv=fsync
 ```
 
 Output device name "of=*/dev/sdX*" depends on your PC environment. Please replace appropriate device name.

--- a/recipes-bsp/rpi-boot-setting/rpi-u-boot-scr.bb
+++ b/recipes-bsp/rpi-boot-setting/rpi-u-boot-scr.bb
@@ -23,6 +23,7 @@ S = "${WORKDIR}/rpi-u-boot-${PV}"
 
 MMC_DEV_NUM:raspberrypi3bplus-64 = "0"
 MMC_DEV_NUM:raspberrypi4b-64 = "1"
+MMC_DEV_NUM:raspberrypi400-64 = "1"
 
 do_prepare_build() {
     mkdir ${S}

--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -24,6 +24,7 @@ SRC_URI:append:qemu-amd64 = " file://qemu-amd64_defconfig"
 SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
+SRC_URI:append:raspberrypi400-64 = " file://raspberrypi4-64_defconfig"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
 SRCREV = "f9ab8e7cbe8c82ae2816e96b065638c1dbe70158"


### PR DESCRIPTION
This PR adds support for RaspberryPi 400, personal computer type of Raspberry Pi, based on RPi4.

SoC of RaspberryPi 400 is identical to RaspberryPi 4B. RPi400 is all in one personal computer type of RPi4B.

- add MACHINE definition of raspberrypi400-64.
- add u-boot setting for RPi400.
- add device tree setting for RPi400.
- fix up documents.

dmesg is as follows.

```
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd083]
[    0.000000] Linux version 6.1.83-cip18 (isar-users@googlegroups.com) (aarch64-linux-gnu-gcc (Debian 12.2.0-14) 12.2.0, GNU ld (GNU Binutils for Debian) 2.40) #1 SMP PREEMPT Thu, 01 Jan 1970 01:00:00 +0000
[    0.000000] Machine model: Raspberry Pi 400 Rev 1.0
[    0.000000] efi: UEFI not found.
[    0.000000] Reserved memory: created CMA memory pool at 0x000000003a400000, size 64 MiB
[    0.000000] OF: reserved mem: initialized node linux,cma, compatible id shared-dma-pool
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000000000000-0x000000003fffffff]
[    0.000000]   DMA32    [mem 0x0000000040000000-0x00000000fbffffff]
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x000000003e5fffff]
[    0.000000]   node   0: [mem 0x0000000040000000-0x00000000fbffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x00000000fbffffff]
[    0.000000] On node 0, zone DMA32: 6656 pages in unavailable ranges
[    0.000000] On node 0, zone DMA32: 16384 pages in unavailable ranges
[    0.000000] percpu: Embedded 30 pages/cpu s82600 r8192 d32088 u122880
[    0.000000] pcpu-alloc: s82600 r8192 d32088 u122880 alloc=30*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Detected PIPT I-cache on CPU0
[    0.000000] CPU features: detected: Spectre-v2
[    0.000000] CPU features: detected: Spectre-v3a
[    0.000000] CPU features: detected: Spectre-v4
[    0.000000] CPU features: detected: Spectre-BHB
[    0.000000] CPU features: kernel page table isolation forced ON by KASLR
[    0.000000] CPU features: detected: Kernel page table isolation (KPTI)
[    0.000000] CPU features: detected: ARM erratum 1742098
[    0.000000] CPU features: detected: ARM errata 1165522, 1319367, or 1530923
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 1009408
[    0.000000] Kernel command line: dwc_otg.lpm_enable=0 earlyprintk root=PARTUUID=7240d634-02 rootfstype=ext4 rootwait
[    0.000000] Unknown kernel command line parameters "earlyprintk", will be passed to user space.
[    0.000000] Dentry cache hash table entries: 524288 (order: 10, 4194304 bytes, linear)
[    0.000000] Inode-cache hash table entries: 262144 (order: 9, 2097152 bytes, linear)
[    0.000000] mem auto-init: stack:all(zero), heap alloc:off, heap free:off
[    0.000000] software IO TLB: area num 4.
[    0.000000] software IO TLB: mapped [mem 0x0000000036400000-0x000000003a400000] (64MB)
[    0.000000] Memory: 3865256K/4102144K available (12672K kernel code, 2140K rwdata, 4224K rodata, 4352K init, 1071K bss, 171352K reserved, 65536K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] ftrace: allocating 41189 entries in 161 pages
[    0.000000] ftrace: allocated 161 pages with 3 groups
[    0.000000] trace event string verifier disabled
[    0.000000] rcu: Preemptible hierarchical RCU implementation.
[    0.000000] rcu: 	RCU event tracing is enabled.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=256 to nr_cpu_ids=4.
[    0.000000] 	Trampoline variant of Tasks RCU enabled.
[    0.000000] 	Rude variant of Tasks RCU enabled.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GIC: Using split EOI/Deactivate mode
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 54.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0xc743ce346, max_idle_ns: 440795203123 ns
[    0.000001] sched_clock: 56 bits at 54MHz, resolution 18ns, wraps every 4398046511102ns
[    0.000254] Console: colour dummy device 80x25
[    0.000803] printk: console [tty0] enabled
[    0.000871] Calibrating delay loop (skipped), value calculated using timer frequency.. 108.00 BogoMIPS (lpj=216000)
[    0.000912] pid_max: default: 32768 minimum: 301
[    0.001042] LSM: Security Framework initializing
[    0.001263] Mount-cache hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.001336] Mountpoint-cache hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.004113] cblist_init_generic: Setting adjustable number of callback queues.
[    0.004153] cblist_init_generic: Setting shift to 2 and lim to 1.
[    0.004333] cblist_init_generic: Setting adjustable number of callback queues.
[    0.004360] cblist_init_generic: Setting shift to 2 and lim to 1.
[    0.004531] cblist_init_generic: Setting adjustable number of callback queues.
[    0.004558] cblist_init_generic: Setting shift to 2 and lim to 1.
[    0.004959] rcu: Hierarchical SRCU implementation.
[    0.004983] rcu: 	Max phase no-delay instances is 1000.
[    0.006154] EFI services will not be available.
[    0.006651] smp: Bringing up secondary CPUs ...
[    0.007647] Detected PIPT I-cache on CPU1
[    0.007795] CPU1: Booted secondary processor 0x0000000001 [0x410fd083]
[    0.008876] Detected PIPT I-cache on CPU2
[    0.008994] CPU2: Booted secondary processor 0x0000000002 [0x410fd083]
[    0.010046] Detected PIPT I-cache on CPU3
[    0.010164] CPU3: Booted secondary processor 0x0000000003 [0x410fd083]
[    0.010325] smp: Brought up 1 node, 4 CPUs
[    0.010409] SMP: Total of 4 processors activated.
[    0.010429] CPU features: detected: 32-bit EL0 Support
[    0.010447] CPU features: detected: 32-bit EL1 Support
[    0.010467] CPU features: detected: CRC32 instructions
[    0.010602] CPU: All CPU(s) started at EL2
[    0.010646] alternatives: applying system-wide alternatives
[    0.012678] devtmpfs: initialized
[    0.018709] Registered cp15_barrier emulation handler
[    0.018766] Registered setend emulation handler
[    0.019089] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.019138] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.021118] pinctrl core: initialized pinctrl subsystem
[    0.021881] DMI not present or invalid.
[    0.022736] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.025889] DMA: preallocated 512 KiB GFP_KERNEL pool for atomic allocations
[    0.026106] DMA: preallocated 512 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.026599] DMA: preallocated 512 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.026691] audit: initializing netlink subsys (disabled)
[    0.026947] audit: type=2000 audit(0.024:1): state=initialized audit_enabled=0 res=1
[    0.027417] thermal_sys: Registered thermal governor 'step_wise'
[    0.027495] cpuidle: using governor menu
[    0.027643] hw-breakpoint: found 6 breakpoint and 4 watchpoint registers.
[    0.027826] ASID allocator initialised with 32768 entries
[    0.027986] Serial: AMBA PL011 UART driver
[    0.058676] KASLR enabled
[    0.090961] SCSI subsystem initialized
[    0.091185] usbcore: registered new interface driver usbfs
[    0.091254] usbcore: registered new interface driver hub
[    0.091331] usbcore: registered new device driver usb
[    0.091696] usb_phy_generic phy: supply vcc not found, using dummy regulator
[    0.091862] usb_phy_generic phy: dummy supplies not allowed for exclusive requests
[    0.091901] usb_phy_generic phy: dummy supplies not allowed for exclusive requests
[    0.092259] pps_core: LinuxPPS API ver. 1 registered
[    0.092283] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
[    0.092320] PTP clock support registered
[    0.092533] Advanced Linux Sound Architecture Driver Initialized.
[    0.093368] vgaarb: loaded
[    0.093840] clocksource: Switched to clocksource arch_sys_counter
[    0.094584] VFS: Disk quotas dquot_6.6.0
[    0.094685] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
[    0.094852] FS-Cache: Loaded
[    0.095037] CacheFiles: Loaded
[    0.104643] NET: Registered PF_INET protocol family
[    0.105211] IP idents hash table entries: 65536 (order: 7, 524288 bytes, linear)
[    0.110086] tcp_listen_portaddr_hash hash table entries: 2048 (order: 3, 32768 bytes, linear)
[    0.110165] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.110204] TCP established hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.110404] TCP bind hash table entries: 32768 (order: 8, 1048576 bytes, linear)
[    0.111437] TCP: Hash tables configured (established 32768 bind 32768)
[    0.111672] UDP hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.111767] UDP-Lite hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.112103] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.112935] RPC: Registered named UNIX socket transport module.
[    0.112964] RPC: Registered udp transport module.
[    0.112983] RPC: Registered tcp transport module.
[    0.113000] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    0.113032] PCI: CLS 0 bytes, default 64
[    0.115395] hw perfevents: enabled with armv8_cortex_a72 PMU driver, 7 counters available
[    0.115730] kvm [1]: IPA Size Limit: 44 bits
[    0.117040] kvm [1]: vgic interrupt IRQ9
[    0.117238] kvm [1]: Hyp mode initialized successfully
[    1.141334] Initialise system trusted keyrings
[    1.141798] workingset: timestamp_bits=46 max_order=20 bucket_order=0
[    1.148215] zbud: loaded
[    1.150639] NFS: Registering the id_resolver key type
[    1.150696] Key type id_resolver registered
[    1.150716] Key type id_legacy registered
[    1.150836] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
[    1.150863] nfs4flexfilelayout_init: NFSv4 Flexfile Layout Driver Registering...
[    1.152087] Key type asymmetric registered
[    1.152117] Asymmetric key parser 'x509' registered
[    1.152199] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 246)
[    1.152464] io scheduler mq-deadline registered
[    1.152491] io scheduler kyber registered
[    1.154455] irq_brcmstb_l2: registered L2 intc (/soc/interrupt-controller@7ef00100, parent irq: 18)
[    1.160246] brcm-pcie fd500000.pcie: host bridge /scb/pcie@7d500000 ranges:
[    1.160298] brcm-pcie fd500000.pcie:   No bus range found for /scb/pcie@7d500000, using [bus 00-ff]
[    1.160386] brcm-pcie fd500000.pcie:      MEM 0x0600000000..0x0603ffffff -> 0x00f8000000
[    1.160476] brcm-pcie fd500000.pcie:   IB MEM 0x0000000000..0x00bfffffff -> 0x0400000000
[    1.161588] brcm-pcie fd500000.pcie: PCI host bridge to bus 0000:00
[    1.161620] pci_bus 0000:00: root bus resource [bus 00-ff]
[    1.161648] pci_bus 0000:00: root bus resource [mem 0x600000000-0x603ffffff] (bus address [0xf8000000-0xfbffffff])
[    1.161738] pci 0000:00:00.0: [14e4:2711] type 01 class 0x060400
[    1.162011] pci 0000:00:00.0: PME# supported from D0 D3hot
[    1.164666] pci_bus 0000:01: supply vpcie3v3 not found, using dummy regulator
[    1.164824] pci_bus 0000:01: supply vpcie3v3aux not found, using dummy regulator
[    1.164919] pci_bus 0000:01: supply vpcie12v not found, using dummy regulator
[    1.227923] brcm-pcie fd500000.pcie: link up, 5.0 GT/s PCIe x1 (SSC)
[    1.228094] pci 0000:01:00.0: [1106:3483] type 00 class 0x0c0330
[    1.228226] pci 0000:01:00.0: reg 0x10: [mem 0x00000000-0x00000fff 64bit]
[    1.228693] pci 0000:01:00.0: PME# supported from D0 D3hot
[    1.229362] pci 0000:00:00.0: BAR 8: assigned [mem 0x600000000-0x6000fffff]
[    1.229400] pci 0000:01:00.0: BAR 0: assigned [mem 0x600000000-0x600000fff 64bit]
[    1.229452] pci 0000:00:00.0: PCI bridge to [bus 01]
[    1.229482] pci 0000:00:00.0:   bridge window [mem 0x600000000-0x6000fffff]
[    1.230295] simple-framebuffer 3e914000.framebuffer: framebuffer at 0x3e914000, 0x6d8c00 bytes
[    1.230330] simple-framebuffer 3e914000.framebuffer: format=a8r8g8b8, mode=1824x984x32, linelength=7296
[    1.237912] Console: switching to colour frame buffer device 228x61
[    1.244707] simple-framebuffer 3e914000.framebuffer: fb0: simplefb registered!
[    1.252949] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
[    1.255456] fe215040.serial: ttyS1 at MMIO 0xfe215040 (irq = 30, base_baud = 62499999) is a 16550
[    2.370693] printk: console [ttyS1] enabled
[    2.377399] iproc-rng200 fe104000.rng: hwrng registered
[    2.399974] brd: module loaded
[    2.410702] loop: module loaded
[    2.414902] bcm2835-power bcm2835-power: Broadcom BCM2835 power domains driver
[    2.422999] Loading iSCSI transport class v2.0-870.
[    2.432382] bcmgenet fd580000.ethernet: GENET 5.0 EPHY: 0x0000
[    2.533977] unimac-mdio unimac-mdio.-19: Broadcom UniMAC MDIO bus
[    2.541142] usbcore: registered new device driver r8152-cfgselector
[    2.547634] usbcore: registered new interface driver r8152
[    2.553321] usbcore: registered new interface driver lan78xx
[    2.559174] usbcore: registered new interface driver smsc95xx
[    2.565845] usbcore: registered new interface driver uas
[    2.571356] usbcore: registered new interface driver usb-storage
[    2.577724] mousedev: PS/2 mouse device common for all mice
[    2.587527] bcm2835-wdt bcm2835-wdt: Broadcom BCM2835 watchdog timer
[    2.595008] sdhci: Secure Digital Host Controller Interface driver
[    2.601352] sdhci: Copyright(c) Pierre Ossman
[    2.606099] sdhci-pltfm: SDHCI platform and OF driver helper
[    2.613471] ledtrig-cpu: registered to indicate activity on CPUs
[    2.620050] hid: raw HID events driver (C) Jiri Kosina
[    2.625483] usbcore: registered new interface driver usbhid
[    2.631207] usbhid: USB HID core driver
[    2.636189] bcm2835-mbox fe00b880.mailbox: mailbox enabled
[    2.643516] NET: Registered PF_PACKET protocol family
[    2.648809] Key type dns_resolver registered
[    2.654098] registered taskstats version 1
[    2.658397] Loading compiled-in X.509 certificates
[    2.665777] zswap: loaded using pool lzo/zbud
[    2.672780] Key type .fscrypt registered
[    2.678714] Key type fscrypt-provisioning registered
[    2.696485] fe201000.serial: ttyAMA0 at MMIO 0xfe201000 (irq = 36, base_baud = 0) is a PL011 rev2
[    2.707839] serial serial0: tty port ttyAMA0 registered
[    2.716388] raspberrypi-firmware soc:firmware: Attached to firmware from 2023-03-17T10:50:56
[    2.728241] uart-pl011 fe201000.serial: Failed to create device link (0x180) with soc:firmware:gpio
[    2.748939] Console: switching to colour dummy device 80x25
[    2.795122] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[    2.847590] pci 0000:00:00.0: enabling device (0000 -> 0002)
[    2.853522] xhci_hcd 0000:01:00.0: xHCI Host Controller
[    2.858876] xhci_hcd 0000:01:00.0: new USB bus registered, assigned bus number 1
[    2.866868] xhci_hcd 0000:01:00.0: hcc params 0x002841eb hci version 0x100 quirks 0x0000000000000890
[    2.877113] xhci_hcd 0000:01:00.0: xHCI Host Controller
[    2.882460] xhci_hcd 0000:01:00.0: new USB bus registered, assigned bus number 2
[    2.890007] xhci_hcd 0000:01:00.0: Host supports USB 3.0 SuperSpeed
[    2.896704] usb usb1: New USB device found, idVendor=1d6b, idProduct=0002, bcdDevice= 6.01
[    2.905131] usb usb1: New USB device strings: Mfr=3, Product=2, SerialNumber=1
[    2.912491] usb usb1: Product: xHCI Host Controller
[    2.917465] usb usb1: Manufacturer: Linux 6.1.83-cip18 xhci-hcd
[    2.923498] usb usb1: SerialNumber: 0000:01:00.0
[    2.928902] hub 1-0:1.0: USB hub found
[    2.932837] hub 1-0:1.0: 1 port detected
[    2.937779] usb usb2: New USB device found, idVendor=1d6b, idProduct=0003, bcdDevice= 6.01
[    2.946230] usb usb2: New USB device strings: Mfr=3, Product=2, SerialNumber=1
[    2.953605] usb usb2: Product: xHCI Host Controller
[    2.958768] usb usb2: Manufacturer: Linux 6.1.83-cip18 xhci-hcd
[    2.964807] usb usb2: SerialNumber: 0000:01:00.0
[    2.970144] hub 2-0:1.0: USB hub found
[    2.974063] hub 2-0:1.0: 4 ports detected
[    2.984264] sdhci-iproc fe300000.mmc: allocated mmc-pwrseq
[    2.992135] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[    3.000098] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[    3.022212] mmc0: SDHCI controller on fe300000.mmc [fe300000.mmc] using PIO
[    3.030767] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[    3.041849] mmc1: SDHCI controller on fe340000.mmc [fe340000.mmc] using ADMA
[    3.050214] ALSA device list:
[    3.053305]   No soundcards found.
[    3.053424] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[    3.063502] Waiting for root device PARTUUID=7240d634-02...
[    3.134358] mmc0: new high speed SDIO card at address 0001
[    3.158114] mmc1: new ultra high speed DDR50 SDHC card at address 59b4
[    3.165704] mmcblk1: mmc1:59b4       29.0 GiB 
[    3.173249]  mmcblk1: p1 p2
[    3.177867] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[    3.189864] usb 1-1: new high-speed USB device number 2 using xhci_hcd
[    3.203163] EXT4-fs (mmcblk1p2): mounted filesystem with ordered data mode. Quota mode: none.
[    3.212033] VFS: Mounted root (ext4 filesystem) readonly on device 179:2.
[    3.219685] devtmpfs: mounted
[    3.230008] Freeing unused kernel memory: 4352K
[    3.234814] Run /sbin/init as init process
[    3.239001]   with arguments:
[    3.239011]     /sbin/init
[    3.239021]     earlyprintk
[    3.239030]   with environment:
[    3.239040]     HOME=/
[    3.239049]     TERM=linux
[    3.349296] usb 1-1: New USB device found, idVendor=2109, idProduct=3431, bcdDevice= 4.21
[    3.357679] usb 1-1: New USB device strings: Mfr=0, Product=1, SerialNumber=0
[    3.365043] usb 1-1: Product: USB2.0 Hub
[    3.370770] hub 1-1:1.0: USB hub found
[    3.374887] hub 1-1:1.0: 4 ports detected
[    3.388582] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[    3.673871] usb 1-1.4: new low-speed USB device number 3 using xhci_hcd
[    3.836555] usb 1-1.4: New USB device found, idVendor=04d9, idProduct=0007, bcdDevice= 1.61
[    3.845084] usb 1-1.4: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[    3.852535] usb 1-1.4: Product: Raspberry Pi Internal Keyboard
[    3.858481] usb 1-1.4: Manufacturer:  
[    3.888994] input:   Raspberry Pi Internal Keyboard as /devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1.4/1-1.4:1.0/0003:04D9:0007.0001/input/input0
[    3.966422] hid-generic 0003:04D9:0007.0001: input,hidraw0: USB HID v1.11 Keyboard [  Raspberry Pi Internal Keyboard] on usb-0000:01:00.0-1.4/input0
[    3.981163] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[    3.999565] input:   Raspberry Pi Internal Keyboard as /devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1.4/1-1.4:1.1/0003:04D9:0007.0002/input/input1
[    4.074212] hid-generic 0003:04D9:0007.0002: input,hidraw1: USB HID v1.11 Device [  Raspberry Pi Internal Keyboard] on usb-0000:01:00.0-1.4/input1
[    4.088751] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[    5.613059] systemd[1]: System time before build time, advancing clock.
[    5.784461] NET: Registered PF_INET6 protocol family
[    5.791369] Segment Routing with IPv6
[    5.795190] In-situ OAM (IOAM) with IPv6
[    5.873569] systemd[1]: systemd 252.22-1~deb12u1 running in system mode (+PAM +AUDIT +SELINUX +APPARMOR +IMA +SMACK +SECCOMP +GCRYPT -GNUTLS +OPENSSL +ACL +BLKID +CURL +ELFUTILS +FIDO2 +IDN2 -IDN +IPTC +KMOD +LIBCRYPTSETUP +LIBFDISK +PCRE2 -PWQUALITY +P11KIT +QRENCODE +TPM2 +BZIP2 +LZ4 +XZ +ZLIB +ZSTD -BPF_FRAMEWORK -XKBCOMMON +UTMP +SYSVINIT default-hierarchy=unified)
[    5.906963] systemd[1]: Detected architecture arm64.
[    5.912920] systemd[1]: Detected first boot.
[    5.937730] systemd[1]: Hostname set to <EMLinux3>.
[    5.955175] systemd[1]: Initializing machine ID from random generator.
[    8.252882] systemd[1]: Failed to populate /etc with preset unit settings, ignoring: Read-only file system
[    8.585409] systemd[1]: Queued start job for default target graphical.target.
[    8.620414] systemd[1]: Created slice system-getty.slice - Slice /system/getty.
[    8.648340] systemd[1]: Created slice system-modprobe.slice - Slice /system/modprobe.
[    8.676267] systemd[1]: Created slice system-serial\x2dgetty.slice - Slice /system/serial-getty.
[    8.702591] systemd[1]: Started systemd-ask-password-console.path - Dispatch Password Requests to Console Directory Watch.
[    8.734511] systemd[1]: Started systemd-ask-password-wall.path - Forward Password Requests to Wall Directory Watch.
[    8.763159] systemd[1]: Set up automount proc-sys-fs-binfmt_misc.automount - Arbitrary Executable File Formats File System Automount Point.
[    8.794119] systemd[1]: Expecting device dev-disk-by\x2duuid-E722\x2dE4C7.device - /dev/disk/by-uuid/E722-E4C7...
[    8.822003] systemd[1]: Expecting device dev-ttyS1.device - /dev/ttyS1...
[    8.846049] systemd[1]: Reached target cryptsetup.target - Local Encrypted Volumes.
[    8.874084] systemd[1]: Reached target integritysetup.target - Local Integrity Protected Volumes.
[    8.902069] systemd[1]: Reached target paths.target - Path Units.
[    8.926071] systemd[1]: Reached target remote-fs.target - Remote File Systems.
[    8.950068] systemd[1]: Reached target slices.target - Slice Units.
[    8.974069] systemd[1]: Reached target swap.target - Swaps.
[    8.994048] systemd[1]: Reached target veritysetup.target - Local Verity Protected Volumes.
[    9.022547] systemd[1]: Listening on systemd-initctl.socket - initctl Compatibility Named Pipe.
[    9.051914] systemd[1]: Listening on systemd-journald-audit.socket - Journal Audit Socket.
[    9.079135] systemd[1]: Listening on systemd-journald-dev-log.socket - Journal Socket (/dev/log).
[    9.107134] systemd[1]: Listening on systemd-journald.socket - Journal Socket.
[    9.135358] systemd[1]: Listening on systemd-udevd-control.socket - udev Control Socket.
[    9.162915] systemd[1]: Listening on systemd-udevd-kernel.socket - udev Kernel Socket.
[    9.190060] systemd[1]: Reached target sockets.target - Socket Units.
[    9.215080] systemd[1]: dev-hugepages.mount - Huge Pages File System was skipped because of an unmet condition check (ConditionPathExists=/sys/kernel/mm/hugepages).
[    9.254453] systemd[1]: Mounting dev-mqueue.mount - POSIX Message Queue File System...
[    9.290120] systemd[1]: Mounting sys-kernel-debug.mount - Kernel Debug File System...
[    9.325492] systemd[1]: Mounting sys-kernel-tracing.mount - Kernel Trace File System...
[    9.374829] systemd[1]: Starting kmod-static-nodes.service - Create List of Static Device Nodes...
[    9.409875] systemd[1]: Starting modprobe@configfs.service - Load Kernel Module configfs...
[    9.445942] systemd[1]: Starting modprobe@dm_mod.service - Load Kernel Module dm_mod...
[    9.478146] systemd[1]: Starting modprobe@efi_pstore.service - Load Kernel Module efi_pstore...
[    9.499134] device-mapper: ioctl: 4.47.0-ioctl (2022-07-28) initialised: dm-devel@redhat.com
[    9.516125] systemd[1]: Starting modprobe@fuse.service - Load Kernel Module fuse...
[    9.550442] systemd[1]: Starting modprobe@loop.service - Load Kernel Module loop...
[    9.575139] fuse: init (API version 7.37)
[    9.586191] systemd[1]: Starting systemd-journald.service - Journal Service...
[    9.620528] systemd[1]: Starting systemd-modules-load.service - Load Kernel Modules...
[    9.682849] systemd[1]: Starting systemd-remount-fs.service - Remount Root and Kernel File Systems...
[    9.718273] systemd[1]: Starting systemd-udev-trigger.service - Coldplug All udev Devices...
[    9.755878] systemd[1]: Mounted dev-mqueue.mount - POSIX Message Queue File System.
[    9.790391] systemd[1]: Mounted sys-kernel-debug.mount - Kernel Debug File System.
[    9.819290] systemd[1]: Mounted sys-kernel-tracing.mount - Kernel Trace File System.
[    9.848220] systemd[1]: Finished kmod-static-nodes.service - Create List of Static Device Nodes.
[    9.881461] systemd[1]: modprobe@configfs.service: Deactivated successfully.
[    9.890263] systemd[1]: Finished modprobe@configfs.service - Load Kernel Module configfs.
[    9.919183] systemd[1]: Started systemd-journald.service - Journal Service.
[    9.964420] EXT4-fs (mmcblk1p2): re-mounted. Quota mode: none.
[   10.230947] systemd-journald[139]: Received client request to flush runtime journal.
[   11.169878] random: crng init done
[   11.234641] bcmgenet fd580000.ethernet end0: renamed from eth0
[   11.370559] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[   11.445804] snd_bcm2835: module is from the staging directory, the quality is unknown, you have been warned.
[   11.481611] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[   11.517684] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[   11.545593] mc: Linux media interface: v0.10
[   11.620835] brcmstb-i2c fef04500.i2c:  @97500hz registered in polling mode
[   11.630020] vc4-drm gpu: bound fe400000.hvs (ops vc4_hvs_ops)
[   11.640867] bcm2835_audio bcm2835_audio: card created with 8 channels
[   11.649813] brcmstb-i2c fef09500.i2c:  @97500hz registered in polling mode
[   11.650494] dwc2 fe980000.usb: supply vusb_d not found, using dummy regulator
[   11.692372] Registered IR keymap rc-cec
[   11.707422] dwc2 fe980000.usb: supply vusb_a not found, using dummy regulator
[   11.741377] rc rc0: vc4-hdmi-0 as /devices/platform/soc/fef00700.hdmi/rc/rc0
[   11.761686] [drm] Initialized v3d 1.0.0 20180419 for fec00000.gpu on minor 0
[   11.799200] input: vc4-hdmi-0 as /devices/platform/soc/fef00700.hdmi/rc/rc0/input2
[   11.829994] dwc2 fe980000.usb: EPs: 8, dedicated fifos, 4080 entries in SPRAM
[   11.856779] vc4-drm gpu: bound fef00700.hdmi (ops vc4_hdmi_ops)
[   11.931939] Registered IR keymap rc-cec
[   11.936285] rc rc1: vc4-hdmi-1 as /devices/platform/soc/fef05700.hdmi/rc/rc1
[   11.943717] videodev: Linux video capture interface: v2.00
[   11.946144] input: vc4-hdmi-1 as /devices/platform/soc/fef05700.hdmi/rc/rc1/input3
[   11.967591] vc4-drm gpu: bound fef05700.hdmi (ops vc4_hdmi_ops)
[   11.974707] vc4-drm gpu: bound fe004000.txp (ops vc4_txp_ops)
[   11.984484] vc4-drm gpu: bound fe206000.pixelvalve (ops vc4_crtc_ops)
[   11.997263] vc4-drm gpu: bound fe207000.pixelvalve (ops vc4_crtc_ops)
[   12.004784] vc4-drm gpu: bound fe20a000.pixelvalve (ops vc4_crtc_ops)
[   12.012435] vc4-drm gpu: bound fe216000.pixelvalve (ops vc4_crtc_ops)
[   12.022375] [drm] Initialized vc4 0.0.0 20140616 for gpu on minor 1
[   12.130416] Console: switching to colour frame buffer device 240x67
[   12.154806] vc4-drm gpu: [drm] fb0: vc4drmfb frame buffer device
[   12.249954] bcm2835_mmal_vchiq: module is from the staging directory, the quality is unknown, you have been warned.
[   12.369766] bcm2835_v4l2: module is from the staging directory, the quality is unknown, you have been warned.
[   12.402109] bcm2835_mmal_vchiq: Failed to open VCHI service connection (status=-1)
[   12.418975] Bluetooth: Core ver 2.22
[   12.429588] NET: Registered PF_BLUETOOTH protocol family
[   12.435804] Bluetooth: HCI device and connection manager initialized
[   12.442921] Bluetooth: HCI socket layer initialized
[   12.449408] Bluetooth: L2CAP socket layer initialized
[   12.455130] Bluetooth: SCO socket layer initialized
[   12.458218] cfg80211: Loading compiled-in X.509 certificates for regulatory database
[   12.486680] Bluetooth: HCI UART driver ver 2.3
[   12.491486] Bluetooth: HCI UART protocol H4 registered
[   12.497028] Bluetooth: HCI UART protocol Three-wire (H5) registered
[   12.499356] cfg80211: Loaded X.509 cert 'sforshee: 00b28ddf47aef9cea7'
[   12.503869] Bluetooth: HCI UART protocol Broadcom registered
[   12.505417] hci_uart_bcm serial0-0: supply vbat not found, using dummy regulator
[   12.505650] hci_uart_bcm serial0-0: supply vddio not found, using dummy regulator
[   12.511096] cfg80211: Loaded X.509 cert 'wens: 61c038651aabdcf94bd0ac7ff06c7248db18c600'
[   12.540517] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2
[   12.549616] cfg80211: failed to load regulatory.db
[   12.626189] uart-pl011 fe201000.serial: no DMA platform data
[   12.832658] brcmfmac: F1 signature read @0x18000000=0x15294345
[   12.839051] brcmfmac: brcmf_fw_alloc_request: using brcm/brcmfmac43456-sdio for chip BCM4345/9
[   12.848924] brcmfmac mmc0:0001:1: Direct firmware load for brcm/brcmfmac43456-sdio.raspberrypi,400.bin failed with error -2
[   12.858487] usbcore: registered new interface driver brcmfmac
[   12.863238] brcmfmac mmc0:0001:1: Direct firmware load for brcm/brcmfmac43456-sdio.bin failed with error -2
[   12.878869] Bluetooth: hci0: BCM: chip id 130
[   12.884516] Bluetooth: hci0: BCM: features 0x0f
[   12.891664] Bluetooth: hci0: BCM4345C5
[   12.896143] Bluetooth: hci0: BCM4345C5 (003.006.006) build 0000
[   12.902950] Bluetooth: hci0: BCM: firmware Patch file not found, tried:
[   12.909794] Bluetooth: hci0: BCM: 'brcm/BCM4345C5.raspberrypi,400.hcd'
[   12.916527] Bluetooth: hci0: BCM: 'brcm/BCM4345C5.hcd'
[   12.921816] Bluetooth: hci0: BCM: 'brcm/BCM.raspberrypi,400.hcd'
[   12.928283] Bluetooth: hci0: BCM: 'brcm/BCM.hcd'
[   12.955101] Bluetooth: hci0: Opcode 0x2031 failed: -22
[   13.885606] brcmfmac: brcmf_sdio_htclk: HT Avail timeout (1000000): clkctl 0x50

```
