### PR TITLE
conf/distro: Set the linux-headers package to SDK_INSTALL

### DIFF
--- a/conf/distro/emlinux-common.inc
+++ b/conf/distro/emlinux-common.inc
@@ -31,7 +31,6 @@ IMAGER_INSTALL:wic = "parted \
 
 WKS_FILE ?= "${MACHINE}.wks"
 
-SDK_PREINSTALL += " \
-    linux-headers-${KERNEL_NAME} \
-    bc \
-"
+SDK_PREINSTALL += "bc"
+
+SDK_INSTALL += "linux-headers-${KERNEL_NAME}"


### PR DESCRIPTION
This is to pull CIP kernel's header from our self-built packages into the SDK creation.
