### PR TITLE
Update kernel to v6.1.112-cip30-rt17

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_git.bb
+++ b/recipes-kernel/linux/linux-cip-rt_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.111-cip29-rt16"
-PV = "6.1.111-cip29-rt16"
+LINUX_CIP_VERSION = "v6.1.112-cip30-rt17"
+PV = "6.1.112-cip30-rt17"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip-rt;destsuffix=${P};protocol=https \
     file://preempt-rt.cfg \
@@ -23,6 +23,6 @@ SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
-SRCREV = "bfe585616d564b2154d198beba419055b1c82e89"
+SRCREV = "325f1b87774845b62b7e7207afc9cc237ef80495"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.112-cip30-rt17

This pull request update the kernel to the following cip versions:
v6.1.112-cip30-rt17 with hash tag 325f1b87774845b62b7e7207afc9cc237ef80495
