### PR TITLE
linux: linux-base: Add CVEs to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -43,6 +43,8 @@ CVE_VERSION = "${LINUX_CVE_VERSION}"
 # CVE-2023-20928: Vulnerable code not present.
 # CVE-2020-0347: Due to the limited information, it is unclear whether this issue is specific to Android or also related to the mainline.
 # CVE-2024-35948: This issue was introduced in 6.7-rc1. 4.19.y is not affected.
+# CVE-2022-48789: This is false positive because 4.19.y is not affected.
+# CVE-2024-21823: This is false positive because 4.19.y is not affected.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-26934 CVE-2021-43057 CVE-2022-29582 \
     CVE-2021-42327 CVE-2021-45402 CVE-2022-0168 \
@@ -56,5 +58,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2021-0399 CVE-2021-1076 CVE-2021-29256 \
     CVE-2021-3492 CVE-2021-39802 CVE-2022-36397 \
     CVE-2021-39801 CVE-2023-20928 CVE-2020-0347 \
-    CVE-2024-35948 \
+    CVE-2024-35948 CVE-2022-48789 CVE-2024-21823 \
 "


### PR DESCRIPTION
Add CVEs to CVE_CHECK_WHITELIST which don't affect 4.19.y.