### PR TITLE
emlinux3: cve-check: Add pre-download CVE database feature

### DIFF
--- a/scripts/cve_check.py
+++ b/scripts/cve_check.py
@@ -610,6 +610,10 @@ def main(args):
         logger.critical("Faied to fetch CVE database from NVD")
         exit(1)
 
+    if args.update_cve_databese_only:
+        logger.info("Finish CVE database update.")
+        exit(0)
+
     debian_cve_list = debian_cve.fetch_cve_data(cve_data_dl_dir)
     if debian_cve_list is None:
         logger.critical("Failed to fetch CVE data from Debian")
@@ -665,6 +669,8 @@ def parse_options():
     parser.add_argument("--image-name", dest="image_name", help="EMLinux image name",
             metavar="IMAGENAME", required=True)
     parser.add_argument("--cve-db-predownload", dest="cve_db_predownload", action="store_true", help="Enable CVE database predownload.URL should be defined by CVE_DB_PREDOWNLOAD_URL in conf/local.conf.")
+    parser.add_argument("--update-cve-databese-only", dest="update_cve_databese_only", default=False, action="store_true",
+            help="Do not run cve check. Update CVE database only.")
     parser.add_argument("--verbose", dest="verbose_output", help="Enable verbose output",
             default=False, action="store_true")
 

--- a/scripts/cve_check.py
+++ b/scripts/cve_check.py
@@ -598,8 +598,15 @@ def main(args):
     cve_data_dl_dir = f"{bitbakeinfo['dl_dir']}/CVE"
     create_directory(cve_data_dl_dir)
 
-    db_file = nvd_cve.update_nvd_db(cve_data_dl_dir, args.nvd_api_key)
-    if db_file is None:
+    predownload_url = None
+    if args.cve_db_predownload:
+        predownload_url = bitbakeinfo["cve_db_predownload"]
+        if predownload_url is None:
+            logger.error("CVE_DB_PREDOWNLOAD_URL variable should be defined in conf/local.conf")
+            exit(1)
+
+    update_result, db_file = nvd_cve.update_nvd_db(cve_data_dl_dir, args.nvd_api_key, predownload_url)
+    if not update_result:
         logger.critical("Faied to fetch CVE database from NVD")
         exit(1)
 
@@ -657,6 +664,7 @@ def parse_options():
             metavar="CVEPRODUCT")
     parser.add_argument("--image-name", dest="image_name", help="EMLinux image name",
             metavar="IMAGENAME", required=True)
+    parser.add_argument("--cve-db-predownload", dest="cve_db_predownload", action="store_true", help="Enable CVE database predownload.URL should be defined by CVE_DB_PREDOWNLOAD_URL in conf/local.conf.")
     parser.add_argument("--verbose", dest="verbose_output", help="Enable verbose output",
             default=False, action="store_true")
 

--- a/scripts/lib/python/bitbake_runner.py
+++ b/scripts/lib/python/bitbake_runner.py
@@ -45,6 +45,7 @@ def get_bitbake_information(image):
     pattern_distro_arch = r'\nDISTRO_ARCH="([^"]*)"'
     pattern_repo_isar_dir = r'\nREPO_ISAR_DIR="([^"]*)"'
     pattern_image_distro = r'\nDISTRO="([^"]*)"'
+    pattern_cve_db_predownload = r'\nCVE_DB_PREDOWNLOAD_URL="([^"]*)"'
 
     deploy_image_dir = re.findall(pattern_deploy_image_dir, output)[0]
     deploy_dir = re.findall(pattern_deploy_dir, output)[0]
@@ -57,6 +58,12 @@ def get_bitbake_information(image):
     repo_isar_dir = re.findall(pattern_repo_isar_dir, output)[0]
     image_distro = re.findall(pattern_image_distro, output)[0]
 
+    cve_db_url = re.findall(pattern_cve_db_predownload, output)
+    if not len(cve_db_url) == 0:
+        cve_db_predownload = cve_db_url[0]
+    else:
+        cve_db_predownload = None
+
     dpkg_status = f"{deploy_image_dir}/{image_full_name}.dpkg_status"
     return {
         "deploy_dir": deploy_dir,
@@ -68,4 +75,5 @@ def get_bitbake_information(image):
         "distro_arch": distro_arch,
         "repo_isar_dir": repo_isar_dir,
         "image_distro": image_distro,
+        "cve_db_predownload": cve_db_predownload,
     }


### PR DESCRIPTION
# Purpose of pull request

## commit:  Add pre-download CVE database feature 

This commit adds the feature to download a prepared database file to reduce access to the NVD's API server. Typically,cve_check.py creates a
database file using the NVD JSON API. However, it takes time to retrieve all CVE information via the API. Therefore, it would be beneficial to
reduce this time. Additionally, the NVD API server can sometimes be unstable for short or long periods. In such cases, downloading a
prepared database file instead of creating it from scratch would be preferable.

To enable download pre-downloaded CVE database feature, usage --cve-db-predownload option and set URL to CVE_DB_PREDOWNLOAD_URL variable in conf/local.conf.
The predownloaded CVE database name should be "nvd_cve_db.db".
e.g.

Add CVE_DB_PREDOWNLOAD_URL in conf/local.conf.

```
CVE_DB_PREDOWNLOAD_URL="http://127.0.0.1:8000/nvd_cve_db.db"
```

Then run cve_check.py with

```
cve_check.py --image emlinux-image-base \
--output-format text,json --cve-db-predownload
```

It download pre-downloaded CVE database when one of following contision is met.

- CVE database is not present
- CVE database is present but it is old


## commit: cve-check: Add update-cve-databese-only

Add update-cve-databese-only that only updates CVE database. It purpose is to prepare CVE database then distribute it to other  machines.

# Test
## How to test

### Download pre-downloaded file

Test patterns

|no|download pre-download file|update CVE database|
|--|--|--|
|1|Yes(CVE database file is not present in build/download/CVE directory|No|
|2|Yes(CVE database file is  present in build/download/CVE directory|No|
|3|Yes(CVE database file is  present in build/download/CVE directory|Yes(Downloaded file is old. may be it is not updated by server)|
|4|No|Yes (normal use case before applying this PR)|

Prepare two CVE database one is up to dated and the other is bit old. for example prepare nvd_cve_db.db.new annd nvd_cve_db.db.old .
Copy .new or .old file to nvd cve db.db which depends on test pattern separately.
Run "python -m http.server" to host CVE database file.

Run cve-check.py for test 1 to 3.

```
 cve_check.py \
--image emlinux-image-base \
--output-format text,json \
--cve-db-predownload 
```

Run cve-check.py for test 4.

```
 cve_check.py \
--image emlinux-image-base \
--output-format text,json \
```

### Update CVE database only

Run "python -m http.server" to host CVE database file.

Run cve-check.py

```
cve_check.py \
--image emlinux-image-base \
--output-format text,json \
--cve-db-predownload \
--update-cve-databese-only
```

## Test result

### Download pre-downloaded file

test pattern 1

```
build@3d4795c39605:~/work$ rm -f build/downloads/CVE/nvd_cve_db.db 
build@3d4795c39605:~/work$ cve_check.py --image emlinux-image-base --output-format text,json  --cve-db-predownload 
2024-07-26 05:37:19,749:INFO: Predownload CVE database file.
2024-07-26 05:37:19,749:INFO: Download CVE database file from http://127.0.0.1:8000/nvd_cve_db.db.
2024-07-26 05:37:19,934:INFO: Download CVE database file was succeeded.
2024-07-26 05:37:22,557:INFO: Last database update is in 1day so skip NVD database update
2024-07-26 05:37:22,558:INFO: Update debian CVE database
2024-07-26 05:37:22,558:INFO: Last database update is in 1day so skip Debian CVE database update
2024-07-26 05:37:22,558:INFO: Update cip-kernel-sec
2024-07-26 05:37:23,389:INFO: Checking CVEs ...
2024-07-26 05:38:00,154:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-arm64
```

test pattern 2

before testing, modify CVE database.

```
build@3d4795c39605:~/work$ sqlite3 ./build/downloads/CVE/nvd_cve_db.db 
SQLite version 3.40.1 2022-12-28 14:03:47
Enter ".help" for usage hints.
sqlite> select * from meta;
1|2024-07-26T05:33:59.720785
sqlite> .schema meta
CREATE TABLE META (ID NUMBER UNIQUE, LASTMODIFIED TEXT);
sqlite> select * from meta;
1|2024-07-26T05:33:59.720785
sqlite> update meta set lastmodified="2024-07-25T01:33:59.720785" where id=1;
sqlite> select * from meta;
1|2024-07-25T01:33:59.720785
```

```
build@3d4795c39605:~/work$ cve_check.py --image emlinux-image-base --output-format text,json  --cve-db-predownload 
2024-07-26 05:44:47,682:INFO: Predownload CVE database file.
2024-07-26 05:44:47,682:INFO: Download CVE database file from http://127.0.0.1:8000/nvd_cve_db.db.
2024-07-26 05:44:47,885:INFO: Download CVE database file was succeeded.
2024-07-26 05:44:50,148:INFO: Last database update is in 1day so skip NVD database update
2024-07-26 05:44:50,148:INFO: Update debian CVE database
2024-07-26 05:44:50,148:INFO: Last database update is in 1day so skip Debian CVE database update
2024-07-26 05:44:50,148:INFO: Update cip-kernel-sec
2024-07-26 05:44:50,796:INFO: Checking CVEs ...
2024-07-26 05:45:27,497:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-arm64
```

test pattern 3

before testing,  copy old CVE database to build/download/CVE directory and web server distributes old CVE database.

```
build@3d4795c39605:~/work$ cp web/nvd_cve_db.db.20240719 build/downloads/CVE/nvd_cve_db.db 
build@3d4795c39605:~/work$ cve_check.py --image emlinux-image-base --output-format text,json  --cve-db-predownload 
2024-07-26 05:48:36,019:INFO: Predownload CVE database file.
2024-07-26 05:48:36,019:INFO: Download CVE database file from http://127.0.0.1:8000/nvd_cve_db.db.
2024-07-26 05:48:36,227:INFO: Download CVE database file was succeeded.
2024-07-26 05:48:38,985:INFO: Update NVD CVE database
2024-07-26 05:48:41,198:INFO: Update last modified date
2024-07-26 05:48:41,758:INFO: Update debian CVE database
2024-07-26 05:48:41,758:INFO: Last database update is in 1day so skip Debian CVE database update
2024-07-26 05:48:41,759:INFO: Update cip-kernel-sec
2024-07-26 05:48:42,393:INFO: Checking CVEs ...
2024-07-26 05:49:19,536:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-arm64
```

test pattern 4

```
build@3d4795c39605:~/work$ cp web/nvd_cve_db.db.20240719 build/downloads/CVE/nvd_cve_db.db 
build@3d4795c39605:~/work$ cve_check.py --image emlinux-image-base --output-format text,json 
2024-07-26 05:49:44,496:INFO: Update NVD CVE database
2024-07-26 05:49:47,136:INFO: Update last modified date
2024-07-26 05:49:48,016:INFO: Update debian CVE database
2024-07-26 05:49:48,016:INFO: Last database update is in 1day so skip Debian CVE database update
2024-07-26 05:49:48,016:INFO: Update cip-kernel-sec
2024-07-26 05:49:48,667:INFO: Checking CVEs ...
2024-07-26 05:50:25,641:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-arm64
```
### Update CVE database only

```
build@5abcfbd7ac81:~/work$ cve_check.py \
--image emlinux-image-base \
--output-format text,json \
--cve-db-predownload \
--update-cve-databese-only
2024-07-24 01:20:06,942:INFO: predownload file is old, download it again.
2024-07-24 01:20:06,942:INFO: Download CVE database file from http://127.0.0.1:8000/nvd_cve_db.db.
2024-07-24 01:20:07,146:INFO: Download CVE database file was succeeded.
2024-07-24 01:20:07,845:INFO: Update NVD CVE database
2024-07-24 01:20:11,465:INFO: Update last modified date
2024-07-24 01:20:11,800:INFO: Finish CVE database update.
```
