### PR TITLE
libxml2: Add patch to fix CVE-2024-25062

### DIFF
--- a/recipes-debian/libxml/files/CVE-2024-25062.patch
+++ b/recipes-debian/libxml/files/CVE-2024-25062.patch
@@ -1,0 +1,27 @@
+From 848f24dcc3589b9d22c390c298aec120b6cfc357 Mon Sep 17 00:00:00 2001
+From: Nick Wellnhofer <wellnhofer@aevum.de>
+Date: Sat, 14 Oct 2023 22:45:54 +0200
+Subject: [PATCH] xmlreader: Don't expand XIncludes when backtracking
+
+[ Upstream commit 2b0aac140d739905c7848a42efc60bfe783a39b7 ]
+
+Fixes a use-after-free if XML Reader if used with DTD validation and
+XInclude expansion.
+
+Fixes #604.
+---
+ xmlreader.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/xmlreader.c b/xmlreader.c
+index f285790..8851042 100644
+--- a/xmlreader.c
++++ b/xmlreader.c
+@@ -1511,6 +1511,7 @@ node_found:
+      * Handle XInclude if asked for
+      */
+     if ((reader->xinclude) && (reader->node != NULL) &&
++	(reader->state != XML_TEXTREADER_BACKTRACK) &&
+ 	(reader->node->type == XML_ELEMENT_NODE) &&
+ 	(reader->node->ns != NULL) &&
+ 	((xmlStrEqual(reader->node->ns->href, XINCLUDE_NS)) ||

--- a/recipes-debian/libxml/libxml2_debian.bbappend
+++ b/recipes-debian/libxml/libxml2_debian.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += " \
+    file://CVE-2024-25062.patch \
+"


### PR DESCRIPTION
# Purpose of pull request

This PR adds a patch to fix [CVE-2024-25062](https://nvd.nist.gov/vuln/detail/CVE-2024-25062). 
Debian and Freexian appear to ignore the CVE, saying that it is a minor issue ([Debian Security Tracker](https://deb.freexian.com/extended-lts/tracker/CVE-2024-25062)). 

The patch is backported from [xmlreader: Don't expand XIncludes when backtracking ](https://gitlab.gnome.org/GNOME/libxml2/-/commit/2b0aac140d739905c7848a42efc60bfe783a39b7).

## Test
Run cve_check 

### Test results
```
>> grep -A1 "CVE: CVE-2024-25062" tmp-glibc/deploy/cve/libxml2
CVE: CVE-2024-25062
CVE STATUS: Patched
```
