### PR TITLE
raspberrypi-bootfiles: Set DPKG_ARCH as a correct architecture

### DIFF
--- a/recipes-bsp/raspberrypi-bootfiles/raspberrypi-bootfiles.bb
+++ b/recipes-bsp/raspberrypi-bootfiles/raspberrypi-bootfiles.bb
@@ -26,6 +26,8 @@ SRC_URI[sha256sum] = "1e923f605b5be8c999dd4bdbe0b4e60d637a4d2dceff0c9a9fd3be3148
  
 UPSTREAM_FILE_UNPACK_DIR="${WORKDIR}/firmware-${RPI_FIRMWARE_VERSION}"
 
+DPKG_ARCH = "arm64"
+
 do_install() {
   cp -a ${UPSTREAM_FILE_UNPACK_DIR}/boot ${D}/
   install -d -m 0755 ${D}/usr/share/doc/${PN}/ 


### PR DESCRIPTION
Since the following change is applied to Isar, the dpkg-raw class sets DPKG_ARCH as all by default in order to pack architecture independent files.

https://github.com/ilbers/isar/commit/0816ae6e97d15712f6b8eb873311464263f5df59

This sets DPKG_ARCH properly to accommodate architecture dependent files.