### PR TITLE
Update kernel to v6.1.107-cip28

### DIFF
--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.102-cip26"
-PV = "6.1.102-cip26"
+LINUX_CIP_VERSION = "v6.1.107-cip28"
+PV = "6.1.107-cip28"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip;destsuffix=${P};protocol=https \
 "
@@ -26,6 +26,6 @@ SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
-SRCREV = "6787d7f96566701d56992eebbea7487ffae55daa"
+SRCREV = "d5cc54849a0b793a2413dcd5f31b45d9907066ab"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.107-cip28

This pull request update the kernel to the following cip versions:
v6.1.107-cip28 with hash tag d5cc54849a0b793a2413dcd5f31b45d9907066ab
