### PR TITLE
Update kernel to v5.10.224-cip52

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "53be161810164d318caa3cfe563e7054f161f1f4"
+LINUX_GIT_SRCREV ?= "a73978e16f87d704893e4b3a637be257420d43f3"
 LINUX_CVE_VERSION ??= "5.10.214"
-LINUX_CIP_VERSION ?= "v5.10.223-cip51"
+LINUX_CIP_VERSION ?= "v5.10.224-cip52"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.224-cip52

This pull request update the kernel to the following cip versions:
v5.10.224-cip52 with hash tag a73978e16f87d704893e4b3a637be257420d43f3
