### PR TITLE
Add multiple configuration files

### DIFF
--- a/conf/mc.conf
+++ b/conf/mc.conf
@@ -1,0 +1,6 @@
+BBMULTICONFIG = " \
+  qemu-arm64-bookworm \
+  qemu-arm-bookworm \
+  qemu-amd64-bookworm \
+  generic-x86-64-bookworm \
+"

--- a/conf/multiconfig/generic-x86-64-bookworm.conf
+++ b/conf/multiconfig/generic-x86-64-bookworm.conf
@@ -1,0 +1,2 @@
+MACHINE ?= "generic-x86-64"
+DISTRO ?= "emlinux-bookworm"

--- a/conf/multiconfig/qemu-amd64-bookworm.conf
+++ b/conf/multiconfig/qemu-amd64-bookworm.conf
@@ -1,0 +1,2 @@
+MACHINE ?= "qemu-amd64"
+DISTRO ?= "emlinux-bookworm"

--- a/conf/multiconfig/qemu-arm-bookworm.conf
+++ b/conf/multiconfig/qemu-arm-bookworm.conf
@@ -1,0 +1,2 @@
+MACHINE ?= "qemu-arm"
+DISTRO ?= "emlinux-bookworm"

--- a/conf/multiconfig/qemu-arm64-bookworm.conf
+++ b/conf/multiconfig/qemu-arm64-bookworm.conf
@@ -1,0 +1,2 @@
+MACHINE ?= "qemu-arm64"
+DISTRO ?= "emlinux-bookworm"

--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -39,13 +39,14 @@ source "${REPOS}/isar/isar-init-build-env" "${ENV_BUILDDIR}"
 ENV_TOPDIR=$(dirname $(pwd))
 
 if [ "${ENV_BUILD_SETUP}" = "true"  ]; then
-  cat <<EOF >"${ENV_TOPDIR}/${ENV_BUILDDIR}/conf/local.conf"
+  cat <<'EOF' >"${ENV_TOPDIR}/${ENV_BUILDDIR}/conf/local.conf"
 # EMLinux configuration
 
 ## ISAR Basic configuratons
 LCONF_VERSION = "6"
 CONF_VERSION = "1"
 ISAR_CROSS_COMPILE = "1"
+include ${LAYERDIR_emlinux}/conf/mc.conf
 
 ## EMLinux user configurations
 USERS += "root"


### PR DESCRIPTION

# Purpose of pull request

After commit ed2f8fda7c ("meta: Drop lazy and recursive unmounts") in the isar, /dev is being mounted after sbuild-chroot-* task.

```
miracle@3e1089e8ee19:/work2/image-weston-ci-bug/emlinux/build$ mount | grep emlinux-bookworm-arm64
tmpfs on
/work2/image-weston-ci-bug/emlinux/build/tmp/work/emlinux-bookworm-arm64/sbuild-chroot-host/1.0-r0/rootfs/dev type tmpfs (rw,nosuid,size=65536k,mode=755,inode64) tmpfs on
/work2/image-weston-ci-bug/emlinux/build/tmp/work/emlinux-bookworm-arm64/sbuild-chroot-target/1.0-r0/rootfs/dev type tmpfs (rw,nosuid,size=65536k,mode=755,inode64)
```

To solve this issue, we need to provide multiple configuration files such as mc.con and multiconfig/<MACHINE>-<DIST>.conf.


# Test
## How to test

1. Build sdk
2. Run mount command

## Result

before this commit, sbuild-chroot-* are being mounted.

```
build@03193fc00a34:~/work/test$ bitbake emlinux-image-base -c populate_sdk
Loading cache: 100% |                                                                                                                                                                 | ETA:  --:--:--
Loaded 0 entries from dependency cache.
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:01
Parsing of 88 .bb files complete (0 cached, 88 parsed). 183 targets, 1 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 16 Local 0 Mirrors 0 Missed 16 Current 0 (0% match, 0% complete)###############################################################################                 | ETA:  0:00:00
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 157 tasks of which 0 didn't need to be rerun and all succeeded.
build@03193fc00a34:~/work/test$ mount
overlay on / type overlay (rw,relatime,lowerdir=/var/lib/docker/overlay2/l/LYT3YSYNNJJMW2SFSIREJAWHXH:/var/lib/docker/overlay2/l/KHTNBKR3JF3AZVAT3LSUNWCWOU:/var/lib/docker/overlay2/l/NMMNBUXJW7CVHXOEFVAUURZSEA:/var/lib/docker/overlay2/l/PLFNQZNHT6YEAD4IX5MMNAUQ4V:/var/lib/docker/overlay2/l/TYDHEZFYTY7HBHC4ZEZCMITWCC:/var/lib/docker/overlay2/l/AY4BMOHZT7ZS5NIVLJBOZ642LF:/var/lib/docker/overlay2/l/TFXBTSCMAPVGHCE5KCVLLZ7B54:/var/lib/docker/overlay2/l/SZSCW4GM2OKE477PDIU7D3UNTK:/var/lib/docker/overlay2/l/A2J3MYIUY2RRQLG25QTGDGM33G:/var/lib/docker/overlay2/l/KXOE3CDR7QNIH6G5RVENXDTI6M:/var/lib/docker/overlay2/l/ZYDGMCZPYBHC72MEMZ54FUZLRL:/var/lib/docker/overlay2/l/2R3LJSFQC5HSHRAUHLGOKNOBQH:/var/lib/docker/overlay2/l/2YN2AUJA4OBLSCMTTY766D5MS7:/var/lib/docker/overlay2/l/BBCEIGSPCHYFN4ABBL4RMXL5SB:/var/lib/docker/overlay2/l/OSJ4PDHQBMHKZTMJYHMVGL6W6Q:/var/lib/docker/overlay2/l/EAK2DAFATEXI6GTOOPIHUPITRJ:/var/lib/docker/overlay2/l/YIA4RW7R4TPCXHSX7BRSUTPTPX:/var/lib/docker/overlay2/l/GMDKEXX6K4W4SJPQXAZMFRYFIV:/var/lib/docker/overlay2/l/3V5UIHSDTABA5RBMFLDUTNXEEL:/var/lib/docker/overlay2/l/BEOSD5NLXAB657DHVMFDOXVB6U:/var/lib/docker/overlay2/l/54CXR6JEICZ6CU2UQZHEKRN7AM:/var/lib/docker/overlay2/l/CNAHLIF2EFZ4VXLCUCEDJA7IKP:/var/lib/docker/overlay2/l/SIFMVNTLLZRASXHHD65E2SVGIQ,upperdir=/var/lib/docker/overlay2/4a8b61c0567f41da4e9008b941d6f8807be74ceefd8782ae9ff669ee69bbeccf/diff,workdir=/var/lib/docker/overlay2/4a8b61c0567f41da4e9008b941d6f8807be74ceefd8782ae9ff669ee69bbeccf/work,nouserxattr)                                                                           
tmpfs on /dev type tmpfs (rw,nosuid,size=65536k,mode=755,inode64)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
cgroup on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot)
mqueue on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=29,pgrp=0,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=14386)
binfmt_misc on /proc/sys/fs/binfmt_misc type binfmt_misc (rw,nosuid,nodev,noexec,relatime)
tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev,inode64)
/dev/nvme0n1p2 on /etc/resolv.conf type ext4 (rw,relatime)
/dev/nvme0n1p2 on /etc/hostname type ext4 (rw,relatime)
/dev/nvme0n1p2 on /etc/hosts type ext4 (rw,relatime)
/dev/md127 on /home/build/work type ext4 (rw,relatime,stripe=256)
devpts on /dev/console type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
tmpfs on /home/build/work/test/tmp/work/emlinux-bookworm-arm64/sbuild-chroot-host/1.0-r0/rootfs/dev type tmpfs (rw,nosuid,size=65536k,mode=755,inode64)
tmpfs on /home/build/work/test/tmp/work/emlinux-bookworm-arm64/sbuild-chroot-target/1.0-r0/rootfs/dev type tmpfs (rw,nosuid,size=65536k,mode=755,inode64)  
```

Applying this commit, sbuild-chroot-* are not mounted.

```
build@15f3bdd08b95:~/work/test$ bitbake emlinux-image-base -c populate_sdk ; mount
Loading cache: 100% |                                                                                                                                                                 | ETA:  --:--:--
Loaded 0 entries from dependency cache.
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:03
Parsing of 390 .bb files complete (0 cached, 390 parsed). 655 targets, 5 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 11 Local 0 Mirrors 0 Missed 11 Current 0 (0% match, 0% complete)###############################################################################                 | ETA:  0:00:00
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 97 tasks of which 0 didn't need to be rerun and all succeeded.
overlay on / type overlay (rw,relatime,lowerdir=/var/lib/docker/overlay2/l/QFGYOPIVNSTKYVSNHWYM3TELNJ:/var/lib/docker/overlay2/l/KHTNBKR3JF3AZVAT3LSUNWCWOU:/var/lib/docker/overlay2/l/NMMNBUXJW7CVHXOEFVAUURZSEA:/var/lib/docker/overlay2/l/PLFNQZNHT6YEAD4IX5MMNAUQ4V:/var/lib/docker/overlay2/l/TYDHEZFYTY7HBHC4ZEZCMITWCC:/var/lib/docker/overlay2/l/AY4BMOHZT7ZS5NIVLJBOZ642LF:/var/lib/docker/overlay2/l/TFXBTSCMAPVGHCE5KCVLLZ7B54:/var/lib/docker/overlay2/l/SZSCW4GM2OKE477PDIU7D3UNTK:/var/lib/docker/overlay2/l/A2J3MYIUY2RRQLG25QTGDGM33G:/var/lib/docker/overlay2/l/KXOE3CDR7QNIH6G5RVENXDTI6M:/var/lib/docker/overlay2/l/ZYDGMCZPYBHC72MEMZ54FUZLRL:/var/lib/docker/overlay2/l/2R3LJSFQC5HSHRAUHLGOKNOBQH:/var/lib/docker/overlay2/l/2YN2AUJA4OBLSCMTTY766D5MS7:/var/lib/docker/overlay2/l/BBCEIGSPCHYFN4ABBL4RMXL5SB:/var/lib/docker/overlay2/l/OSJ4PDHQBMHKZTMJYHMVGL6W6Q:/var/lib/docker/overlay2/l/EAK2DAFATEXI6GTOOPIHUPITRJ:/var/lib/docker/overlay2/l/YIA4RW7R4TPCXHSX7BRSUTPTPX:/var/lib/docker/overlay2/l/GMDKEXX6K4W4SJPQXAZMFRYFIV:/var/lib/docker/overlay2/l/3V5UIHSDTABA5RBMFLDUTNXEEL:/var/lib/docker/overlay2/l/BEOSD5NLXAB657DHVMFDOXVB6U:/var/lib/docker/overlay2/l/54CXR6JEICZ6CU2UQZHEKRN7AM:/var/lib/docker/overlay2/l/CNAHLIF2EFZ4VXLCUCEDJA7IKP:/var/lib/docker/overlay2/l/SIFMVNTLLZRASXHHD65E2SVGIQ,upperdir=/var/lib/docker/overlay2/67a82ad7a549c016cf5b8aeec5f0b944613fb4669a7e915ff45df6bfd51bdb20/diff,workdir=/var/lib/docker/overlay2/67a82ad7a549c016cf5b8aeec5f0b944613fb4669a7e915ff45df6bfd51bdb20/work,nouserxattr)
tmpfs on /dev type tmpfs (rw,nosuid,size=65536k,mode=755,inode64)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
cgroup on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot)
mqueue on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=29,pgrp=0,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=14386)
binfmt_misc on /proc/sys/fs/binfmt_misc type binfmt_misc (rw,nosuid,nodev,noexec,relatime)
tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev,inode64)
/dev/nvme0n1p2 on /etc/resolv.conf type ext4 (rw,relatime)
/dev/nvme0n1p2 on /etc/hostname type ext4 (rw,relatime)
/dev/nvme0n1p2 on /etc/hosts type ext4 (rw,relatime)
/dev/md127 on /home/build/work type ext4 (rw,relatime,stripe=256)
devpts on /dev/console type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
```


