### PR TITLE
Update kernel to v5.10.229-cip54

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "d6d2e910ede61a28e3de9ccfd7e8bce9093b7c6d"
+LINUX_GIT_SRCREV ?= "051f31291baaa10873ff2e883094828f9069dbe5"
 LINUX_CVE_VERSION ??= "5.10.214"
-LINUX_CIP_VERSION ?= "v5.10.226-cip53"
+LINUX_CIP_VERSION ?= "v5.10.229-cip54"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.229-cip54

This pull request update the kernel to the following cip versions:
v5.10.229-cip54 with hash tag 051f31291baaa10873ff2e883094828f9069dbe5
