### PR TITLE
linux: linux-k510: Add CVE-2021-39801 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -48,6 +48,7 @@ do_shared_workdir_prepend () {
 # CVE-2021-3492: This is false positive becuase it is Ubuntu specified kernel issue.
 # CVE-2021-39802: This is false positive because it is Android kernel issue.
 # CVE-2022-36397: This is false positive because it is Intel QAT driver issue.
+# CVE-2021-39801: This is false positive because it is Android kernel issue.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-43057 CVE-2015-8955 CVE-2020-8834 \
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
@@ -55,5 +56,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-1999-0524 CVE-1999-0656 CVE-2006-2932 \
     CVE-2023-1476 CVE-2021-0399 CVE-2021-1076 \
     CVE-2021-29256 CVE-2021-3492 CVE-2021-39802 \
-    CVE-2022-36397 \
+    CVE-2022-36397 CVE-2021-39801 \
 "


### PR DESCRIPTION
# Purpose of pull request

Add CVE-2021-39801 to CVE_CHECK_WHITELIST which don't affect 5.10.y.
- https://nvd.nist.gov/vuln/detail/CVE-2021-39801

# Test
## How to test

Add following line into conf/local.conf.

```
INHERIT += "cve-check debian-cve-check kernel-cve-check"
```

And then run following command.

```
$ bitbake linux-k510 -c cve_check
```

## Test result

Before applying this PR, we can see "CVE-2021-39801" in command output.
After applying this PR, we can't see "CVE-2021-39801" in command output.