### PR TITLE
Update kernel to v4.19.322-cip113

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "72fd755c494bf69e165c988b15e91295569c7938"
+LINUX_GIT_SRCREV ?= "95b722b3ebb739e01ce712254a92789f843917e3"
 LINUX_CVE_VERSION ??= "4.19.312"
-LINUX_CIP_VERSION ??= "v4.19.320-cip112"
+LINUX_CIP_VERSION ??= "v4.19.322-cip113"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.322-cip113

This pull request update the kernel to the following cip versions:
v4.19.322-cip113 with hash tag 95b722b3ebb739e01ce712254a92789f843917e3
