### PR TITLE
cve-update-nvd2-native: Add database file pre-downloading feature

### DIFF
--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -37,10 +37,46 @@ CVE_DB_TEMP_FILE ?= "${CVE_CHECK_DB_DIR}/temp_nvdcve_2.db"
 
 CVE_CHECK_DB_FILE ?= "${CVE_CHECK_DB_DIR}/nvdcve_2.db"
 
+CVE_DB_PREDOWNLOAD_TEMP_FILE = "downlaod_temp_nvdcve_2.db"
+
 python () {
     if not bb.data.inherits_class("cve-check", d):
         raise bb.parse.SkipRecipe("Skip recipe when cve-check class is not loaded.")
 }
+
+def run_predownload_db_file(d):
+    base_url = d.getVar("CVE_DB_PREDOWNLOAD_URL")
+    if not base_url:
+        bb.warn("CVE_DB_PREDOWNLOAD_URL is not set")
+        return False
+
+    url = base_url  + ";downloadfilename=" + d.getVar("CVE_DB_PREDOWNLOAD_TEMP_FILE")
+
+    try:
+        bb.plain('Fetching prepared NVD database file from ... %s' % url)
+        fetcher = bb.fetch2.Fetch([url], d)
+        fetcher.download()
+    except bb.fetch2.BBFetchException as e:
+        bb.warn("Failed to fetch prepared NVD database file: %s" % e)
+        return False
+
+    return True
+
+def predownload_db_file (d):
+    import os
+    # Temporary disable to run checksum check because database file may be updated
+    d.setVar("BB_STRICT_CHECKSUM", "0")
+    r = run_predownload_db_file(d)
+    d.setVar("BB_STRICT_CHECKSUM", "1")
+    if not r:
+        return False
+
+    db_file = d.getVar("CVE_CHECK_DB_FILE")
+    downloaded_file = d.getVar("DL_DIR") + "/" + d.getVar("CVE_DB_PREDOWNLOAD_TEMP_FILE");
+    os.rename(downloaded_file, db_file)
+    bb.note("file renamed to %s to %s" % (downloaded_file, db_file))
+
+    return True
 
 python do_populate_cve_db() {
     """
@@ -49,6 +85,7 @@ python do_populate_cve_db() {
     import bb.utils
     import bb.progress
     import shutil
+    import os
 
     bb.utils.export_proxies(d)
 
@@ -68,11 +105,24 @@ python do_populate_cve_db() {
         if update_interval < 0:
             bb.note("CVE database update skipped")
             return
-        if time.time() - os.path.getmtime(db_file) < update_interval:
-            bb.note("CVE database recently updated, skipping")
-            return
-        database_time = os.path.getmtime(db_file)
-
+        elif d.getVar("CVE_DB_PREDOWNLOAD") == "1":
+            if not os.path.exists(db_file):
+                bb.note("There is no CVE database file locally, we will pre-download it.")
+                if not predownload_db_file(d):
+                    return
+            else:
+                 if time.time() - os.path.getmtime(db_file) >= update_interval:
+                    bb.note("Too old CVE database file found locally, we will replace it by pre-download.")
+                    if not predownload_db_file(d):
+                        return
+        
+        if os.path.exists(db_file):
+            if time.time() - os.path.getmtime(db_file) < update_interval:
+                bb.note("CVE database recently updated, skipping")
+                return
+            database_time = os.path.getmtime(db_file)
+        else:
+            bb.note("Create CVE database using NVD API.")
     except OSError:
         pass
 


### PR DESCRIPTION
# Purpose of pull request

This commit adds the feature to download a prepared database file to reduce
access to the NVD's API server. Typically, cve-update-nvd2-native creates a
database file using the NVD JSON API. However, it takes time to retrieve all
CVE information via the API. Therefore, it would be beneficial to reduce this
time. Additionally, the NVD API server can sometimes be unstable for short or
long periods. In such cases, downloading a prepared database file instead of
creating it from scratch would be preferable.

To download the file from the server, we must check its checksum as per BitBake's
policy. However, since the file may be updated, we cannot determine its
checksum in advance. Therefore, we temporarily disable the checksum check during
the download. Even with the checksum check disabled, BitBake will show a warning
message, which can be ignored.


```
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Missing md5 SRC_URI checksum for /home/build/work/emlinux/latest-dev/build/../downloads/downlaod_temp_nvdcve_2.db, consider adding to the recipe:
SRC_URI[md5sum] = "30e3069969f28e6cf07ceb6645267d56"
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Missing sha256 SRC_URI checksum for /home/build/work/emlinux/latest-dev/build/../downloads/downlaod_temp_nvdcve_2.db, consider adding to the recipe:
SRC_URI[sha256sum] = "e9540629d955a0f045c0becd5f02b271dd28062dc0b649c9c30840187562c8e2"
```

To download the file, the user needs the following setup in local.conf or
another config file. The download file name must be nvdcve_2.db.

```
CVE_DB_PREDOWNLOAD="1"
CVE_DB_PREDOWNLOAD_URL="http://somewhere/nvdcve_2.db"
```

We pre-download the database file when CVE_DB_PREDOWNLOAD is set to 1 and one of the following conditions is met:
 - The database file is not present
 - The database file is present, and the modification time (mtime) is too old



# Test
## How to test

### Prepare

1. Run cve-check if you don't  have nvdcve_2.db
2. copy $DL_DIR/CVE_CHECK/nvdcve_2.db to other directory(e.g. $HOME/tmp)
3. Run "cd $HOME/tmp"
4. Run " python3 -m http.server  8080"

### Test1

No nvdcve_2.db file and download prepared database file.
Then update database.

1. Remove $DL_DIR/CVE_CHECK/nvdcve_2.db
2. Add following lines in your local.conf (Also add NVDCVE_API_KEY value if you have NVD api key)

```
CVE_DB_PREDOWNLOAD="1"
CVE_DB_PREDOWNLOAD_URL="http://localhost:8080/nvdcve_2.db"
```

2. Run "bitbake cve-update-nvd2-native -vv"

### Test2

nvdcve_2.db exist and download prepared database file then update database.

1. Ensure $DL_DIR/CVE_CHECK/nvdcve_2.db is present
2. Add 'CVE_DB_UPDATE_INTERVAL = "10"' to local.conf
3. Run "bitbake cve-update-nvd2-native -vv"

### Test3

Create database using NVD api (default behavior when run cve-check first time)

1. Remove $DL_DIR/CVE_CHECK/nvdcve_2.db
2. Remove CVE_DB_PREDOWNLOAD, CVE_DB_PREDOWNLOAD_URL, and CVE_DB_UPDATE_INTERVAL from local.conf
3. Run "bitbake cve-update-nvd2-native -vv"

## Test result

### Test1

It download database file from web server, then update CVE entries.

```
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: There is no NVD database file, we will download it.
Fetching prepared NVD database file from ... http://localhost:8080/nvdcve_2.db;downloadfilename=downlaod_temp_nvdcve_2.db
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Missing md5 SRC_URI checksum for /home/build/work/emlinux/latest-dev/build/../downloads/downlaod_temp_nvdcve_2.db, consider adding to the recipe:
SRC_URI[md5sum] = "30e3069969f28e6cf07ceb6645267d56"
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Missing sha256 SRC_URI checksum for /home/build/work/emlinux/latest-dev/build/../downloads/downlaod_temp_nvdcve_2.db, consider adding to the recipe:
SRC_URI[sha256sum] = "e9540629d955a0f045c0becd5f02b271dd28062dc0b649c9c30840187562c8e2"
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: file renamed to /home/build/work/emlinux/latest-dev/build/../downloads/downlaod_temp_nvdcve_2.db to /home/build/work/emlinux/latest-dev/build/../downloads/CVE_CHECK/nvdcve_2.db
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE database: performing partial update
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Updating entries
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=0&lastModStartDate=2024-07-05T05%3A38%3A20%2B00%3A00&lastModEndDate=2024-07-08T04%3A44%3A23.486207%2B00%3A00
Currently  1 running tasks (1 of 4)   0% |       
```

### Test2

It download database file even though database file exists. Then update CVE entries.

```
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Download and replace NVD database file. 
Fetching prepared NVD database file from ... http://localhost:8080/nvdcve_2.db;downloadfilename=downlaod_temp_nvdcve_2.db
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Missing md5 SRC_URI checksum for /home/build/work/emlinux/latest-dev/build/../downloads/downlaod_temp_nvdcve_2.db, consider adding to the r
ecipe:                                                                                             
SRC_URI[md5sum] = "30e3069969f28e6cf07ceb6645267d56"                                            
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Missing sha256 SRC_URI checksum for /home/build/work/emlinux/latest-dev/build/../downloads/downlaod_temp_nvdcve_2.db, consider adding to th
e recipe:                                                                                          
SRC_URI[sha256sum] = "e9540629d955a0f045c0becd5f02b271dd28062dc0b649c9c30840187562c8e2"         
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: file renamed to /home/build/work/emlinux/latest-dev/build/../downloads/downlaod_temp_nvdcve_2.db to /home/build/work/emlinux/latest-dev/build/
../downloads/CVE_CHECK/nvdcve_2.db                                                                 
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE database: performing partial update 
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Updating entries                        
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=0&lastModStartDate=2024-07-05T05%3A38%3A20%2B00%3A00&lastModEndDate=202
4-07-08T04%3A20%3A44.296292%2B00%3A00                                                              
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Got 275 entries   
```

### Test3

It executes NVD API to get CVE information. As you can see "startIndex=0" which means get oldest data

Create
```
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE database: performing partial update 
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Updating entries                        
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=0&lastModStartDate=2024-07-05T05%3A38%3A20%2B00%3A00&lastModEndDate=202
4-07-08T04%3A20%3A44.296292%2B00%3A00                                                              
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Got 275 entries   

default
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Create CVE database using NVD API.
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Updating entries
NOTE: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=0
```