### PR TITLE
scripts: Add ELTS updates repository to mirror list

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -58,6 +58,8 @@ if [ -z "$TEMPLATECONF" ] && [ "${EML_BUILDDIR_SETUP_DONE}" = "false" ]; then
 
     # Add debian security updates repository
     echo "DEBIAN_SECURITY_UPDATE_MIRROR=\"http://security.debian.org/debian-security/pool/updates\"" >> conf/local.conf
+    # Add ELTS updates repository
+    echo "DEBIAN_ELTS_SECURITY_UPDATE_MIRROR=\"http://deb.freexian.com/extended-lts/pool\"" >> conf/local.conf
 
     if [ -d "${EML_HOOKS}" ]; then
 	for hook in $(\ls ${EML_HOOKS}); do


### PR DESCRIPTION
# Purpose of pull request

This change adds ELTS updates repository url provided by Freexian to mirror list. It only adds url to mirror list, so it doesn't enable feature of download update package from Freexian's ELTS mirror server.

It supports downloading debian source package from ELTS updates repository, if DEBIAN_SRC_URI contains DEBIAN_ELTS_SECURITY_UPDATE_MIRROR variable.

If user want to update package version to get security fix from debian security updates repository, user must set DEBIAN_SOURCE_ENABLED, DEBIAN_SRC_FORCE_REGEN, and DEBIAN_SECURITY_UPDATE_ENABLED by themself.

# Test
## How to test
1. Setup build directory as TEST
   ```
   source setup-emlinux TEST
   ```

2. Check local.conf contains DEBIAN_ELTS_SECURITY_UPDATE_MIRROR
   ```
   tail -n 20 conf/local.conf
   ```

## Test result
```
$ source setup-emlinux TEST
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/


### Shell environment set up for builds. ###

You can now run 'bitbake <target>'

Common targets are:
    core-image-minimal
    core-image-sato
    meta-toolchain
    meta-ide-support

You can also run generated qemu images with a command like 'runqemu qemux86'
NOTE: Starting bitbake server...
NOTE: Starting bitbake server...
NOTE: Starting bitbake server...
```
```
TEST$ tail -n 20 conf/local.conf 
# nsswitch.conf is not provided by debian base-file package but systemd requires it.
# use poky's base-files package temporary.
BBMASK += "meta-debian/recipes-debian/base-files/base-files_debian.bb"
BBMASK += "poky/meta/recipes-sato/webkit/webkitgtk_2.22.7.bb \
           poky/meta/recipes-gnome/epiphany/epiphany_3.30.3.bb \
           poky/meta/recipes-core/packagegroups/packagegroup-self-hosted.bb \
           poky/meta/recipes-graphics/xorg-lib/libxxf86misc_1.0.4.bb \
           meta-debian/recipes-debian/fcode-utils/fcode-utils_debian.bb"
DEBIAN_SECURITY_UPDATE_MIRROR="http://security.debian.org/debian-security/pool/updates"
DEBIAN_ELTS_SECURITY_UPDATE_MIRROR="http://deb.freexian.com/extended-lts/pool"
CTJ_DEBIAN_MIRROR='http://emlinux-pkgs.miraclelinux.com/debian/pool'
MIRRORS+="${DEBIAN_MIRROR}    ${CTJ_DEBIAN_MIRROR} \n"
CTJ_DEBIAN_SECURITY_UPDATE_MIRROR='http://emlinux-pkgs.miraclelinux.com/debian-security/pool/updates'
MIRRORS+="${DEBIAN_SECURITY_UPDATE_MIRROR}    ${CTJ_DEBIAN_SECURITY_UPDATE_MIRROR} \n"
CTJ_SOURCE_MIRROR = 'http://emlinux-pkgs.miraclelinux.com/mirror/sources'
MIRRORS += "git://.*/.*    ${CTJ_SOURCE_MIRROR} \n"
MIRRORS += "http://.*/.*    ${CTJ_SOURCE_MIRROR} \n"
MIRRORS += "https://.*/.*    ${CTJ_SOURCE_MIRROR} \n"
MIRRORS += "ftp://.*/.*    ${CTJ_SOURCE_MIRROR} \n"
PREMIRRORS_append = "\n git://git.kernel.org/pub/scm/linux/kernel/git/cip    git://gitlab.com/cip-project/cip-kernel \n"
```
