### PR TITLE
distro: Add netbase package to resolve hostname localhost

### DIFF
--- a/conf/distro/emlinux-common.inc
+++ b/conf/distro/emlinux-common.inc
@@ -29,6 +29,8 @@ IMAGER_INSTALL:wic = "parted \
   tar \
   fdisk"
 
+IMAGE_PREINSTALL:append = " netbase"
+
 WKS_FILE ?= "${MACHINE}.wks"
 
 SDK_PREINSTALL += "bc"

--- a/recipes-core/emlinux-customization/emlinux-customization.bb
+++ b/recipes-core/emlinux-customization/emlinux-customization.bb
@@ -12,6 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 DESCRIPTION = "EMLinux 3.x specific customization"
 
+DEBIAN_DEPENDS = "netbase"
+
 inherit dpkg-raw
 
 SRC_URI = " \


### PR DESCRIPTION
# Purpose of pull request

Debian's netbase package creates /etc/hosts to resolve hostnames such as localhost. So, added netbase package to emlinux default install.

The emlinux-customization package writes EMLinux3 as hostname therefore add DEBIAN_DEPENDS variable to write data after netbase package is installed.

# Test
## How to test

1. Build emlinux-image-base
2. boot from created image then check /etc/hosts

## Test result

/etc/hosts has localhost entries.

```
root@EMLinux3:~# cat /etc/hosts
127.0.0.1       localhost
::1             localhost ip6-localhost ip6-loopback
ff02::1         ip6-allnodes
ff02::2         ip6-allrouters

127.0.0.1 EMLinux3
```



