### PR TITLE
cve-check: Get kernel patched/unpatched CVE information from cip-kernel-sec 

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -64,8 +64,24 @@ python do_cve_check () {
             if len(cip_kernel_sec_affected_cves) > 0:
                 tmp = cip_kernel_sec_affected_cves.split(" ")
                 for cve in tmp:
-                    if not cve in unpatched:
+                    # Do not override poky's cve-check result when cve is in patched list.
+                    if not cve in unpatched and not cve in patched:
                         unpatched.append(cve)
+
+                unpatched = sorted(unpatched)
+
+            cip_kernel_sec_fixed_cves = d.getVar("CIP_KERNEL_SEC_FIXED_CVES")
+            if len(cip_kernel_sec_fixed_cves) > 0:
+                tmp = cip_kernel_sec_fixed_cves.split(" ")
+                for cve in tmp:
+                    if cve in unpatched:
+                        # in case poky's cve-check thought this cve is unpatched but cip-kernel-sec said it's fixed
+                        idx = unpatched.index(cve)
+                        unpatched.pop(idx)
+                    if not cve in patched:
+                        patched.append(cve)
+
+                patched = sorted(patched)
 
         if patched or unpatched:
             cve_data = get_cve_info(d, patched + unpatched)

--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -101,6 +101,9 @@ python kernel_cve_check () {
     from bb.fetch2 import runfetchcmd
     import requests
     import bb.process
+    import yaml
+    import os
+    import tempfile
 
     kernel_path = d.getVar("S")
     linux_cip_ver = d.getVar("LINUX_CIP_VERSION")
@@ -116,6 +119,8 @@ python kernel_cve_check () {
         return
 
     opt_ignore = "--include-ignored" if include_ignore == "1" else ""
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        output_filename = f.name
 
     # Try to get remote name from kernel repository
     if not remote_repo_name and remote_repo_autodetect == "1":
@@ -127,10 +132,23 @@ python kernel_cve_check () {
             bb.warn("Failed to detect remote name. bitbake assumes that remote is 'origin'. Please consider setting KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO")
 
     cert_path = requests.certs.where()
-    cmd = "SSL_CERT_FILE='%s' %s scripts/report_affected.py %s --remote-name cip:%s --git-repo %s %s" % (cert_path, python_path, opt_ignore, remote_repo_name, kernel_path, linux_cip_ver)
-    output = runfetchcmd(cmd, d, workdir=cip_kernel_sec_path)
+    cmd = "SSL_CERT_FILE='%s' %s scripts/report_affected.py %s --include-fixed --output-format=yaml --output-filename=%s --remote-name cip:%s --git-repo %s %s" % (cert_path, python_path, opt_ignore, output_filename, remote_repo_name, kernel_path, linux_cip_ver)
+    try:
+        runfetchcmd(cmd, d, workdir=cip_kernel_sec_path)
+    except bb.fetch2.FetchError as e:
+        bb.warn("Failed to run report_affected.py: %s" % (e))
 
-    tmp_affected_cves = output.split(":")[2].strip().split()
+    fixed_cves = None
+    tmp_affected_cves = []
+    with open(output_filename) as f:
+        yaml_data = yaml.safe_load(f)
+        k = list(yaml_data)[0]
+
+        # We don't need ignored data because CVEs in ignore section is not affected to this kernel version.
+        tmp_affected_cves.extend(yaml_data[k]["affected"])
+        fixed_cves = yaml_data[k]["fixed"]
+
+    os.unlink(output_filename)
 
     whitelist = []
     for cve in get_issue_list(cip_kernel_sec_path):
@@ -147,8 +165,11 @@ python kernel_cve_check () {
     for cve in tmp_affected_cves:
         if not cve in safelist:
             affected_cves.append(cve)
+        else:
+            fixed_cves.append(cve)
 
     d.setVar("CIP_KERNEL_SEC_AFFECTED_CVES", " ".join(affected_cves))
+    d.setVar("CIP_KERNEL_SEC_FIXED_CVES", " ".join(fixed_cves))
 }
 
 do_cve_check[prefuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'kernel_cve_check', '', d)}"


### PR DESCRIPTION
# Purpose of pull request

Recent kernel CVE entries don't contain CPE in the NVD database. Therefore, cve-check cannot get these CVE information from NVD database. To report these CVEs, get CVE information by cip-kernel-sec that report all CVE status. Previous change only report unpatched CVEs only. This change reports patched CVEs as well.

# Test
## How to test

1. Run cve-check for linux-base and linux-k510 using warrior branch
2. Run cve-check for linux-base and linux-k510 with this PR's commit
3. Compare above results that only number of PATCHED CVEs is updated

Here is check script.

```python
#!/usr/bin/env python3

import sys
import os.path
import pprint

def line_value(line):
    return line.split(":")[1].strip()

def parse_cvefile(cvefile):
    cves = {}

    with open(cvefile) as f:
        lines = f.readlines()
        cve = None
        cvssv3 = None
        status = None

        i = 0
        while True:
            if i >= len(lines):
                break
            line = lines[i]

            if line.startswith("CVE:"):
                cve = line_value(line)
            elif line.startswith("CVSS v3 BASE SCORE:"):
                cvssv3 = line_value(line)
            elif line.startswith("CVE STATUS:"):
                status = line_value(line)
            elif line.startswith("MORE INFORMATION:"):
                if not cve is None:
                    if not cve in cves:
                        cves[cve] = {
                            "CVE": cve,
                            "CVSSv3": cvssv3,
                            "STATUS": status,
                        }
                        cve = None
                        cvssv3 = None
                        status = None
                    else:
                        print(f"CVE {cve} is duplicated")
                        exit(1)

            i += 1

    return cves

def cve_summary(cves):
    patched = 0
    unpatched = 0
    unkown = 0

    for k in cves:
        status = cves[k]["STATUS"]
        if status == "Patched":
            patched += 1
        elif status == "Unpatched":
            unpatched += 1
        else:
            unkown += 1

    return patched, unpatched, unkown

def get_unpatched_cves(cves):
    ret = []

    for k in cves:
        if cves[k]["STATUS"] == "Unpatched":
            ret.append(k)

    return sorted(ret)

def show_unpatched_cves(old_cves, new_cves):
    old_unpatched = get_unpatched_cves(old_cves)
    new_unpatched = get_unpatched_cves(new_cves)

    if len(old_unpatched) > len(new_unpatched):
        diff = sorted(list(set(old_unpatched) - set(new_unpatched)))
    else:
        diff = sorted(list(set(new_unpatched) - set(old_unpatched)))

    if len(diff) > 0:
        print("CVEs that only in new data")
        for cve in diff:
            print(cve)

def main(cvefile_old, cvefile_new):
    old_cves = parse_cvefile(cvefile_old)
    new_cves = parse_cvefile(cvefile_new)

    old_patched, old_unpatched, old_unknown = cve_summary(old_cves)
    new_patched, new_unpatched, new_unknown = cve_summary(new_cves)

    print(f"{cvefile_old} cve-check result:")
    print(f"  Total CVEs: {len(old_cves)}")
    print(f"  patched: {old_patched}")
    print(f"  unpatched: {old_unpatched}")
    print(f"  unknown status: {old_unknown}")
    print(f"{cvefile_new} cve-check result:")
    print(f"  Total CVEs: {len(new_cves)}")
    print(f"  patched: {new_patched}")
    print(f"  unpatched: {new_unpatched}")
    print(f"  unknown status: {new_unknown}")

    show_unpatched_cves(old_cves, new_cves)

if __name__ == "__main__":
    if not len(sys.argv) == 3:
        print(f"Usage: {sys.argv[0]} <file> <file>")
        exit(1)
        
    main(sys.argv[1], sys.argv[2])
```

## Test result

As you can see only number of patched cve count is increased.

```
$ ./parse_cve_log.py linux-base.warrior linux-base.new 
linux-base.warrior cve-check result:
  Total CVEs: 4225
  patched: 3574
  unpatched: 651
  unknown status: 0
linux-base.new cve-check result:
  Total CVEs: 5998
  patched: 5347
  unpatched: 651
  unknown status: 0
$ ./parse_cve_log.py linux-k510.warrior linux-k510.new 
linux-k510.warrior cve-check result:
  Total CVEs: 4150
  patched: 3623
  unpatched: 527
  unknown status: 0
linux-k510.new cve-check result:
  Total CVEs: 6004
  patched: 5477
  unpatched: 527
  unknown status: 0

```



