### PR TITLE
classes/sdk-installer: Change containerized sdk output directory

### DIFF
--- a/classes/sdk-installer.bbclass
+++ b/classes/sdk-installer.bbclass
@@ -112,11 +112,17 @@ setup_toolchains_for_container() {
 }
 
 setup_docker_files() {
+    container_sdk_dir="${DEPLOY_DIR_IMAGE}/${PN}-${SDK_FORMATS}"
+    # Remove old directory
+    if [ -d "${container_sdk_dir}" ]; then
+        rm -fr "${container_sdk_dir}"
+    fi
+    mkdir "${container_sdk_dir}"
     templates_dir="${TOPDIR}/../repos/meta-emlinux/templates/containerized-sdk"
-    cp "${templates_dir}/Dockerfile" "${DEPLOY_DIR_IMAGE}"
-    cp "${templates_dir}/docker-compose.yml" "${DEPLOY_DIR_IMAGE}"
-    sed -i "s/@CONTAINER_IMAGE_NAME@/${CONTAINER_IMAGE_NAME}/g" "${DEPLOY_DIR_IMAGE}/Dockerfile"
-    sed -i "s/@CONTAINER_IMAGE_TAG@/${CONTAINER_IMAGE_TAG}/g" "${DEPLOY_DIR_IMAGE}/Dockerfile"
+    cp "${templates_dir}/Dockerfile" "${container_sdk_dir}/"
+    cp "${templates_dir}/docker-compose.yml" "${container_sdk_dir}/"
+    sed -i "s/@CONTAINER_IMAGE_NAME@/${CONTAINER_IMAGE_NAME}/g" "${container_sdk_dir}/Dockerfile"
+    sed -i "s/@CONTAINER_IMAGE_TAG@/${CONTAINER_IMAGE_TAG}/g" "${container_sdk_dir}/Dockerfile"
 }
 
 ROOTFS_POSTPROCESS_COMMAND:append:class-sdk = " rename_installer_script setup_kernel_source_dir"
@@ -134,3 +140,8 @@ setup_kernel_source_dir() {
     (cd ${ROOTFSDIR}/usr/src && sudo ln -s linux-headers-* kernel)
 }
 
+do_move_docker_archive() {
+    mv "${DEPLOY_DIR_IMAGE}/${PN}-${DISTRO}-${DISTRO_ARCH}.${SDK_FORMATS}" "${DEPLOY_DIR_IMAGE}/${PN}-${SDK_FORMATS}"
+}
+
+do_image_docker_archive[postfuncs] += "do_move_docker_archive"


### PR DESCRIPTION
# Purpose of pull request

The containerized SDK provides following files.
- docker archive
- Dockerfile
- docker-compose.yml

This commit stores above files in sdk specific directory instead of DEPLOY_DIR_IMAGE directory.

# Test
## How to test

Add following lines in conf/local.conf

```
BB_ENV_PASSTHROUGH_ADDITIONS="$BB_ENV_EXTRAWHITE SDK_FORMATS"
SDK_FORMATS="docker-archive"
```

Then build sdk.

```
bitbake emlinux-image-base -c populate_sdk
```

Check tmp/deploy/images/qemu-arm64/emlinux-image-base-sdk-docker-archive when build is finished.

Then copy emlinux-image-base-sdk-docker-archive to other host and load the sdk image.

## Test result

There is three files in the tmp/deploy/images/qemu-arm64/emlinux-image-base-sdk-docker-archive directory.

```
$ ls tmp/deploy/images/qemu-arm64/emlinux-image-base-sdk-docker-archive/
docker-compose.yml  Dockerfile  emlinux-image-base-sdk-emlinux-bookworm-arm64.docker-archive
```

Load sdk container.

```
$ docker load -i emlinux-image-base-sdk-emlinux-bookworm-arm64.docker-archive                                                                                                                       
3cd77cd0c982: Loading layer [==================================================>]  823.5MB/823.5MB                                                                                                    
Loaded image: emlinux-image-base-sdk-emlinux-bookworm-arm64:1.0-r0     
$ docker compose build
[+] Building 5.5s (6/6) FINISHED                                                                                                                                                       docker:default
 => [emlinux3-sdk internal] load build definition from Dockerfile                                                                                                                                0.2s
 => => transferring dockerfile: 274B                                                                                                                                                             0.0s
 => [emlinux3-sdk internal] load metadata for docker.io/library/emlinux-image-base-sdk-emlinux-bookworm-arm64:1.0-r0                                                                             0.0s
 => [emlinux3-sdk internal] load .dockerignore                                                                                                                                                   0.1s
 => => transferring context: 2B                                                                                                                                                                  0.0s
 => [emlinux3-sdk 1/2] FROM docker.io/library/emlinux-image-base-sdk-emlinux-bookworm-arm64:1.0-r0                                                                                               0.1s
 => [emlinux3-sdk 2/2] RUN useradd -m sdkuser -u 1000                                                                                                                                            3.5s
 => [emlinux3-sdk] exporting to image                                                                                                                                                            1.0s
 => => exporting layers                                                                                                                                                                          0.4s
 => => writing image sha256:d26a5f710eb3ddda6bc8257ba3880c4f9c9eea8c1d0cca30adfbd897502b8dfa                                                                                                     0.0s
 => => naming to docker.io/library/emlinux3-sdk     
$ docker compose run --rm emlinux3-sdk
[+] Creating 1/1
 ✔ Network emlinux-image-base-sdk-docker-archive_default  Created                                                                                                                                0.2s 
sdkuser@f932a6ed4d40:/$ 
```



