### PR TITLE
Update kernel to v6.1.96-cip24-rt13

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_git.bb
+++ b/recipes-kernel/linux/linux-cip-rt_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.92-cip22-rt12"
-PV = "6.1.92-cip22-rt12"
+LINUX_CIP_VERSION = "v6.1.96-cip24-rt13"
+PV = "6.1.96-cip24-rt13"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip-rt;destsuffix=${P};protocol=https \
     file://preempt-rt.cfg \
@@ -23,6 +23,6 @@ SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
-SRCREV = "96fd74998d4ca50439f3dae4cef527201c2e3e79"
+SRCREV = "b77cb6b6bfbb621ea419f462dc501ebf38139612"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.96-cip24-rt13

This pull request update the kernel to the following cip versions:
v6.1.96-cip24-rt13 with hash tag b77cb6b6bfbb621ea419f462dc501ebf38139612
