### PR TITLE
Update kernel to v5.10.218-cip49

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "91af320f42aad5646d0832d1627aca3f0964b284"
+LINUX_GIT_SRCREV ?= "9b6b51fe8dad7c7e6e091bd99901171e42b1b80c"
 LINUX_CVE_VERSION ??= "5.10.214"
-LINUX_CIP_VERSION ?= "v5.10.216-cip47"
+LINUX_CIP_VERSION ?= "v5.10.218-cip49"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.218-cip49

This pull request update the kernel to the following cip versions:
v5.10.218-cip49 with hash tag 9b6b51fe8dad7c7e6e091bd99901171e42b1b80c
