### PR TITLE
docker: Do not bind mount whole proc filesystem

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,6 @@ services:
       - ftp_proxy=$ftp_proxy
       - no_proxy=$no_proxy
     volumes:
-      - /proc:/proc:rw
       - /dev/shm:/dev/shm:rw
       - ../../../:/home/build/work:rw
     devices:
@@ -27,5 +26,5 @@ services:
     cap_add:
       - NET_ADMIN
     user: build
-    command: /bin/bash
+    command: /bin/sh -c "sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc && /bin/bash"
 


### PR DESCRIPTION
When bind mount host's proc filesystem, pid numbers are not expected in a docker container. To avoid this, enabling binfmt_misc before start shell.
If bind mount host's proc filesystem in a container, building busybox package will fail because  of pid in container and host is different.

Setup following busybox.bb file into custom layer.
```
inherit dpkg
SRC_URI = "apt://${PN}"
```

Then, build busybox failed.

```
| --------------------------------------------------------------------------------
| Finished at 2024-11-14T07:55:40Z
| Build needed 00:03:47, 173856k disk space
| E: Build failure (dpkg-buildpackage died)
| WARNING: exit code 2 from a shell command.
| DEBUG: Executing shell function schroot_delete_configs
| Removing /etc/schroot/isar-build-8e954c8e-8b98-4211-9ae8-d603a2a7b214-71816
| Removing /etc/schroot/chroot.d/isar-build-8e954c8e-8b98-4211-9ae8-d603a2a7b214-71816
| DEBUG: Shell function schroot_delete_configs finished
| DEBUG: Python function do_dpkg_build finished
ERROR: Task (/home/build/work/build/../repos/meta-custom/recipes-app/busyboox/busybox.bb:do_dpkg_build) failed with exit code '1'
NOTE: Tasks Summary: Attempted 32 tasks of which 31 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  /home/build/work/build/../repos/meta-custom/recipes-app/busyboox/busybox.bb:do_dpkg_build
Summary: There was 1 ERROR message, returning a non-zero exit code.
```

Applying this PR then build busybox succeeded.

```
build@4ba992921bb7:~/work/build$ bitbake busybox
Loading cache: 100% |                                                                                                                                                                 | ETA:  --:--:--
Loaded 0 entries from dependency cache.
Parsing recipes: 100% |################################################################################################################################################################| Time: 0:00:01
Parsing of 553 .bb files complete (0 cached, 553 parsed). 803 targets, 5 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 3 Local 0 Mirrors 0 Missed 3 Current 0 (0% match, 0% complete)#################################################################################                 | ETA:  0:00:00
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 34 tasks of which 0 didn't need to be rerun and all succeeded.
```

I tested following pairs to build image and sdk.

|ARCH|IMAGE|
|---|---|
|qemu-arm64|emlinux-image-base|
|qemu-arm64|emlinux-image-weston|
|raspberrypi3bplus-64|emlinux-image-base|
|raspberrypi3bplus-64|emlinux-image-weston|

