### PR TITLE
linux-base/linux-k510: Add CVE-2020-0347 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -41,6 +41,7 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2022-36397: This is false positive because it is Intel QAT driver issue.
 # CVE-2021-39801: This is false positive because it is Android kernel issue.
 # CVE-2023-20928: Vulnerable code not present.
+# CVE-2020-0347: Due to the limited information, it is unclear whether this issue is specific to Android or also related to the mainline.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
@@ -53,5 +54,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2023-6915 CVE-2023-1611 CVE-2024-26594 \
     CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 \
     CVE-2021-3492 CVE-2021-39802 CVE-2022-36397 \
-    CVE-2021-39801 CVE-2023-20928 \
+    CVE-2021-39801 CVE-2023-20928 CVE-2020-0347 \
 "

--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -49,6 +49,7 @@ do_shared_workdir_prepend () {
 # CVE-2021-39802: This is false positive because it is Android kernel issue.
 # CVE-2022-36397: This is false positive because it is Intel QAT driver issue.
 # CVE-2021-39801: This is false positive because it is Android kernel issue.
+# CVE-2020-0347: Due to the limited information, it is unclear whether this issue is specific to Android or also related to the mainline.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-43057 CVE-2015-8955 CVE-2020-8834 \
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
@@ -56,5 +57,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-1999-0524 CVE-1999-0656 CVE-2006-2932 \
     CVE-2023-1476 CVE-2021-0399 CVE-2021-1076 \
     CVE-2021-29256 CVE-2021-3492 CVE-2021-39802 \
-    CVE-2022-36397 CVE-2021-39801 \
+    CVE-2022-36397 CVE-2021-39801 CVE-2020-0347 \
 "


### PR DESCRIPTION
# Purpose of pull request

Add CVE-2020-0347 because due to the limited information, it is unclear whether this issue is specific to Android or also related to the mainline.


# Test

Run cve-check for linux-base and linux-k510.

## Test result

### linux-base

Before

```
┌──build@d311c88ad270:~/work/emlinux/latest-dev/build
└─$ grep -A1 "CVE: CVE-2020-0347" tmp-glibc/deploy/cve/linux-base 
CVE: CVE-2020-0347
CVE STATUS: Unpatched
```

With this PR

```
┌──build@d311c88ad270:~/work/emlinux/latest-dev/build
└─$ grep -A1 "CVE: CVE-2020-0347" tmp-glibc/deploy/cve/linux-base 
CVE: CVE-2020-0347
CVE STATUS: Patched
```

### linux-k510

Before

```
┌──build@d311c88ad270:~/work/emlinux/latest-dev/build
└─$ grep -A1 "CVE: CVE-2020-0347"  tmp-glibc/deploy/cve/linux-k510 
CVE: CVE-2020-0347
CVE STATUS: Unpatched
```

With this PR

```
┌──build@d311c88ad270:~/work/emlinux/latest-dev/build
└─$ grep -A1 "CVE: CVE-2020-0347"  tmp-glibc/deploy/cve/linux-k510 
CVE: CVE-2020-0347
CVE STATUS: Patched
```
