### PR TITLE
cve-check: bug fix patch from poky/dunfell

### DIFF
--- a/scripts/lib/python/cve/nvd_cve.py
+++ b/scripts/lib/python/cve/nvd_cve.py
@@ -126,6 +126,10 @@ def update_db(conn, elt):
                 [cveId, vulnStatus, cveDesc, cvssv2, cvssv3, date, accessVector, vectorString]).close()
 
     try:
+        # Remove any pre-existing CVE configuration. Even for partial database
+        # update, those will be repopulated. This ensures that old
+        # configuration is not kept for an updated CVE.
+        conn.execute("delete from PRODUCTS where ID = ?", [cveId]).close()
         for config in elt['cve']['configurations']:
             # This is suboptimal as it doesn't handle AND/OR and negate, but is better than nothing
             for node in config["nodes"]:


### PR DESCRIPTION


# Purpose of pull request

Backport  "cve-update-nvd2-native: Fix CVE configuration update" patch from poky/dunfell.

This patch is required to continuously update CVE database correctly.

From: poky/dunfell
Rev: 80319227065c066c4984d719c6d7249d3cb42037
Link:
https://git.yoctoproject.org/poky/commit/meta/recipes-core/meta/cve-update-nvd2-native.bb?h=dunfell&id=80319227065c066c4984d719c6d7249d3cb42037
