### PR TITLE
Update kernel to v6.1.102-cip26

### DIFF
--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.101-cip25"
-PV = "6.1.101-cip25"
+LINUX_CIP_VERSION = "v6.1.102-cip26"
+PV = "6.1.102-cip26"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip;destsuffix=${P};protocol=https \
 "
@@ -26,6 +26,6 @@ SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
-SRCREV = "bd5674d39200556fdf00d5443ce363b3a134bf2b"
+SRCREV = "6787d7f96566701d56992eebbea7487ffae55daa"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.102-cip26

This pull request update the kernel to the following cip versions:
v6.1.102-cip26 with hash tag 6787d7f96566701d56992eebbea7487ffae55daa
