### PR TITLE
linux/linux-base: Add CVE-2023-20928 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -40,6 +40,7 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2021-39802: This is false positive because it is Android kernel issue.
 # CVE-2022-36397: This is false positive because it is Intel QAT driver issue.
 # CVE-2021-39801: This is false positive because it is Android kernel issue.
+# CVE-2023-20928: Vulnerable code not present.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
@@ -52,5 +53,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2023-6915 CVE-2023-1611 CVE-2024-26594 \
     CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 \
     CVE-2021-3492 CVE-2021-39802 CVE-2022-36397 \
-    CVE-2021-39801 \
+    CVE-2021-39801 CVE-2023-20928 \
 "


### PR DESCRIPTION
# Purpose of pull request

Vulnerable code is not present in 4.19 so we can safely ignore it.

# Test
## How to test

1. Run 'bitbake linux-base -c cve_check'
2. Check tmp/deploy/cve/linux-base 


## Test result

Before applying the patch.

```
$ grep "CVE-2023-20928" -A3 tmp-glibc/deploy/cve/linux-base | grep -E "^CVE:|^CVE STATUS:" ; echo $?
CVE: CVE-2023-20928
CVE STATUS: Unpatched
0
```

After applying the patch.

```
$ grep "CVE-2023-20928" -A3 tmp-glibc/deploy/cve/linux-base | grep -E "^CVE:|^CVE STATUS:" ; echo $?
1
```


