### PR TITLE
Update kernel to v4.19.312-cip109

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "d1b399d941d4ab1d2107fef7a680deac88ccbc38"
+LINUX_GIT_SRCREV ?= "91af320f42aad5646d0832d1627aca3f0964b284"
 LINUX_CVE_VERSION ??= "5.10.214"
-LINUX_CIP_VERSION ?= "v5.10.214-cip46"
+LINUX_CIP_VERSION ?= "v5.10.216-cip47"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.312-cip109

This pull request update the kernel to the following cip versions:
v4.19.312-cip109 with hash tag 959de52810ed02ef75efb3d00ed0b01718396700
