### PR TITLE
Support  containerized SDK

### DIFF
--- a/classes/sdk-installer.bbclass
+++ b/classes/sdk-installer.bbclass
@@ -14,7 +14,7 @@ EMLINUX_SDK_FILE_PATH="${DEPLOY_DIR_IMAGE}/${EMLINUX_SDK_FILE_NAME}"
 EMLINUX_SDK_INSTALLER_NAME="${PN}-${DISTRO}-${MACHINE}-sdk-installer.sh"
 EMLINUX_SDK_INSTALLER_FILE_PATH="${DEPLOY_DIR_IMAGE}/${EMLINUX_SDK_INSTALLER_NAME}"
 
-create_sdk_installer_script() {
+get_toolchain_prefix() {
     toolchain_prefix=""
     if [ "${DISTRO_ARCH}" = "amd64" ]; then
         toolchain_prefix="x86_64-linux-gnu"
@@ -23,7 +23,11 @@ create_sdk_installer_script() {
     elif [ "${DISTRO_ARCH}" = "armhf" ]; then
         toolchain_prefix="arm-linux-gnueabihf"
     fi
+    echo "${toolchain_prefix}"
+}
 
+create_sdk_installer_script() {
+    toolchain_prefix=$(get_toolchain_prefix)
     cat << "EOF" > ${EMLINUX_SDK_INSTALLER_FILE_PATH}
 #!/bin/bash
 
@@ -95,12 +99,29 @@ python do_create_sdk_installer() {
 
 do_image_tar[postfuncs] += "do_create_sdk_installer"
 
+setup_toolchains_for_container() {
+    tmpl_file="$1"
+    toolchain_prefix=$(get_toolchain_prefix)
+    sudo sed -i '1d' "${tmpl_file}"
+    sudo sed -i 's:@EMLINUX_SDK_INSTALL_DIR@::g' "${tmpl_file}"
+    sudo sed -i -e "s/@EMLINUX_SDK_TOOLCHAIN_PREFIX@/${toolchain_prefix}/g" "${tmpl_file}"
+    sudo mkdir -p "${ROOTFSDIR}/etc/profile.d/"
+    bname=$(basename ${tmpl_file})
+    sudo mv "${tmpl_file}" "${ROOTFSDIR}/etc/profile.d/${bname}.sh"
+    sudo chmod 755 "${ROOTFSDIR}/etc/profile.d/${bname}.sh"
+}
+
 ROOTFS_POSTPROCESS_COMMAND:append:class-sdk = " rename_installer_script setup_kernel_source_dir"
 rename_installer_script() {
     setupfile="${ROOTFSDIR}/environment-setup-${MACHINE}-${DISTRO}"
     sudo mv "${ROOTFSDIR}/environment-setup-template" "${ROOTFSDIR}/environment-setup-${MACHINE}-${DISTRO}"
+
+    if [ "${SDK_FORMATS}" = "docker-archive" ]; then
+        setup_toolchains_for_container "${ROOTFSDIR}/environment-setup-${MACHINE}-${DISTRO}"
+    fi
 }
 
 setup_kernel_source_dir() {
     (cd ${ROOTFSDIR}/usr/src && sudo ln -s linux-headers-* kernel)
 }
+

--- a/classes/sdk-installer.bbclass
+++ b/classes/sdk-installer.bbclass
@@ -111,6 +111,14 @@ setup_toolchains_for_container() {
     sudo chmod 755 "${ROOTFSDIR}/etc/profile.d/${bname}.sh"
 }
 
+setup_docker_files() {
+    templates_dir="${TOPDIR}/../repos/meta-emlinux/templates/containerized-sdk"
+    cp "${templates_dir}/Dockerfile" "${DEPLOY_DIR_IMAGE}"
+    cp "${templates_dir}/docker-compose.yml" "${DEPLOY_DIR_IMAGE}"
+    sed -i "s/@CONTAINER_IMAGE_NAME@/${CONTAINER_IMAGE_NAME}/g" "${DEPLOY_DIR_IMAGE}/Dockerfile"
+    sed -i "s/@CONTAINER_IMAGE_TAG@/${CONTAINER_IMAGE_TAG}/g" "${DEPLOY_DIR_IMAGE}/Dockerfile"
+}
+
 ROOTFS_POSTPROCESS_COMMAND:append:class-sdk = " rename_installer_script setup_kernel_source_dir"
 rename_installer_script() {
     setupfile="${ROOTFSDIR}/environment-setup-${MACHINE}-${DISTRO}"
@@ -118,6 +126,7 @@ rename_installer_script() {
 
     if [ "${SDK_FORMATS}" = "docker-archive" ]; then
         setup_toolchains_for_container "${ROOTFSDIR}/environment-setup-${MACHINE}-${DISTRO}"
+        setup_docker_files
     fi
 }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,9 @@ RUN apt-get install --fix-missing -y \
   screen \
   socat \
   patchelf \
-  sqlite3
+  sqlite3 \
+  umoci \
+  skopeo
 
 RUN useradd -m build -u $uid
 RUN gpasswd -a build sbuild

--- a/templates/containerized-sdk/Dockerfile
+++ b/templates/containerized-sdk/Dockerfile
@@ -1,0 +1,12 @@
+FROM @CONTAINER_IMAGE_NAME@:@CONTAINER_IMAGE_TAG@
+
+ARG uid
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+
+RUN useradd -m sdkuser -u $uid 
+
+USER sdkuser
+CMD /bin/bash -l
+

--- a/templates/containerized-sdk/docker-compose.yml
+++ b/templates/containerized-sdk/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  emlinux3-sdk:
+    image: emlinux3-sdk
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        uid: ${UID:-1000}
+        http_proxy: $http_proxy
+        https_proxy: $https_proxy
+        ftp_proxy: $ftp_proxy
+        no_proxy: $no_proxy
+    environment:
+      - http_proxy=$http_proxy
+      - https_proxy=$https_proxy
+      - ftp_proxy=$ftp_proxy
+      - no_proxy=$no_proxy
+    volumes:
+      - /proc:/proc:rw
+      - /dev/shm:/dev/shm:rw
+      - $HOME:/host-home:rw
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    privileged: true
+    cap_add:
+      - NET_ADMIN
+    user: sdkuser
+    command: /bin/bash -l


### PR DESCRIPTION
# Purpose of pull request

This PR supports building containerized SDK. To do it, we needed umoci and skopeo packages to create containerized SDK. To setup cross build environment values such as TARGET_PREFIX,. CC,  and so on,  we use the mechanism of /etc/profile.d . Install environment setup script into the /etc/profile.d directory to execute setup script when user logged into  container image.

Above steps is enough for using a containerized SDK. However, this environment doesn't contain user other than root. This will make problem when developer use volume mount to share a directory both host and container. If developer creates a file from container, this file owner will be root on the host. It's not expected behavior for building software from container. So, we use containerized SDK as base image instead of using image directory.  We provide simple Dockerfile  and docker-compose.yml file to create a user which uid is same as host user's uid to resolve uid mapping problem.


# Test
## How to test

1. Add following setting in the conf/local.conf

```
BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_EXTRAWHITE SDK_FORMATS"
SDK_FORMATS="docker-archive"
```
2. Build sdk with 'bitbake emlinux-image-base -c populate_sdk'
3. exit from container if you executed run.sh to enter build env
4. move directory to image deploy dir.  e.g. /your build directory/tmp/deploy/images/qemu-arm64/
5. load  containerized SDK.  sdk image name has .docker-archive extension. e.g. emlinux-image-base-sdk-emlinux-bookworm-arm64.docker-archive
```
docker load -i <containerized sdk image name>
```
6. build build environment image from  containerized SDK
```
docker compose build
```
7. logged into container
```
docker compose run --rm emlinux3-sdk
```
## Test result

```
$ docker image load -i emlinux-image-base-sdk-emlinux-bookworm-arm64.docker-archive
f48b2f3a238f: Loading layer [==================================================>]  823.5MB/823.5MB
Loaded image: emlinux-image-base-sdk-emlinux-bookworm-arm64:1.0-r0
$ docker compose build
>>> snip <<<
$ id -u
1000
$ docker compose run --rm emlinux3-sdk
>>> snip <<<
sdkuser@0821337e7ae0:/$ id -u
1000
```



