### PR TITLE
Update kernel to v6.1.96-cip24

### DIFF
--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,9 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.94-cip23"
-PV = "6.1.94-cip23"
-
+LINUX_CIP_VERSION = "v6.1.96-cip24"
+PV = "6.1.96-cip24"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip;destsuffix=${P};protocol=https \
 "
@@ -25,9 +24,8 @@ SRC_URI:append:qemu-amd64 = " file://qemu-amd64_defconfig"
 SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
-SRC_URI:append:raspberrypi400-64 = " file://raspberrypi4-64_defconfig"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
-SRCREV = "63c8d79d0e6331712687d30af6667e96d7833109"
+SRCREV = "30eabd096d28d66c597dc50705a373a0c7eda4bf"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.96-cip24

This pull request update the kernel to the following cip versions:
v6.1.96-cip24 with hash tag 30eabd096d28d66c597dc50705a373a0c7eda4bf
