### PR TITLE
cve-update-nvd2-native: Create CVE_CHECK directory if it is not present

### DIFF
--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -73,6 +73,11 @@ def predownload_db_file (d):
 
     db_file = d.getVar("CVE_CHECK_DB_FILE")
     downloaded_file = d.getVar("DL_DIR") + "/" + d.getVar("CVE_DB_PREDOWNLOAD_TEMP_FILE");
+
+    cve_check_dir = d.getVar("CVE_CHECK_DB_DIR")
+    if not os.path.exists(cve_check_dir):
+        os.makedirs(cve_check_dir)
+
     os.rename(downloaded_file, db_file)
     bb.note("file renamed to %s to %s" % (downloaded_file, db_file))
 


### PR DESCRIPTION
# Purpose of pull request

The pre-download feature of the CVE database file moves the downloaded file to $DL_DIR/CVE_CHECK. However, during the first execution of the cve-check task, the destination directory does not exist at the time the database file is downloaded, causing the file move operation to fail. Therefore, after downloading the database file, we will check if the destination directory exists, and if it does not, we will create it.

# Test
## How to test

1. Prepare web server to download CVE database file. Then add following lines in your conf/local.conf

```
CVE_DB_PREDOWNLOAD_URL="http://somewhere/nvdcve_2.db"
MACHINE = "qemuarm64"
CVE_DB_PREDOWNLOAD="1"
INHERIT += "cve-check debian-cve-check kernel-cve-check"
```

2. If you have NVD API key, add API key as well.

```
NVDCVE_API_KEY="your key"
```

3. Remove  bitbake-cookerdaemon.log  cache/ sstate-cache/ tmp* ../downloads/  
4. Run bitbake busybox -c cve_check

## Test result

```
┌──build@73d7d68e3a67:~/work/emlinux/latest-dev/build
└─$ rm -fr bitbake-cookerdaemon.log  cache/ sstate-cache/ tmp* ../downloads/ ; bitbake busybox -c cve_check
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:17
Parsing of 1359 .bb files complete (0 cached, 1359 parsed). 2381 targets, 79 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-18.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.9"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "deb10.13-2:40440f15e2c2d06f685da17b9af7bb105467954a"
meta-debian-extended = "HEAD:1c715cd814488f37b7fe8c57181541faa23795be"
meta-emlinux         = "create_cve_check_dir:2e9aa15b38e7fe8bab7710bc80b6456c9f40ad6c"
meta-emlinux-private = "add-predownload-db-url:7eb66fcbcd7c70236bd353e50dfdd9ce839726f4"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
Fetching prepared NVD database file from ... http://127.0.0.1:8000/nvdcve_2.db;downloadfilename=downlaod_temp_nvdcve_2.db
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Missing md5 SRC_URI checksum for /home/build/work/emlinux/latest-dev/build/../downloads/downlaod_temp_nvdcve_2.db, consider adding to the recipe:
SRC_URI[md5sum] = "d45b12110aeb6e6a99802013c3b6abd9"
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Missing sha256 SRC_URI checksum for /home/build/work/emlinux/latest-dev/build/../downloads/downlaod_temp_nvdcve_2.db, consider adding to the recipe:
SRC_URI[sha256sum] = "59b156982738d8cf9e11f1e2f37e4fc866c4d3b2737d9a957457c50f5a9714e3"
WARNING: busybox-1.30.1-r1 do_cve_check: Found unpatched CVE (CVE-2018-1000500 CVE-2021-42374 CVE-2021-42376 CVE-2021-42378 CVE-2021-42379 CVE-2021-42380 CVE-2021-42381 CVE-2021-42382 CVE-2021-42384 CVE-2021-42385 CVE-2021-42386 CVE-2022-28391 CVE-2023-39810), for more information check /home/build/work/emlinux/latest-dev/build/tmp-glibc/work/aarch64-emlinux-linux/busybox/1.30.1-r1/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There were 3 WARNING messages shown.
```



