### PR TITLE
Update kernel to v5.10.218-cip49

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "959de52810ed02ef75efb3d00ed0b01718396700"
+LINUX_GIT_SRCREV ?= "80b2464ae89aaaa73b7a2daa3526c1ed9971ab5a"
 LINUX_CVE_VERSION ??= "4.19.312"
-LINUX_CIP_VERSION ??= "v4.19.312-cip109"
+LINUX_CIP_VERSION ??= "v4.19.315-cip110"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.218-cip49

This pull request update the kernel to the following cip versions:
v5.10.218-cip49 with hash tag 9b6b51fe8dad7c7e6e091bd99901171e42b1b80c
