### PR TITLE
script: Add repository settings

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -56,10 +56,14 @@ if [ -z "$TEMPLATECONF" ] && [ "${EML_BUILDDIR_SETUP_DONE}" = "false" ]; then
     echo "DL_DIR = \"\${TOPDIR}/../downloads\"" >> conf/local.conf
     cat ${REPOS}/meta-emlinux/scripts/bbmask.conf >> conf/local.conf
 
+    # Add debian repository
+    echo "DEBIAN_MIRROR=\"http://archive.debian.org/debian/pool\"" >> conf/local.conf
     # Add debian security updates repository
     echo "DEBIAN_SECURITY_UPDATE_MIRROR=\"http://security.debian.org/debian-security/pool/updates\"" >> conf/local.conf
     # Add ELTS updates repository
     echo "DEBIAN_ELTS_SECURITY_UPDATE_MIRROR=\"http://deb.freexian.com/extended-lts/pool\"" >> conf/local.conf
+    # Add repository mirrors
+    echo 'MIRRORS+="${DEBIAN_SECURITY_UPDATE_MIRROR}    http://archive.debian.org/debian-security/pool/updates \n"' >> conf/local.conf
 
     if [ -d "${EML_HOOKS}" ]; then
 	for hook in $(\ls ${EML_HOOKS}); do


### PR DESCRIPTION
# Purpose of pull request
Debian has entered the ELTS phase, the DEBIAN_MIRROR URL defined in Poky will eventually no longer be available.
So, add setting to local.conf for refer to 'archive.debian.org'.

And, same to definition of DEBIAN_SECURITY_UPDATE_MIRROR, but 'debian-security' archive does not yet exist, add it to MIRRORS for the future.

# Test
## How to test
1. Run setup-emlinux script
   ```
   $ source setup-emlinux test
   ```
2. Check local.conf setting
   ```
   test$ echo 'DISTRO = "emlinux"' >> conf/local.conf
   test$ echo 'MACHINE = "qemuarm64"' >> conf/local.conf
   test$ tail -n 20 conf/local.conf
   ```

3. Confirm fetch
   ```
   test$ rm -fr ../downloads
   test$ bitbake core-image-minimal --runall=fetch
   test$ ls ../downloads | head
   test$ grep -B 5 "Saving to:" tmp-glibc/work/aarch64-emlinux-linux/acl/2.2.53-r0/temp/log.do_fetch
   ```

## Test result
### 1. Run setup-emlinux script
```
$ source setup-emlinux test
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/


### Shell environment set up for builds. ###

You can now run 'bitbake <target>'

Common targets are:
    core-image-minimal
    core-image-sato
    meta-toolchain
    meta-ide-support

You can also run generated qemu images with a command like 'runqemu qemux86'
NOTE: Starting bitbake server...
NOTE: Starting bitbake server...
NOTE: Starting bitbake server...
```

### 2. Check local.conf setting
local.conf is configured as expected.
```
test$ tail -n 20 conf/local.conf 
           poky/meta/recipes-graphics/xorg-lib/libxxf86misc_1.0.4.bb \
           meta-debian/recipes-debian/fcode-utils/fcode-utils_debian.bb"
DEBIAN_MIRROR="http://archive.debian.org/debian/pool"
DEBIAN_SECURITY_UPDATE_MIRROR="http://security.debian.org/debian-security/pool/updates"
DEBIAN_ELTS_SECURITY_UPDATE_MIRROR="http://deb.freexian.com/extended-lts/pool"
MIRRORS+="${DEBIAN_SECURITY_UPDATE_MIRROR}    http://archive.debian.org/debian-security/pool/updates/ \n"
CTJ_DEBIAN_MIRROR='http://emlinux-pkgs.miraclelinux.com/debian/pool'
MIRRORS+="${DEBIAN_MIRROR}    ${CTJ_DEBIAN_MIRROR} \n"
CTJ_DEBIAN_SECURITY_UPDATE_MIRROR='http://emlinux-pkgs.miraclelinux.com/debian-security/pool/updates'
MIRRORS+="${DEBIAN_SECURITY_UPDATE_MIRROR}    ${CTJ_DEBIAN_SECURITY_UPDATE_MIRROR} \n"
CTJ_DEBIAN_ELTS_SECURITY_UPDATE_MIRROR='http://emlinux-pkgs.miraclelinux.com/extended-lts/pool'
MIRRORS+="${DEBIAN_ELTS_SECURITY_UPDATE_MIRROR}    ${CTJ_DEBIAN_ELTS_SECURITY_UPDATE_MIRROR} \n"
CTJ_SOURCE_MIRROR = 'http://emlinux-pkgs.miraclelinux.com/mirror/sources'
MIRRORS += "git://.*/.*    ${CTJ_SOURCE_MIRROR} \n"
MIRRORS += "http://.*/.*    ${CTJ_SOURCE_MIRROR} \n"
MIRRORS += "https://.*/.*    ${CTJ_SOURCE_MIRROR} \n"
MIRRORS += "ftp://.*/.*    ${CTJ_SOURCE_MIRROR} \n"
PREMIRRORS_append = "\n git://git.kernel.org/pub/scm/linux/kernel/git/cip    git://gitlab.com/cip-project/cip-kernel \n"
DISTRO = "emlinux"
MACHINE = "qemuarm64"
```

### 3. Confirm fetch
As expected, the source code was successfully fetched from "archive.debian.org".
```
test$ bitbake core-image-minimal --runall=fetch
Parsing recipes: 100% |#################################################################################################| Time: 0:00:36
Parsing of 1359 .bb files complete (0 cached, 1359 parsed). 2381 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.9"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:40440f15e2c2d06f685da17b9af7bb105467954a"
meta-debian-extended = "HEAD:1c715cd814488f37b7fe8c57181541faa23795be"
meta-emlinux         = "add-repository-setting:7bbcbf34901dfe8a618de45dea95e1d5f6a117f7"
meta-emlinux-private = "HEAD:33c0e2e32b02917b5bae6538579eea4325fdcf1c"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |##############################################################################################| Time: 0:00:02
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 219 tasks of which 0 didn't need to be rerun and all succeeded.
```
```
test$ ls ../downloads | head
Error-0.17027.tar.gz
Error-0.17027.tar.gz.done
acl_2.2.53-4.debian.tar.xz
acl_2.2.53-4.debian.tar.xz.done
acl_2.2.53-4.dsc
acl_2.2.53-4.dsc.done
acl_2.2.53.orig.tar.gz
acl_2.2.53.orig.tar.gz.asc
acl_2.2.53.orig.tar.gz.asc.done
acl_2.2.53.orig.tar.gz.done
```
```
test$ grep -B 5 "Saving to:" tmp-glibc/work/aarch64-emlinux-linux/acl/2.2.53-r0/temp/log.do_fetch
--2024-07-17 09:01:40--  http://archive.debian.org/debian/pool/main/a/acl/acl_2.2.53-4.dsc
Resolving proxy-sgy.miraclelinux.com (proxy-sgy.miraclelinux.com)... 10.2.200.16
Connecting to proxy-sgy.miraclelinux.com (proxy-sgy.miraclelinux.com)|10.2.200.16|:8080... connected.
Proxy request sent, awaiting response... 200 OK
Length: 2330 (2.3K) [text/prs.lines.tag]
Saving to: ‘/project/security-update/test3/test/../downloads/acl_2.2.53-4.dsc’
--
--2024-07-17 09:01:40--  http://archive.debian.org/debian/pool/main/a/acl/acl_2.2.53.orig.tar.gz
Resolving proxy-sgy.miraclelinux.com (proxy-sgy.miraclelinux.com)... 10.2.200.16
Connecting to proxy-sgy.miraclelinux.com (proxy-sgy.miraclelinux.com)|10.2.200.16|:8080... connected.
Proxy request sent, awaiting response... 200 OK
Length: 524300 (512K) [application/x-gzip]
Saving to: ‘/project/security-update/test3/test/../downloads/acl_2.2.53.orig.tar.gz’
--
--2024-07-17 09:01:40--  http://archive.debian.org/debian/pool/main/a/acl/acl_2.2.53.orig.tar.gz.asc
Resolving proxy-sgy.miraclelinux.com (proxy-sgy.miraclelinux.com)... 10.2.200.16
Connecting to proxy-sgy.miraclelinux.com (proxy-sgy.miraclelinux.com)|10.2.200.16|:8080... connected.
Proxy request sent, awaiting response... 200 OK
Length: 833 [application/pgp-keys]
Saving to: ‘/project/security-update/test3/test/../downloads/acl_2.2.53.orig.tar.gz.asc’
--
--2024-07-17 09:01:40--  http://archive.debian.org/debian/pool/main/a/acl/acl_2.2.53-4.debian.tar.xz
Resolving proxy-sgy.miraclelinux.com (proxy-sgy.miraclelinux.com)... 10.2.200.16
Connecting to proxy-sgy.miraclelinux.com (proxy-sgy.miraclelinux.com)|10.2.200.16|:8080... connected.
Proxy request sent, awaiting response... 200 OK
Length: 18572 (18K) [application/x-xz]
Saving to: ‘/project/security-update/test3/test/../downloads/acl_2.2.53-4.debian.tar.xz’
```