### PR TITLE
Update kernel to v6.1.92-cip22-rt12

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_git.bb
+++ b/recipes-kernel/linux/linux-cip-rt_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.90-cip20-rt11"
-PV = "6.1.90-cip20-rt11"
+LINUX_CIP_VERSION = "v6.1.92-cip22-rt12"
+PV = "6.1.92-cip22-rt12"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip-rt;destsuffix=${P};protocol=https \
     file://preempt-rt.cfg \
@@ -23,6 +23,6 @@ SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
-SRCREV = "a5d281b04d5bd8e58f9d1de802632ae9c5a262c8"
+SRCREV = "96fd74998d4ca50439f3dae4cef527201c2e3e79"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.92-cip22-rt12

This pull request update the kernel to the following cip versions:
v6.1.92-cip22-rt12 with hash tag 96fd74998d4ca50439f3dae4cef527201c2e3e79
