### PR TITLE
Update kernel to v5.10.223-cip51

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "d51eece9d08b331aac5a1d4e1410f6b345b1e04b"
+LINUX_GIT_SRCREV ?= "53be161810164d318caa3cfe563e7054f161f1f4"
 LINUX_CVE_VERSION ??= "5.10.214"
-LINUX_CIP_VERSION ?= "v5.10.221-cip50"
+LINUX_CIP_VERSION ?= "v5.10.223-cip51"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.223-cip51

This pull request update the kernel to the following cip versions:
v5.10.223-cip51 with hash tag 53be161810164d318caa3cfe563e7054f161f1f4
