### PR TITLE
bmap-tools: change fetch URL

### DIFF
--- a/recipes-support/bmap-tools/bmap-tools_3.5.bbappend
+++ b/recipes-support/bmap-tools/bmap-tools_3.5.bbappend
@@ -1,0 +1,1 @@
+SRC_URI = "git://github.com/yoctoproject/bmaptool;branch=main"


### PR DESCRIPTION
# Purpose of pull request

The original bmap-tools recipe refers to the intel repository on github. The branch name in this repository has been changed form "master" to "main" recently. So, bitbake cannot fetch it.

In addtion, the Intel repository is no longer supported.

Therefore, This PR changes the URL to the active repository maintained by Yocto Project.

# Test

## How to test the package
1. fetch bmap-tools by bitbake
2. check log.do_fetch

## Fetch by bitbake

Confirm that the following fetch command finish without error.

```shell
$ bitbake bmap-tools -c fetch
```

## check log.do_fetch

Make sure the new URL "git://github.com/yoctoproject/bmaptool;branch=main" is included.

```shell
$ grep github.com.yoctoproject.bmaptool tmp-glibc/work/*/bmap-tools/3.5+gitAUTOINC+db7087b883-r0/temp/log.do_fetch
```

# Test result

## Fetch by bitbake
Fetch succeeded.

```shell
$ bitbake bmap-tools -c fetch
Loading cache: 100% |#######################################################| Time: 0:00:00
Loaded 2394 entries from dependency cache.
Parsing recipes: 100% |#####################################################| Time: 0:00:00
Parsing of 1372 .bb files complete (1371 cached, 1 parsed). 2394 targets, 83 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "ek874"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.10"
TUNE_FEATURES        = "aarch64 cortexa53 crc"
TARGET_FPU           = ""
meta
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:8bc9a34e420f83b9cd43b7618add410ac0769827"
meta-debian-extended = "HEAD:617601d24518268fc6d6a4c2da80f74c3f89306f"
meta-emlinux         = "HEAD:4b3bfebbbb90ccbc921436e86ba45595e9b10b36"

Initialising tasks: 100% |##################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 1 tasks of which 0 didn't need to be rerun and all succeeded.
$ 
```

## check log.do_fetch

The new URL "git://github.com/yoctoproject/bmaptool;branch=main" was included.

```shell
$ grep github.com.yoctoproject.bmaptool tmp-glibc/work/aarch64-emlinux-linux/bmap-tools/3.5+gitAUTOINC+db7087b883-r0/temp/log.do_fetch
DEBUG: For url git://github.com/yoctoproject/bmaptool;branch=main returning http://downloads.yoctoproject.org/mirror/sources/git2_github.com.yoctoproject.bmaptool.tar.gz
(snip)
```
