### PR TITLE
Update kernel to v4.19.320-cip112

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "9adf72a2f9807d3ca20128711c0610328a7bae28"
+LINUX_GIT_SRCREV ?= "72fd755c494bf69e165c988b15e91295569c7938"
 LINUX_CVE_VERSION ??= "4.19.312"
-LINUX_CIP_VERSION ??= "v4.19.317-cip111"
+LINUX_CIP_VERSION ??= "v4.19.320-cip112"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.320-cip112

This pull request update the kernel to the following cip versions:
v4.19.320-cip112 with hash tag 72fd755c494bf69e165c988b15e91295569c7938
