### PR TITLE
Use individual temp dir for each build task on dl_srcpkg

### DIFF
--- a/classes/dl-srcpkg.bbclass
+++ b/classes/dl-srcpkg.bbclass
@@ -78,6 +78,7 @@ do_install_source_package() {
     sudo -E rm ${ROOTFSDIR}/etc/apt/apt.conf.d/30-${EML_SELF_BUILD} ${ROOTFSDIR}/etc/apt/preferences.d/${EML_SELF_BUILD} ${ROOTFSDIR}/etc/apt/sources.list.d/${EML_SELF_BUILD}.list
     rm "${ROOTFSDIR}${SRCDIRHOME}/${ROOTFS_PACKAGE_SUFFIX}.manifest"
     sudo -E umount "${ROOTFSDIR}${SRCDIRHOME}"
+    rmdir "${SRCDIRHOME}"
     sudo -E umount ${ROOTFSDIR}/tmp
     cleanup_local_isarapt
     if [ ${not_exist_resolvconf} -ne 0 ]; then

--- a/classes/dl-srcpkg.bbclass
+++ b/classes/dl-srcpkg.bbclass
@@ -40,8 +40,6 @@ do_install_source_package() {
         exit
     fi
 
-    local not_exist_resolvconf=`file '${ROOTFSDIR}'/etc/resolv.conf 2>&1 | grep "cannot open" | wc -c`
-
     ### backup apt status
     sudo sh -c "(cd ${ROOTFSDIR} && tar zcpf apt_status.tar.gz var/cache/apt var/lib/apt)"
 
@@ -57,7 +55,7 @@ do_install_source_package() {
     cp ${ROOTFS_MANIFEST_DEPLOY_DIR}/${ROOTFS_PACKAGE_SUFFIX}.manifest "${ROOTFSDIR}${SRCDIRHOME}"
 
     ### setup network & apt environment
-    if [ ${not_exist_resolvconf} -ne 0 ]; then
+    if [ ! -e "${ROOTFSDIR}/etc/resolv.conf" ]; then
         sudo cp /etc/resolv.conf ${ROOTFSDIR}/etc/resolv.conf
     else
         sudo mv ${ROOTFSDIR}/etc/resolv.conf ${ROOTFSDIR}/etc/resolv.conf.orig
@@ -81,7 +79,7 @@ do_install_source_package() {
     rmdir "${SRCDIRHOME}"
     sudo -E umount ${ROOTFSDIR}/tmp
     cleanup_local_isarapt
-    if [ ${not_exist_resolvconf} -ne 0 ]; then
+    if [ ! -e "${ROOTFSDIR}/etx/resolv.conf.orig" ]; then
         sudo -E rm ${ROOTFSDIR}/etc/resolv.conf
     else
         sudo mv ${ROOTFSDIR}/etc/resolv.conf.orig ${ROOTFSDIR}/etc/resolv.conf


### PR DESCRIPTION
# Purpose of pull request

Enhance function of source package install into SDK.

- Modify to use individual temporary directory for each build task.
- Cleanup temporary directory
- Optimize resolv.conf manipulation in SDK chroot

# Test
## How to test

To install source packages into SDK, add following line into the local.conf.

```
INHERIT += "dl-srcpkg"
```

And then type following build command.

```
$ bitbake emlinux-image-base -c populate_sdk
```

## Test result

- Confirm /tmp/srcdirhome* directory is not exist after build.

```
$ ls /tmp/srcdirhome*
ls: cannot access '/tmp/srcdirhome*': No such file or directory
```



