### PR TITLE
image: Add a Weston image for general use for EMLinux machines

### DIFF
--- a/recipes-core/images/emlinux-image-weston.bb
+++ b/recipes-core/images/emlinux-image-weston.bb
@@ -1,0 +1,30 @@
+#
+# EMLinux image to enable Weston
+#
+# Copyright (c) Cybertrust Japan Co., Ltd.
+#
+# SPDX-License-Identifier: MIT
+#
+
+require recipes-core/images/emlinux-image-base.bb
+
+DESCRIPTION = "EMLinux target filesystem to enable Weston"
+
+IMAGE_INSTALL:append = " weston-init"
+
+IMAGE_PREINSTALL:append = " weston libgl1 libpam-systemd kbd"
+
+GROUPS += "weston-launch"
+GROUP_weston-launch[flags] = "system"
+GROUPS += "render"
+GROUP_render[flags] = "system"
+GROUPS += "wayland"
+GROUP_wayland[flags] = "system"
+
+USERS += "weston"
+USER_weston[groups] = "video input render wayland"
+USER_weston[home] = "/home/weston"
+USER_weston[flags] = "create-home"
+
+# Remove unnecessary account setting in the SDK generation
+ROOTFS_POSTPROCESS_COMMAND:remove:class-sdk = "image_postprocess_accounts"

--- a/recipes-graphics/wayland/files/weston-autologin
+++ b/recipes-graphics/wayland/files/weston-autologin
@@ -1,0 +1,11 @@
+auth      required  pam_nologin.so
+auth      required  pam_unix.so     try_first_pass nullok
+
+account   required  pam_nologin.so
+account   required  pam_unix.so
+
+session   required  pam_env.so
+session   required  pam_unix.so
+-session  optional  pam_systemd.so type=wayland class=user desktop=weston
+-session  optional  pam_loginuid.so
+

--- a/recipes-graphics/wayland/files/weston-socket.sh
+++ b/recipes-graphics/wayland/files/weston-socket.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# set weston variables for use with global weston socket
+global_socket="/run/wayland-0"
+if [ -e "$global_socket" ]; then
+	weston_group=$(stat -c "%G" "$global_socket")
+	if [ "$(id -u)" = "0" ]; then
+		export WAYLAND_DISPLAY="$global_socket"
+	else
+		case "$(groups "$USER")" in
+			*"$weston_group"*)
+				export WAYLAND_DISPLAY="$global_socket"
+				;;
+			*)
+				;;
+		esac
+	fi
+	unset weston_group
+fi
+unset global_socket

--- a/recipes-graphics/wayland/files/weston-start
+++ b/recipes-graphics/wayland/files/weston-start
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Copyright (C) 2016 O.S. Systems Software LTDA.
+# Copyright (C) 2016 Freescale Semiconductor
+
+export PATH="/sbin:/usr/sbin:/bin:/usr/bin"
+
+usage() {
+	cat <<EOF
+	$0 [<weston options>]
+EOF
+}
+
+## Module support
+modules_dir=/usr/share/weston-start
+
+# Add weston extra argument
+add_weston_argument() {
+	weston_args="$weston_args $1"
+}
+
+## Add module to --modules argument
+add_weston_module() {
+	if [[ "x${weston_modules}" == "x" ]]; then
+		weston_modules="--modules "
+	fi;
+	weston_modules+="${1},"
+}
+
+if [ -n "$WAYLAND_DISPLAY" ]; then
+	echo "ERROR: A Wayland compositor is already running, nested Weston instance is not supported yet."
+	exit 1
+fi
+
+if [ -n "$WESTON_USER" ]; then
+	if [ -z "$WESTON_GROUP" ]; then
+		# no explicit WESTON_GROUP given, therefore use WESTON_USER
+		export WESTON_GROUP="${WESTON_USER}"
+	fi
+fi
+
+weston_args=$*
+
+# Load and run modules
+if [ -d "$modules_dir" ]; then
+	for m in "$modules_dir"/*; do
+		# Skip backup files
+		if [ "`echo $m | sed -e 's/\~$//'`" != "$m" ]; then
+			continue
+		fi
+
+		# process module
+		. $m
+		if [[ x"{$weston_modules}" != "x" ]]; then
+			add_weston_argument "${weston_modules}"
+		fi;
+	done
+fi
+
+if test -z "$XDG_RUNTIME_DIR"; then
+	export XDG_RUNTIME_DIR=/run/user/`id -u ${WESTON_USER}`
+	if ! test -d "$XDG_RUNTIME_DIR"; then
+		mkdir --parents $XDG_RUNTIME_DIR
+		chmod 0700 $XDG_RUNTIME_DIR
+	fi
+	if [ -n "$WESTON_USER" ]
+	then
+		chown $WESTON_USER:$WESTON_GROUP $XDG_RUNTIME_DIR
+	fi
+fi
+
+su -c "XDG_RUNTIME_DIR=/run/user/`id -u ${WESTON_USER}` weston $weston_args --log=/tmp/weston.log" $WESTON_USER

--- a/recipes-graphics/wayland/files/weston.ini
+++ b/recipes-graphics/wayland/files/weston.ini
@@ -1,0 +1,9 @@
+# configuration file for Weston
+
+[core]
+require-input=false
+idle-time=0
+use-pixman=true
+
+[screen-share]
+command=/usr/bin/weston --backend=rdp-backend.so --shell=fullscreen-shell.so --no-clients-resize

--- a/recipes-graphics/wayland/files/weston.service
+++ b/recipes-graphics/wayland/files/weston.service
@@ -1,0 +1,71 @@
+# This is a system unit for launching Weston with auto-login as the
+# user configured here.
+#
+# Weston must be built with systemd support, and your weston.ini must load
+# the plugin systemd-notify.so.
+[Unit]
+Description=Weston, a Wayland compositor, as a system service
+Documentation=man:weston(1) man:weston.ini(5)
+Documentation=http://wayland.freedesktop.org/
+
+# Make sure we are started after logins are permitted.
+Requires=systemd-user-sessions.service
+After=systemd-user-sessions.service
+
+# If Plymouth is used, we want to start when it is on its way out.
+After=plymouth-quit-wait.service
+
+# D-Bus is necessary for contacting logind. Logind is required.
+Wants=dbus.socket
+After=dbus.socket
+
+# Ensure the socket is present
+Requires=weston.socket
+
+# Since we are part of the graphical session, make sure we are started before
+# it is complete.
+Before=graphical.target
+
+# Prevent starting on systems without virtual consoles, Weston requires one
+# for now.
+ConditionPathExists=/dev/tty0
+
+[Service]
+# Requires systemd-notify.so Weston plugin.
+Type=notify
+EnvironmentFile=/etc/default/weston
+ExecStart=/usr/bin/weston --log=${XDG_RUNTIME_DIR}/weston.log --modules=systemd-notify.so
+
+# Optional watchdog setup
+#TimeoutStartSec=60
+#WatchdogSec=20
+
+# The user to run Weston as.
+User=root
+Group=root
+
+# Make sure the working directory is the users home directory
+WorkingDirectory=/root
+
+# Set up a full user session for the user, required by Weston.
+PAMName=weston-autologin
+
+# A virtual terminal is needed.
+TTYPath=/dev/tty7
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
+
+# Fail to start if not controlling the tty.
+StandardInput=tty-fail
+StandardOutput=journal
+StandardError=journal
+
+# Log this user with utmp, letting it show up with commands 'w' and 'who'.
+UtmpIdentifier=tty7
+UtmpMode=user
+
+[Install]
+# Note: If you only want weston to start on-demand, remove this line with a
+# service drop file
+WantedBy=graphical.target

--- a/recipes-graphics/wayland/files/weston.socket
+++ b/recipes-graphics/wayland/files/weston.socket
@@ -1,0 +1,14 @@
+[Unit]
+Description=Weston socket
+RequiresMountsFor=/run
+
+[Socket]
+ListenStream=/run/wayland-0
+SocketMode=0775
+SocketUser=weston
+SocketGroup=wayland
+RemoveOnStop=yes
+
+[Install]
+WantedBy=sockets.target
+

--- a/recipes-graphics/wayland/weston-init.bb
+++ b/recipes-graphics/wayland/weston-init.bb
@@ -1,0 +1,37 @@
+#
+# Startup script and systemd unit file for the Weston Wayland compositor
+# Copyright (c) Cybertrust Japan Co., Ltd.
+#
+# SPDX-License-Identifier: MIT
+#
+
+SUMMARY = "Startup script and systemd unit file for the Weston Wayland compositor"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${LAYERDIR_core}/licenses/COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
+
+inherit dpkg-raw
+
+SRC_URI = " \
+    file://weston.env \
+    file://weston.ini \
+    file://weston.service \
+    file://weston.socket \
+    file://weston-socket.sh \
+    file://weston-autologin \
+    file://weston-start"
+
+do_install () {
+    # Install Weston systemd service
+    install -D -p -m0644 ${WORKDIR}/weston.service ${D}/lib/systemd/system/weston.service
+    install -D -p -m0644 ${WORKDIR}/weston.socket ${D}/lib/systemd/system/weston.socket
+    install -D -p -m0644 ${WORKDIR}/weston-socket.sh ${D}/etc/profile.d/weston-socket.sh
+
+    install -D -p -m0644 ${WORKDIR}/weston-autologin ${D}/etc/pam.d/weston-autologin
+
+    install -D -p -m0644 ${WORKDIR}/weston.ini ${D}/etc/xdg/weston/weston.ini
+    install -Dm644 ${WORKDIR}/weston.env ${D}/etc/default/weston
+
+    if [ ${MACHINE} = "raspberrypi3bplus-64" -o ${MACHINE} = "raspberrypi4b-64" ]; then
+        sed -i -e "/use-pixman/d" ${D}/etc/xdg/weston/weston.ini
+    fi
+}


### PR DESCRIPTION
This installs the Weston and Mesa Debian packages on the default Weston image for EMLinux 3.x.

Also it introduces poky's systemd startup script for Weston by migrating to Isar. In the original script, a non-root user launches the Weston process, but this script adopts root for that due to missing DRM master permission when Weson is launched by a non-root user.