### PR TITLE
classes/cve-check: Fix overwriting patched status by cip-kernel-sec

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -60,9 +60,9 @@ python do_cve_check () {
         patched, unpatched = check_cves(d, patched_cves)
 
         if d.getVar("PN") == d.getVar("KERNEL_PN"):
-            cip_sec_reported_cves = d.getVar("CIP_KERNEL_SEC_REPORTED_CVES")
-            if len(cip_sec_reported_cves) > 0:
-                tmp = cip_sec_reported_cves.split(" ")
+            cip_kernel_sec_affected_cves = d.getVar("CIP_KERNEL_SEC_AFFECTED_CVES")
+            if len(cip_kernel_sec_affected_cves) > 0:
+                tmp = cip_kernel_sec_affected_cves.split(" ")
                 for cve in tmp:
                     if not cve in unpatched:
                         unpatched.append(cve)

--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -130,17 +130,25 @@ python kernel_cve_check () {
     cmd = "SSL_CERT_FILE='%s' %s scripts/report_affected.py %s --remote-name cip:%s --git-repo %s %s" % (cert_path, python_path, opt_ignore, remote_repo_name, kernel_path, linux_cip_ver)
     output = runfetchcmd(cmd, d, workdir=cip_kernel_sec_path)
 
-    affect_cves = output.split(":")[2].strip().split()
+    tmp_affected_cves = output.split(":")[2].strip().split()
 
     whitelist = []
     for cve in get_issue_list(cip_kernel_sec_path):
-        if cve not in affect_cves:
+        if cve not in tmp_affected_cves:
             whitelist.append(cve)
 
     bb.debug(2, "Whitelisted by cip-kernel-sec:\n    %s" % "\n    ".join(whitelist))
     d.appendVar("CVE_CHECK_WHITELIST", ' ' + ' '.join(whitelist))
 
-    d.setVar("CIP_KERNEL_SEC_REPORTED_CVES", " ".join(affect_cves))
+    safelist_str = d.getVar("CVE_CHECK_WHITELIST")
+    safelist = safelist_str.split(" ")
+
+    affected_cves = []
+    for cve in tmp_affected_cves:
+        if not cve in safelist:
+            affected_cves.append(cve)
+
+    d.setVar("CIP_KERNEL_SEC_AFFECTED_CVES", " ".join(affected_cves))
 }
 
 do_cve_check[prefuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'kernel_cve_check', '', d)}"


### PR DESCRIPTION
# Purpose of pull request

When run cve-check, it executes poky's cve-check then run cip-kernel-sec. If a CVE is listed in CVE_CHECK_WHITELIST, the CVE status will be patched. However, if cip-kernel-sec reports the CVE is not fixed, then this CVE is marked as unpatched. Then, final cve-check reports the CVE is unpatched.

To fix this situation, kernel-cve-check should check CVE_CHECK_WHITELIST if cip-kernel-sec reported CVE is in the list or not. If the CVE is listed in the list, kernel-cve-check reports this CVE is patched.

# Test
## How to test

Run cve-check both linux-base and linux-k510
Check following CVEs status which are litsted in CVE_CHECK_WHITELIST.
CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 CVE-2021-3492 CVE-2021-39802 CVE-2022-36397

## Test result

### before this patch

CVEs are reported as unpatched both linux-base and linux-k510.

linux-base

```
$ for cve in CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 CVE-2021-3492 CVE-2021-39802 CVE-2022-36397; do grep -n -A1 "CVE: ${cve}" tmp-glibc/deploy/cve/linux-base  ; done 
27042:CVE: CVE-2021-0399
27043-CVE STATUS: Unpatched
27072:CVE: CVE-2021-1076
27073-CVE STATUS: Unpatched
27522:CVE: CVE-2021-29256
27523-CVE STATUS: Unpatched
27932:CVE: CVE-2021-3492
27933-CVE STATUS: Unpatched
28472:CVE: CVE-2021-39802
28473-CVE STATUS: Unpatched
35722:CVE: CVE-2022-36397
35723-CVE STATUS: Unpatched
```

linux-k510

```
$ for cve in CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 CVE-2021-3492 CVE-2021-39802 CVE-2022-36397; do grep -n -A1 "CVE: ${cve}" tmp-glibc/deploy/cve/linux-k510  ; done 
26904:CVE: CVE-2021-0399
26905-CVE STATUS: Unpatched
26924:CVE: CVE-2021-1076
26925-CVE STATUS: Unpatched
27374:CVE: CVE-2021-29256
27375-CVE STATUS: Unpatched
27784:CVE: CVE-2021-3492
27785-CVE STATUS: Unpatched
28324:CVE: CVE-2021-39802
28325-CVE STATUS: Unpatched
34113:CVE: CVE-2022-36397
34114-CVE STATUS: Unpatched
```

### applying this patch

CVEs are reported as patched both linux-base and linux-k510.

linux-base

```
$ for cve in CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 CVE-2021-3492 CVE-2021-39802 CVE-2022-36397; do grep -n -A1 "CVE: ${cve}" tmp-glibc/deploy/cve/linux-base  ; done 
27042:CVE: CVE-2021-0399
27043-CVE STATUS: Patched
27072:CVE: CVE-2021-1076
27073-CVE STATUS: Patched
27522:CVE: CVE-2021-29256
27523-CVE STATUS: Patched
27932:CVE: CVE-2021-3492
27933-CVE STATUS: Patched
28472:CVE: CVE-2021-39802
28473-CVE STATUS: Patched
35722:CVE: CVE-2022-36397
35723-CVE STATUS: Patched
```

linux-k510

```
$ for cve in CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 CVE-2021-3492 CVE-2021-39802 CVE-2022-36397; do grep -n -A1 "CVE: ${cve}" tmp-glibc/deploy/cve/linux-k510  ; done 
26904:CVE: CVE-2021-0399
26905-CVE STATUS: Patched
26924:CVE: CVE-2021-1076
26925-CVE STATUS: Patched
27374:CVE: CVE-2021-29256
27375-CVE STATUS: Patched
27784:CVE: CVE-2021-3492
27785-CVE STATUS: Patched
28324:CVE: CVE-2021-39802
28325-CVE STATUS: Patched
34113:CVE: CVE-2022-36397
34114-CVE STATUS: Patched
```