### PR TITLE
conf: Add multiple configurations setting for RPI 3b and 4b.

### DIFF
--- a/conf/mc.conf
+++ b/conf/mc.conf
@@ -3,4 +3,6 @@ BBMULTICONFIG = " \
   qemu-arm-bookworm \
   qemu-amd64-bookworm \
   generic-x86-64-bookworm \
+  raspberrypi3bplus-64-bookworm \
+  raspberrypi4b-64-bookworm \
 "

--- a/conf/multiconfig/raspberrypi3bplus-64-bookworm.conf
+++ b/conf/multiconfig/raspberrypi3bplus-64-bookworm.conf
@@ -1,0 +1,2 @@
+MACHINE ?= "raspberrypi3bplus-64"
+DISTRO ?= "emlinux-bookworm"

--- a/conf/multiconfig/raspberrypi4b-64-bookworm.conf
+++ b/conf/multiconfig/raspberrypi4b-64-bookworm.conf
@@ -1,0 +1,2 @@
+MACHINE ?= "raspberrypi4b-64"
+DISTRO ?= "emlinux-bookworm"


### PR DESCRIPTION
# Purpose of pull request

The raspberrypi3bplus-64 and raspberrypi4b-64 machines need multiple configurations setting as well.

Related PR: https://github.com/miraclelinux/meta-emlinux/pull/380

# Test
## How to test

1. Build SDK
2. Check mounted filesystems


## Test result

sbuild-chroot-* directories are not mounted after building SDK.

### raspberrypi3bplus-64

```
build@233038b634b0:~/work/test$ bitbake emlinux-image-base -c populate_sdk ; mount
Loading cache: 100% |                                                                                                                                                                 | ETA:  --:--:--
Loaded 0 entries from dependency cache.
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:05
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 15 Local 0 Mirrors 0 Missed 15 Current 0 (0% match, 0% complete)###############################################################################                 | ETA:  0:00:00
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 147 tasks of which 0 didn't need to be rerun and all succeeded.
overlay on / type overlay (rw,relatime,lowerdir=/var/lib/docker/overlay2/l/RRPGFJFRVANW5P4CCQEBJKRSD5:/var/lib/docker/overlay2/l/KHTNBKR3JF3AZVAT3LSUNWCWOU:/var/lib/docker/overlay2/l/NMMNBUXJW7CVHXOEFVAUURZSEA:/var/lib/docker/overlay2/l/PLFNQZNHT6YEAD4IX5MMNAUQ4V:/var/lib/docker/overlay2/l/TYDHEZFYTY7HBHC4ZEZCMITWCC:/var/lib/docker/overlay2/l/AY4BMOHZT7ZS5NIVLJBOZ642LF:/var/lib/docker/overlay2/l/TFXBTSCMAPVGHCE5KCVLLZ7B54:/var/lib/docker/overlay2/l/SZSCW4GM2OKE477PDIU7D3UNTK:/var/lib/docker/overlay2/l/A2J3MYIUY2RRQLG25QTGDGM33G:/var/lib/docker/overlay2/l/KXOE3CDR7QNIH6G5RVENXDTI6M:/var/lib/docker/overlay2/l/ZYDGMCZPYBHC72MEMZ54FUZLRL:/var/lib/docker/overlay2/l/2R3LJSFQC5HSHRAUHLGOKNOBQH:/var/lib/docker/overlay2/l/2YN2AUJA4OBLSCMTTY766D5MS7:/var/lib/docker/overlay2/l/BBCEIGSPCHYFN4ABBL4RMXL5SB:/var/lib/docker/overlay2/l/OSJ4PDHQBMHKZTMJYHMVGL6W6Q:/var/lib/docker/overlay2/l/EAK2DAFATEXI6GTOOPIHUPITRJ:/var/lib/docker/overlay2/l/YIA4RW7R4TPCXHSX7BRSUTPTPX:/var/lib/docker/overlay2/l/GMDKEXX6K4W4SJPQXAZMFRYFIV:/var/lib/docker/overlay2/l/3V5UIHSDTABA5RBMFLDUTNXEEL:/var/lib/docker/overlay2/l/BEOSD5NLXAB657DHVMFDOXVB6U:/var/lib/docker/overlay2/l/54CXR6JEICZ6CU2UQZHEKRN7AM:/var/lib/docker/overlay2/l/CNAHLIF2EFZ4VXLCUCEDJA7IKP:/var/lib/docker/overlay2/l/SIFMVNTLLZRASXHHD65E2SVGIQ,upperdir=/var/lib/docker/overlay2/c7b96bf398db843ee5bf512e3c21b846f9e88f4eacb9ca0d211a06b88b1a2938/diff,workdir=/var/lib/docker/overlay2/c7b96bf398db843ee5bf512e3c21b846f9e88f4eacb9ca0d211a06b88b1a2938/work,nouserxattr)
tmpfs on /dev type tmpfs (rw,nosuid,size=65536k,mode=755,inode64)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
cgroup on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot)
mqueue on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=29,pgrp=0,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=14386)
binfmt_misc on /proc/sys/fs/binfmt_misc type binfmt_misc (rw,nosuid,nodev,noexec,relatime)
tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev,inode64)
/dev/nvme0n1p2 on /etc/resolv.conf type ext4 (rw,relatime)
/dev/nvme0n1p2 on /etc/hostname type ext4 (rw,relatime)
/dev/nvme0n1p2 on /etc/hosts type ext4 (rw,relatime)
/dev/md127 on /home/build/work type ext4 (rw,relatime,stripe=256)
devpts on /dev/console type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
```

### raspberrypi4b-64

```
build@3477db23b2c7:~/work/test$ bitbake emlinux-image-base -c populate_sdk ; mount
Loading cache: 100% |                                                                                                                                                                 | ETA:  --:--:--
Loaded 0 entries from dependency cache.
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:05
Parsing of 546 .bb files complete (0 cached, 546 parsed). 1148 targets, 0 skipped, 0 masked, 0 errors.      
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 15 Local 0 Mirrors 0 Missed 15 Current 0 (0% match, 0% complete)###############################################################################                 | ETA:  0:00:00
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 147 tasks of which 0 didn't need to be rerun and all succeeded.
overlay on / type overlay (rw,relatime,lowerdir=/var/lib/docker/overlay2/l/Q4Q5NG7RAUNM7Y7AKQPQOF554H:/var/lib/docker/overlay2/l/KHTNBKR3JF3AZVAT3LSUNWCWOU:/var/lib/docker/overlay2/l/NMMNBUXJW7CVHXOEFVAUURZSEA:/var/lib/docker/overlay2/l/PLFNQZNHT6YEAD4IX5MMNAUQ4V:/var/lib/docker/overlay2/l/TYDHEZFYTY7HBHC4ZEZCMITWCC:/var/lib/docker/overlay2/l/AY4BMOHZT7ZS5NIVLJBOZ642LF:/var/lib/docker/overlay2/l/TFXBTSCMAPVGHCE5KCVLLZ7B54:/var/lib/docker/overlay2/l/SZSCW4GM2OKE477PDIU7D3UNTK:/var/lib/docker/overlay2/l/A2J3MYIUY2RRQLG25QTGDGM33G:/var/lib/docker/overlay2/l/KXOE3CDR7QNIH6G5RVENXDTI6M:/var/lib/docker/overlay2/l/ZYDGMCZPYBHC72MEMZ54FUZLRL:/var/lib/docker/overlay2/l/2R3LJSFQC5HSHRAUHLGOKNOBQH:/var/lib/docker/overlay2/l/2YN2AUJA4OBLSCMTTY766D5MS7:/var/lib/docker/overlay2/l/BBCEIGSPCHYFN4ABBL4RMXL5SB:/var/lib/docker/overlay2/l/OSJ4PDHQBMHKZTMJYHMVGL6W6Q:/var/lib/docker/overlay2/l/EAK2DAFATEXI6GTOOPIHUPITRJ:/var/lib/docker/overlay2/l/YIA4RW7R4TPCXHSX7BRSUTPTPX:/var/lib/docker/overlay2/l/GMDKEXX6K4W4SJPQXAZMFRYFIV:/var/lib/docker/overlay2/l/3V5UIHSDTABA5RBMFLDUTNXEEL:/var/lib/docker/overlay2/l/BEOSD5NLXAB657DHVMFDOXVB6U:/var/lib/docker/overlay2/l/54CXR6JEICZ6CU2UQZHEKRN7AM:/var/lib/docker/overlay2/l/CNAHLIF2EFZ4VXLCUCEDJA7IKP:/var/lib/docker/overlay2/l/SIFMVNTLLZRASXHHD65E2SVGIQ,upperdir=/var/lib/docker/overlay2/f2281c1246004e80a999b5e63b53f1f4c8e98077b69fbc4d0cf2321bb251fe81/diff,workdir=/var/lib/docker/overlay2/f2281c1246004e80a999b5e63b53f1f4c8e98077b69fbc4d0cf2321bb251fe81/work,nouserxattr)
tmpfs on /dev type tmpfs (rw,nosuid,size=65536k,mode=755,inode64)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
cgroup on /sys/fs/cgroup type cgroup2 (rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot)
mqueue on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=29,pgrp=0,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=14386)
binfmt_misc on /proc/sys/fs/binfmt_misc type binfmt_misc (rw,nosuid,nodev,noexec,relatime)
tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev,inode64)
/dev/nvme0n1p2 on /etc/resolv.conf type ext4 (rw,relatime)
/dev/nvme0n1p2 on /etc/hostname type ext4 (rw,relatime)
/dev/nvme0n1p2 on /etc/hosts type ext4 (rw,relatime)
/dev/md127 on /home/build/work type ext4 (rw,relatime,stripe=256)
devpts on /dev/console type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
```


