### PR TITLE
Update cyclonedx lib

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN bash -c 'if test -n "$http_proxy"; then git config --global http.proxy "$htt
 RUN bash -c 'if test -n "$https_proxy"; then git config --global https.proxy "$https_proxy"; fi'
 RUN bash -c 'if test -n "$no_proxy"; then git config --global core.noproxy "$no_proxy"; fi'
 
-RUN pip install --user cyclonedx-python-lib==7.3.1 --break-system-packages
+RUN pip install --user 'cyclonedx-python-lib>=7.3.2,<=7.5.1' --break-system-packages
 RUN pip install --user jsonschema==4.21.1 --break-system-packages
 RUN pip install --user spdx-tools==0.8.2 --break-system-packages
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,8 +71,8 @@ RUN bash -c 'if test -n "$http_proxy"; then git config --global http.proxy "$htt
 RUN bash -c 'if test -n "$https_proxy"; then git config --global https.proxy "$https_proxy"; fi'
 RUN bash -c 'if test -n "$no_proxy"; then git config --global core.noproxy "$no_proxy"; fi'
 
-RUN pip install --user pip install cyclonedx-python-lib==7.3.1 --break-system-packages
-RUN pip install --user pip install jsonschema==4.21.1 --break-system-packages
+RUN pip install --user cyclonedx-python-lib==7.3.1 --break-system-packages
+RUN pip install --user jsonschema==4.21.1 --break-system-packages
 RUN pip install --user spdx-tools==0.8.2 --break-system-packages
 
 RUN mkdir work


### PR DESCRIPTION
# Purpose of pull request

This PR contains 2 commits.

03ffba123046752022016b35222396cf7cdf4153 : Remove unneeded "pip install" line from install command.
44949c2331b866ae46dbb82361dc7e9740344dc3: Version up  cyclone-python-lib 

The main purpose of this PR is the cyclonedx-python-lib version 7.3.1 has been yanked by upstream[1] so that update its version to 7.5.1. The pip install command line use version range from 7.3.2 to 7.5.1, even if 7.5.1 was yanked, 7.5.0 will be installed.

Installing 7.3.1, we will get following error.

```
 => ERROR [emlinux3-build 18/22] RUN pip install --user pip install cyclonedx-python-lib==7.3.1 --break-system-packages                                                                          1.1s
------                                                                                                                                                                                                
 > [emlinux3-build 18/22] RUN pip install --user pip install cyclonedx-python-lib==7.3.1 --break-system-packages:                                                                                     
0.748 Requirement already satisfied: pip in /usr/lib/python3/dist-packages (23.0.1)
1.008 ERROR: Could not find a version that satisfies the requirement install (from versions: none)
1.009 ERROR: No matching distribution found for install
------
failed to solve: process "/bin/sh -c pip install --user pip install cyclonedx-python-lib==7.3.1 --break-system-packages" did not complete successfully: exit code: 1
```

1: https://pypi.org/project/cyclonedx-python-lib/7.3.1/

# Test
## How to test

1. Build docker image
2. Create cyclonedx sbom

## Test result

Building docker image was succeeded.

```
$ ./run.sh build
WARN[0000] /raid0array1/masami/isar-emlinux/latest-dev/repos/meta-emlinux/docker/docker-compose.yml: `version` is obsolete 
[+] Building 164.7s (27/27) FINISHED                                                                                                                                                   docker:default
 => [emlinux3-build internal] load build definition from Dockerfile                                                                                                                              0.0s
 => => transferring dockerfile: 2.25kB                                                                                                                                                           0.0s
 => [emlinux3-build internal] load metadata for docker.io/library/debian:bookworm                                                                                                                1.3s
 => [emlinux3-build internal] load .dockerignore                                                                                                                                                 0.0s
 => => transferring context: 2B                                                                                                                                                                  0.0s
 => CACHED [emlinux3-build  1/22] FROM docker.io/library/debian:bookworm@sha256:1dc55ed6871771d4df68d393ed08d1ed9361c577cfeb903cd684a182e8a3e3ae                                                 0.0s
 => [emlinux3-build internal] load build context                                                                                                                                                 0.0s
 => => transferring context: 29B                                                                                                                                                                 0.0s
 => [emlinux3-build  2/22] RUN apt-get update --fix-missing && apt-get -y upgrade --fix-missing                                                                                                  2.0s
 => [emlinux3-build  3/22] RUN apt-get install --fix-missing -y   binfmt-support   debootstrap   dosfstools   dpkg-dev   gettext-base   git   mtools   parted   python3   quilt   qemu-system  137.2s
 => [emlinux3-build  4/22] RUN useradd -m build -u 1001                                                                                                                                          0.3s 
 => [emlinux3-build  5/22] RUN gpasswd -a build sbuild                                                                                                                                           0.5s 
 => [emlinux3-build  6/22] RUN apt-get install -y sudo                                                                                                                                           0.9s 
 => [emlinux3-build  7/22] RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers                                                                                                        0.4s 
 => [emlinux3-build  8/22] RUN echo  "Defaults env_keep += " http_proxy https_proxy no_proxy"" | tee -a /etc/sudoers                                                                             0.4s 
 => [emlinux3-build  9/22] RUN apt-get install -y locales                                                                                                                                        2.8s 
 => [emlinux3-build 10/22] RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen &&         echo 'LANG="en_US.UTF-8"'>/etc/default/locale &&         dpkg-reconfigure --fron  1.6s 
 => [emlinux3-build 11/22] ADD gitproxy /usr/bin                                                                                                                                                 0.1s 
 => [emlinux3-build 12/22] RUN chmod +x /usr/bin/gitproxy                                                                                                                                        0.3s 
 => [emlinux3-build 13/22] RUN bash -c 'if test -n "$http_proxy"; then sed -i -e "s#\(http_proxy=\"\).*#\1$http_proxy\"#" /usr/bin/gitproxy; fi'                                                 0.4s 
 => [emlinux3-build 14/22] WORKDIR /home/build                                                                                                                                                   0.0s 
 => [emlinux3-build 15/22] RUN bash -c 'if test -n "$http_proxy"; then git config --global http.proxy "$http_proxy";                                             git config --global core.gitpr  0.3s 
 => [emlinux3-build 16/22] RUN bash -c 'if test -n "$https_proxy"; then git config --global https.proxy "$https_proxy"; fi'                                                                      0.3s
 => [emlinux3-build 17/22] RUN bash -c 'if test -n "$no_proxy"; then git config --global core.noproxy "$no_proxy"; fi'                                                                           0.4s
 => [emlinux3-build 18/22] RUN pip install --user 'cyclonedx-python-lib>=7.3.2,<=7.5.1' --break-system-packages                                                                                  1.5s
 => [emlinux3-build 19/22] RUN pip install --user jsonschema==4.21.1 --break-system-packages                                                                                                     1.9s
 => [emlinux3-build 20/22] RUN pip install --user spdx-tools==0.8.2 --break-system-packages                                                                                                      2.2s 
 => [emlinux3-build 21/22] RUN mkdir work                                                                                                                                                        0.5s 
 => [emlinux3-build 22/22] WORKDIR /home/build/work                                                                                                                                              0.1s 
 => [emlinux3-build] exporting to image                                                                                                                                                          9.0s 
 => => exporting layers                                                                                                                                                                          9.0s 
 => => writing image sha256:415d1521e7a2cf2355e63af2d9263b669f4b7ab3c8a21a53c97a2f72c75a75ed                                                                                                     0.0s 
 => => naming to docker.io/library/emlinux3-build              
```

Creating cylonedx sbom was succeeded.

```
build@1b8b5a1b1c92:~/work$ pip list --user | grep cyclonedx-python-lib
cyclonedx-python-lib      7.5.1
build@1b8b5a1b1c92:~/work$ source ./setup-emlinux build
### Shell environment set up for builds. ###

You can now run 'bitbake <target>'

Common targets are:
    mc:qemuarm-bullseye:isar-image-base
    mc:qemuarm64-bullseye:isar-image-base
    mc:qemuamd64-bullseye:isar-image-base
build@1b8b5a1b1c92:~/work/build$ pip list --user | grep cyclonedx-python-lib
cyclonedx-python-lib      7.5.1
build@1b8b5a1b1c92:~/work/build$ create_sbom.py --image emlinux-image-base --supplier "Cybertrust Japan Co., Ltd." --product EMLinux3 --sbom-format cyclonedx --verbose
2024-07-18 02:45:29,448:INFO: Create cyclonedx format sbom for emlinux-image-base
2024-07-18 02:45:29,641:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-cyclonedx.json
```

Testing cyclonedx-python-lib 7.3.2 through 7.5.0 was also succeeded.

7.3.2
```
build@b622aa09e4ab:~/work$ echo y | pip uninstall cyclonedx-python-lib --break-system-packages
pip install -U --user cyclonedx-python-lib==7.3.2 --break-system-packages
pip list --user | grep cyclonedx-python-lib
create_sbom.py --image emlinux-image-base --supplier "Cybertrust Japan Co., Ltd." --product EMLinux3 --sbom-format cyclonedx --verbose
Found existing installation: cyclonedx-python-lib 7.3.1
Uninstalling cyclonedx-python-lib-7.3.1:
  Would remove:
    /home/build/.local/lib/python3.11/site-packages/cyclonedx/*
    /home/build/.local/lib/python3.11/site-packages/cyclonedx_python_lib-7.3.1.dist-info/*
Proceed (Y/n)?   Successfully uninstalled cyclonedx-python-lib-7.3.1
Collecting cyclonedx-python-lib==7.3.2
  Using cached cyclonedx_python_lib-7.3.2-py3-none-any.whl (359 kB)
Requirement already satisfied: license-expression<31,>=30 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.2) (30.3.0)
Requirement already satisfied: packageurl-python<2,>=0.11 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.2) (0.15.4)
Requirement already satisfied: py-serializable<2,>=1.0.3 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.2) (1.1.0)
Requirement already satisfied: sortedcontainers<3.0.0,>=2.4.0 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.2) (2.4.0)
Requirement already satisfied: boolean.py>=4.0 in /home/build/.local/lib/python3.11/site-packages (from license-expression<31,>=30->cyclonedx-python-lib==7.3.2) (4.0)
Requirement already satisfied: defusedxml<0.8.0,>=0.7.1 in /home/build/.local/lib/python3.11/site-packages (from py-serializable<2,>=1.0.3->cyclonedx-python-lib==7.3.2) (0.7.1)
Installing collected packages: cyclonedx-python-lib
Successfully installed cyclonedx-python-lib-7.3.2
cyclonedx-python-lib      7.3.2
2024-07-18 02:38:10,155:INFO: Create cyclonedx format sbom for emlinux-image-base
2024-07-18 02:38:10,344:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-cyclonedx.json

```

7.3.3
```
build@1574bfe5c82a:~/work$ echo y | pip uninstall cyclonedx-python-lib --break-system-packages
pip install -U --user cyclonedx-python-lib==7.3.3 --break-system-packages
pip list --user | grep cyclonedx-python-lib
create_sbom.py --image emlinux-image-base --supplier "Cybertrust Japan Co., Ltd." --product EMLinux3 --sbom-format cyclonedx --verbose
Found existing installation: cyclonedx-python-lib 7.3.2
Uninstalling cyclonedx-python-lib-7.3.2:
  Would remove:
    /home/build/.local/lib/python3.11/site-packages/cyclonedx/*
    /home/build/.local/lib/python3.11/site-packages/cyclonedx_python_lib-7.3.2.dist-info/*
Proceed (Y/n)?   Successfully uninstalled cyclonedx-python-lib-7.3.2
Collecting cyclonedx-python-lib==7.3.3
  Downloading cyclonedx_python_lib-7.3.3-py3-none-any.whl (359 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 359.3/359.3 kB 11.6 MB/s eta 0:00:00
Requirement already satisfied: license-expression<31,>=30 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.3) (30.3.0)
Requirement already satisfied: packageurl-python<2,>=0.11 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.3) (0.15.4)
Requirement already satisfied: py-serializable<2,>=1.0.3 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.3) (1.1.0)
Requirement already satisfied: sortedcontainers<3.0.0,>=2.4.0 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.3) (2.4.0)
Requirement already satisfied: boolean.py>=4.0 in /home/build/.local/lib/python3.11/site-packages (from license-expression<31,>=30->cyclonedx-python-lib==7.3.3) (4.0)
Requirement already satisfied: defusedxml<0.8.0,>=0.7.1 in /home/build/.local/lib/python3.11/site-packages (from py-serializable<2,>=1.0.3->cyclonedx-python-lib==7.3.3) (0.7.1)
Installing collected packages: cyclonedx-python-lib
Successfully installed cyclonedx-python-lib-7.3.3
cyclonedx-python-lib      7.3.3
2024-07-18 02:18:52,310:INFO: Create cyclonedx format sbom for emlinux-image-base
2024-07-18 02:18:52,501:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-cyclonedx.json
```

7.3.4
```
build@1574bfe5c82a:~/work$ echo y | pip uninstall cyclonedx-python-lib --break-system-packages
pip install -U --user cyclonedx-python-lib==7.3.4 --break-system-packages
pip list --user | grep cyclonedx-python-lib
create_sbom.py --image emlinux-image-base --supplier "Cybertrust Japan Co., Ltd." --product EMLinux3 --sbom-format cyclonedx --verbose
Found existing installation: cyclonedx-python-lib 7.3.3
Uninstalling cyclonedx-python-lib-7.3.3:
  Would remove:
    /home/build/.local/lib/python3.11/site-packages/cyclonedx/*
    /home/build/.local/lib/python3.11/site-packages/cyclonedx_python_lib-7.3.3.dist-info/*
Proceed (Y/n)?   Successfully uninstalled cyclonedx-python-lib-7.3.3
Collecting cyclonedx-python-lib==7.3.4
  Downloading cyclonedx_python_lib-7.3.4-py3-none-any.whl (359 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 359.3/359.3 kB 9.3 MB/s eta 0:00:00
Requirement already satisfied: license-expression<31,>=30 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.4) (30.3.0)
Requirement already satisfied: packageurl-python<2,>=0.11 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.4) (0.15.4)
Requirement already satisfied: py-serializable<2,>=1.0.3 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.4) (1.1.0)
Requirement already satisfied: sortedcontainers<3.0.0,>=2.4.0 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.3.4) (2.4.0)
Requirement already satisfied: boolean.py>=4.0 in /home/build/.local/lib/python3.11/site-packages (from license-expression<31,>=30->cyclonedx-python-lib==7.3.4) (4.0)
Requirement already satisfied: defusedxml<0.8.0,>=0.7.1 in /home/build/.local/lib/python3.11/site-packages (from py-serializable<2,>=1.0.3->cyclonedx-python-lib==7.3.4) (0.7.1)
Installing collected packages: cyclonedx-python-lib
Successfully installed cyclonedx-python-lib-7.3.4
cyclonedx-python-lib      7.3.4
2024-07-18 02:19:48,490:INFO: Create cyclonedx format sbom for emlinux-image-base
2024-07-18 02
```

7.4.0
```
build@1574bfe5c82a:~/work$ echo y | pip uninstall cyclonedx-python-lib --break-system-packages
pip install -U --user cyclonedx-python-lib==7.4.0 --break-system-packages
pip list --user | grep cyclonedx-python-lib
create_sbom.py --image emlinux-image-base --supplier "Cybertrust Japan Co., Ltd." --product EMLinux3 --sbom-format cyclonedx --verbose

Found existing installation: cyclonedx-python-lib 7.3.4
Uninstalling cyclonedx-python-lib-7.3.4:
  Would remove:
    /home/build/.local/lib/python3.11/site-packages/cyclonedx/*
    /home/build/.local/lib/python3.11/site-packages/cyclonedx_python_lib-7.3.4.dist-info/*
Proceed (Y/n)?   Successfully uninstalled cyclonedx-python-lib-7.3.4
Collecting cyclonedx-python-lib==7.4.0
  Downloading cyclonedx_python_lib-7.4.0-py3-none-any.whl (359 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 359.8/359.8 kB 9.8 MB/s eta 0:00:00
Requirement already satisfied: license-expression<31,>=30 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.4.0) (30.3.0)
Requirement already satisfied: packageurl-python<2,>=0.11 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.4.0) (0.15.4)
Requirement already satisfied: py-serializable<2,>=1.0.3 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.4.0) (1.1.0)
Requirement already satisfied: sortedcontainers<3.0.0,>=2.4.0 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.4.0) (2.4.0)
Requirement already satisfied: boolean.py>=4.0 in /home/build/.local/lib/python3.11/site-packages (from license-expression<31,>=30->cyclonedx-python-lib==7.4.0) (4.0)
Requirement already satisfied: defusedxml<0.8.0,>=0.7.1 in /home/build/.local/lib/python3.11/site-packages (from py-serializable<2,>=1.0.3->cyclonedx-python-lib==7.4.0) (0.7.1)
Installing collected packages: cyclonedx-python-lib
Successfully installed cyclonedx-python-lib-7.4.0
cyclonedx-python-lib      7.4.0
2024-07-18 02:21:53,995:INFO: Create cyclonedx format sbom for emlinux-image-base
2024-07-18 02:21:54,185:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-cyclonedx.json
```

7.4.1
```
build@1574bfe5c82a:~/work$ echo y | pip uninstall cyclonedx-python-lib --break-system-packages
pip install -U --user cyclonedx-python-lib==7.4.1 --break-system-packages
pip list --user | grep cyclonedx-python-lib
create_sbom.py --image emlinux-image-base --supplier "Cybertrust Japan Co., Ltd." --product EMLinux3 --sbom-format cyclonedx --verbose
Found existing installation: cyclonedx-python-lib 7.4.0
Uninstalling cyclonedx-python-lib-7.4.0:
  Would remove:
    /home/build/.local/lib/python3.11/site-packages/cyclonedx/*
    /home/build/.local/lib/python3.11/site-packages/cyclonedx_python_lib-7.4.0.dist-info/*
Proceed (Y/n)?   Successfully uninstalled cyclonedx-python-lib-7.4.0
Collecting cyclonedx-python-lib==7.4.1
  Downloading cyclonedx_python_lib-7.4.1-py3-none-any.whl (359 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 359.8/359.8 kB 9.1 MB/s eta 0:00:00
Requirement already satisfied: license-expression<31,>=30 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.4.1) (30.3.0)
Requirement already satisfied: packageurl-python<2,>=0.11 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.4.1) (0.15.4)
Requirement already satisfied: py-serializable<2,>=1.0.3 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.4.1) (1.1.0)
Requirement already satisfied: sortedcontainers<3.0.0,>=2.4.0 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.4.1) (2.4.0)
Requirement already satisfied: boolean.py>=4.0 in /home/build/.local/lib/python3.11/site-packages (from license-expression<31,>=30->cyclonedx-python-lib==7.4.1) (4.0)
Requirement already satisfied: defusedxml<0.8.0,>=0.7.1 in /home/build/.local/lib/python3.11/site-packages (from py-serializable<2,>=1.0.3->cyclonedx-python-lib==7.4.1) (0.7.1)
Installing collected packages: cyclonedx-python-lib
Successfully installed cyclonedx-python-lib-7.4.1
cyclonedx-python-lib      7.4.1
2024-07-18 02:22:50,345:INFO: Create cyclonedx format sbom for emlinux-image-base
2024-07-18 02:22:50,535:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-cyclonedx.json
```

7.5.0
```
build@1574bfe5c82a:~/work$ echo y | pip uninstall cyclonedx-python-lib --break-system-packages
pip install -U --user cyclonedx-python-lib==7.5.0 --break-system-packages
pip list --user | grep cyclonedx-python-lib
create_sbom.py --image emlinux-image-base --supplier "Cybertrust Japan Co., Ltd." --product EMLinux3 --sbom-format cyclonedx --verbose
Found existing installation: cyclonedx-python-lib 7.4.1
Uninstalling cyclonedx-python-lib-7.4.1:
  Would remove:
    /home/build/.local/lib/python3.11/site-packages/cyclonedx/*
    /home/build/.local/lib/python3.11/site-packages/cyclonedx_python_lib-7.4.1.dist-info/*
Proceed (Y/n)?   Successfully uninstalled cyclonedx-python-lib-7.4.1

Collecting cyclonedx-python-lib==7.5.0
  Downloading cyclonedx_python_lib-7.5.0-py3-none-any.whl (360 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 360.0/360.0 kB 11.8 MB/s eta 0:00:00
Requirement already satisfied: license-expression<31,>=30 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.5.0) (30.3.0)
Requirement already satisfied: packageurl-python<2,>=0.11 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.5.0) (0.15.4)
Requirement already satisfied: py-serializable<2,>=1.0.3 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.5.0) (1.1.0)
Requirement already satisfied: sortedcontainers<3.0.0,>=2.4.0 in /home/build/.local/lib/python3.11/site-packages (from cyclonedx-python-lib==7.5.0) (2.4.0)
Requirement already satisfied: boolean.py>=4.0 in /home/build/.local/lib/python3.11/site-packages (from license-expression<31,>=30->cyclonedx-python-lib==7.5.0) (4.0)
Requirement already satisfied: defusedxml<0.8.0,>=0.7.1 in /home/build/.local/lib/python3.11/site-packages (from py-serializable<2,>=1.0.3->cyclonedx-python-lib==7.5.0) (0.7.1)
Installing collected packages: cyclonedx-python-lib
Successfully installed cyclonedx-python-lib-7.5.0
cyclonedx-python-lib      7.5.0
2024-07-18 02:24:02,329:INFO: Create cyclonedx format sbom for emlinux-image-base
2024-07-18 02:2
```
