### PR TITLE
linux-base: Add multiple CVEs to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -33,6 +33,12 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2023-6915: This is false positive because 4.19.y is not affected.
 # CVE-2023-1611: This is false positive because 4.19.y is not affected.
 # CVE-2024-26594: This is false positive because 4.19.y is not affected.
+# CVE-2021-0399: This is false positive because it is Android kernel issue.
+# CVE-2021-1076: This is false positive because it is NVIDIA driver issue.
+# CVE-2021-29256: This is false positive because it is ARM Mali driver issue.
+# CVE-2021-3492: This is false positive becuase it is Ubuntu specified kernel issue.
+# CVE-2021-39802: This is false positive because it is Android kernel issue.
+# CVE-2022-36397: This is false positive because it is Intel QAT driver issue.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
@@ -43,4 +49,6 @@ CVE_CHECK_WHITELIST = "\
     CVE-1999-0524 CVE-2023-1076 CVE-2015-7312 \
     CVE-1999-0656 CVE-2006-2932 CVE-2023-1476 \
     CVE-2023-6915 CVE-2023-1611 CVE-2024-26594 \
+    CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 \
+    CVE-2021-3492 CVE-2021-39802 CVE-2022-36397 \
 "


### PR DESCRIPTION
# Purpose of pull request

This PR adds multiple CVEs to CVE_CHECK_WHITELIST of linux-base recipe, because kernel 4.19.y has no vulnerable code which these CVEs has pointed.
- CVE-2021-0399
- CVE-2021-1076
- CVE-2021-29256
- CVE-2021-3492
- CVE-2021-39802
- CVE-2022-36397

# Test
## How to test

Add following line into conf/local.conf

```
INHERIT += "cve-check"
```

And then run following command.

```
$ bitbake linux-base -c cve_check
```

## Test result

Before applying this PR, we can see above CVEs in command output.
After applying this PR, we can't see above CVEs in command output.