### PR TITLE
cve_check: Improve getting CVE status by cip-kernel-sec

### DIFF
--- a/scripts/cve_check.py
+++ b/scripts/cve_check.py
@@ -458,15 +458,20 @@ def check_kernel_cves_by_cip_kernel_sec(uniq_installed_pkgs, cves, kernel_src_di
 
     cip_kernel_sec_result = kernel_cve.run_cip_kernel_sec(kernel_src_dir, kver, cip_kernel_sec_dir)
 
-    for cve in cip_kernel_sec_result:
-        if cve in kernel_cves:
-            status = kernel_cves[cve]["CVE STATUS"]
-            if status == "Patched":
-                # Replace cve status by cip-kernel-sec result.
-                kernel_cves[cve]["CVE STATUS"] = "Unpatched"
-        else:
-            cveinfo = recheck_kernel_cve(db_file, pkgname, kernel_name, kver, cve)
-            kernel_cves[cve] = cveinfo
+    for patched_status in cip_kernel_sec_result:
+        cip_kernel_sec_cves = cip_kernel_sec_result[patched_status]
+        for cve in cip_kernel_sec_cves:
+            if not cve in kernel_cves:
+                cveinfo = recheck_kernel_cve(db_file, pkgname, kernel_name, kver, cve)
+                kernel_cves[cve] = cveinfo
+
+            # Replace cve status by cip-kernel-sec result
+            if kernel_cves[cve]["CVE STATUS"] == "Rejected":
+                pass
+            elif kernel_cves[cve]["CVE STATUS"] == patched_status:
+                pass
+            else:
+                kernel_cves[cve]["CVE STATUS"] = patched_status
 
     return cves
 


### PR DESCRIPTION
# Purpose of pull request

Get patched and unpatched CVE status by cip-kernel-sec to be able to get CVE information that is not taken from NVD database. Because if CPE is not set to NVD database, poky based CVE search feature cannot get CVE information from its database.

Note 1: Number of rejected CVEs are increased because following reasons.

1. cip-kernel-sec tracks REJECTED cves
2. CVE was not handled by cve-check feature because CPE was not set when cve was published 

Note 2: Number of unpatched CVEs are decreased the reasons are

1. NVD database doesn't contain upper limit version. e.g. [CVE-2023-6535](https://nvd.nist.gov/vuln/detail/CVE-2023-6535)
2. NVD database contains upper limit version but not contains upper limit version for 6.1 kernel. e.g. [CVE-2024-36891](https://nvd.nist.gov/vuln/detail/CVE-2024-36891)

# Test
## How to test

Run cve_check.py for PR version and bookworm branch versions.

```
cve_check.py \
--image emlinux-image-base \
--output-format text,json 
```

# Test result


```python
#!/usr/bin/env python3

import sys
import os.path
import pprint

def line_value(line):
    return line.split(":")[1].strip()

def parse_cvefile(cvefile):
    cves = {}

    with open(cvefile) as f:
        lines = f.readlines()
        cve = None
        cvssv3 = None
        status = None

        i = 0
        while True:
            if i >= len(lines):
                break
            line = lines[i]

            if line.startswith("CVE:"):
                cve = line_value(line)
            elif line.startswith("CVSS v3 BASE SCORE:"):
                cvssv3 = line_value(line)
            elif line.startswith("CVE STATUS:"):
                status = line_value(line)
            elif line.startswith("MORE INFORMATION:"):
                if not cve is None:
                    if not cve in cves:
                        cves[cve] = {
                            "CVE": cve,
                            "CVSSv3": cvssv3,
                            "STATUS": status,
                        }
                        cve = None
                        cvssv3 = None
                        status = None
                    else:
                        print(f"CVE {cve} is duplicated")
                        exit(1)

            i += 1

    return cves

def cve_summary(cves):
    patched = 0
    unpatched = 0
    rejected = 0
    unkown = 0

    for k in cves:
        status = cves[k]["STATUS"]
        if status == "Patched":
            patched += 1
        elif status == "Unpatched":
            unpatched += 1
        elif status == "Rejected":
            rejected += 1
        else:
            unkown += 1

    return patched, unpatched, rejected, unkown

def get_unpatched_cves(cves):
    ret = []

    for k in cves:
        if cves[k]["STATUS"] == "Unpatched":
            ret.append(k)

    return sorted(ret)

def main(cvefile_old, cvefile_new):
    old_cves = parse_cvefile(cvefile_old)
    new_cves = parse_cvefile(cvefile_new)

    old_patched, old_unpatched, old_rejected, old_unknown = cve_summary(old_cves)
    new_patched, new_unpatched, new_rejected, new_unknown = cve_summary(new_cves)

    print(f"{cvefile_old} cve-check result:")
    print(f"  Total CVEs: {len(old_cves)}")
    print(f"  patched: {old_patched}")
    print(f"  unpatched: {old_unpatched}")
    print(f"  rejected: {old_rejected}")
    print(f"  unknown status: {old_unknown}")
    print(f"{cvefile_new} cve-check result:")
    print(f"  Total CVEs: {len(new_cves)}")
    print(f"  patched: {new_patched}")
    print(f"  unpatched: {new_unpatched}")
    print(f"  rejected: {new_rejected}")
    print(f"  unknown status: {new_unknown}")

if __name__ == "__main__":
    if not len(sys.argv) == 3:
        print(f"Usage: {sys.argv[0]} <file> <file>")
        exit(1)
        
    main(sys.argv[1], sys.argv[2])
```

Run above script to check number of CVEs.

```
$ ./eml3-parse_cve_log.py linux-cip.bookworm linux-cip.new 
linux-cip.bookworm cve-check result:
  Total CVEs: 3897
  patched: 3512
  unpatched: 375
  rejected: 10
  unknown status: 0
linux-cip.new cve-check result:
  Total CVEs: 6080
  patched: 5674
  unpatched: 287
  rejected: 119
  unknown status: 0
```