### PR TITLE
cve-update-nvd2-native: Backport patches from poky/dunfell

### DIFF
--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -393,6 +393,10 @@ def update_db(conn, elt):
                 [cveId, cveDesc, cvssv2, cvssv3, date, accessVector]).close()
 
     try:
+        # Remove any pre-existing CVE configuration. Even for partial database
+        # update, those will be repopulated. This ensures that old
+        # configuration is not kept for an updated CVE.
+        conn.execute("delete from PRODUCTS where ID = ?", [cveId]).close()
         for config in elt['cve']['configurations']:
             # This is suboptimal as it doesn't handle AND/OR and negate, but is better than nothing
             for node in config["nodes"]:

--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -360,6 +360,10 @@ def update_db(conn, elt):
     accessVector = None
     cveId = elt['cve']['id']
     if elt['cve']['vulnStatus'] ==  "Rejected":
+        c = conn.cursor()
+        c.execute("delete from PRODUCTS where ID = ?;", [cveId])
+        c.execute("delete from NVD where ID = ?;", [cveId])
+        c.close()
         return
     cveDesc = ""
     for desc in elt['cve']['descriptions']:


### PR DESCRIPTION
# Purpose of pull request

The poky dunfell branch contains following 2 bug fix commits.  We need these patches to continuous update CVE database correctly.

- [cve-update-nvd2-native: Remove rejected CVE from database](https://git.yoctoproject.org/poky/commit/meta/recipes-core/meta/cve-update-nvd2-native.bb?h=dunfell&id=e2ed3bde51e14bc36b7ce424e384d26b6cad615a)
- [cve-update-nvd2-native: Fix CVE configuration update](https://git.yoctoproject.org/poky/commit/meta/recipes-core/meta/cve-update-nvd2-native.bb?h=dunfell&id=80319227065c066c4984d719c6d7249d3cb42037)

The commit "cve-update-nvd2-native: Remove rejected CVE from database" removes CVE from sqlite3 database if existing CVE is rejected
The commit "cve-update-nvd2-native: Fix CVE configuration update" removes CVE from sqlite3 database, then insert CVE data.  This patch is able to update affected version(s) correctly. 

