### PR TITLE
linux-base/linux-k510: Add CVE-2024-35948 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -42,6 +42,7 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2021-39801: This is false positive because it is Android kernel issue.
 # CVE-2023-20928: Vulnerable code not present.
 # CVE-2020-0347: Due to the limited information, it is unclear whether this issue is specific to Android or also related to the mainline.
+# CVE-2024-35948: This issue was introduced in 6.7-rc1. 4.19.y is not affected.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
@@ -55,4 +56,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 \
     CVE-2021-3492 CVE-2021-39802 CVE-2022-36397 \
     CVE-2021-39801 CVE-2023-20928 CVE-2020-0347 \
+    CVE-2024-35948 \
 "

--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -50,6 +50,7 @@ do_shared_workdir_prepend () {
 # CVE-2022-36397: This is false positive because it is Intel QAT driver issue.
 # CVE-2021-39801: This is false positive because it is Android kernel issue.
 # CVE-2020-0347: Due to the limited information, it is unclear whether this issue is specific to Android or also related to the mainline.
+# CVE-2024-35948: This issue was introduced in 6.7-rc1. 5.10.y is not affected.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-43057 CVE-2015-8955 CVE-2020-8834 \
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
@@ -58,4 +59,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2023-1476 CVE-2021-0399 CVE-2021-1076 \
     CVE-2021-29256 CVE-2021-3492 CVE-2021-39802 \
     CVE-2022-36397 CVE-2021-39801 CVE-2020-0347 \
+    CVE-2024-35948 \
 "


### PR DESCRIPTION
# Purpose of pull request
Add CVE-2024-35948 to CVE_CHECK_WHITELIST which don't affect 4.19.y.
- [CVE-2024-35948](https://nvd.nist.gov/vuln/detail/CVE-2024-35948)

# Test
## linux-base
Before
```
build$ grep -A1 "CVE: CVE-2024-35948" tmp-glibc/deploy/cve/linux-base
CVE: CVE-2024-35948
CVE STATUS: Unpatched
```

With this PR
```
build$ grep -A1 "CVE: CVE-2024-35948" tmp-glibc/deploy/cve/linux-base
CVE: CVE-2024-35948
CVE STATUS: Patched
```

## linux-k510
Before
```
build$ grep -A1 "CVE: CVE-2024-35948" tmp-glibc/deploy/cve/linux-k510 
CVE: CVE-2024-35948
CVE STATUS: Unpatched
```

With this PR
```
build$ grep -A1 "CVE: CVE-2024-35948" tmp-glibc/deploy/cve/linux-k510 
CVE: CVE-2024-35948
CVE STATUS: Patched
```
