### PR TITLE
linux-base: Add CVE-2021-39801 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -39,6 +39,7 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2021-3492: This is false positive becuase it is Ubuntu specified kernel issue.
 # CVE-2021-39802: This is false positive because it is Android kernel issue.
 # CVE-2022-36397: This is false positive because it is Intel QAT driver issue.
+# CVE-2021-39801: This is false positive because it is Android kernel issue.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
@@ -51,4 +52,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2023-6915 CVE-2023-1611 CVE-2024-26594 \
     CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 \
     CVE-2021-3492 CVE-2021-39802 CVE-2022-36397 \
+    CVE-2021-39801 \
 "


### PR DESCRIPTION
# Purpose of pull request

This PR adds CVE-2021-39801 to CVE_CHECK_WHITELIST of linux-base recipe, because kernel 4.19.y has no vulnerable code which this CVE has pointed.

# Test
## How to test

Add following line into conf/local.conf.

```
INHERIT += "cve-check debian-cve-check kernel-cve-check"
```

And then run following command.

```
$ bitbake linux-base -c cve_check
```

## Test result

Before applying this PR, we can see "CVE-2021-39801" in command output.
After applying this PR, we can't see "CVE-2021-39801" in command output.
