### PR TITLE
cvecheck: Add KEV information support

### DIFF
--- a/scripts/cve_check.py
+++ b/scripts/cve_check.py
@@ -121,9 +121,6 @@ def fill_cve_info(cves, cve_products, db_file):
 
             # CVE id such as TEMP-0290435-0B57B5 not in NVD database.
             if data:
-                cves[pkgname][cveid]["PACKAGE NAME"] = cves[pkgname][cveid]["PACKAGE NAME"]
-                cves[pkgname][cveid]["BINARY PACKAGE NAME"] = cves[pkgname][cveid]["BINARY PACKAGE NAME"]
-                cves[pkgname][cveid]["VERSION"] = cves[pkgname][cveid]["VERSION"]
                 if data[0] == "Rejected":
                     cves[pkgname][cveid]["CVE STATUS"] = "Rejected"
 
@@ -135,9 +132,6 @@ def fill_cve_info(cves, cve_products, db_file):
                 cves[pkgname][cveid]["KEV"] = "Not Found"
                 cves[pkgname][cveid]["MORE INFORMATION"] = f"https://nvd.nist.gov/vuln/detail/{cveid}"
             else:
-                cves[pkgname][cveid]["PACKAGE NAME"] = cves[pkgname][cveid]["PACKAGE NAME"]
-                cves[pkgname][cveid]["BINARY PACKAGE NAME"] = cves[pkgname][cveid]["BINARY PACKAGE NAME"]
-                cves[pkgname][cveid]["VERSION"] = cves[pkgname][cveid]["VERSION"]
                 cves[pkgname][cveid]["CVE SUMMARY"] = ""
                 cves[pkgname][cveid]["CVSS v2 BASE SCORE"] = "0.0"
                 cves[pkgname][cveid]["CVSS v3 BASE SCORE"] = "0.0"

--- a/scripts/lib/python/cve/kev_cve.py
+++ b/scripts/lib/python/cve/kev_cve.py
@@ -1,0 +1,66 @@
+#
+# EMLinux CVE checker.
+# Download and store KEV data
+#
+# Copyright (c) Cybertrust Japan Co., Ltd.
+#
+# SPDX-License-Identifier: MIT
+#
+
+import urllib.request
+import gzip
+import json
+import os.path
+import time
+import logging
+
+logger = logging.getLogger("emlinux-cve-check")
+KEV_JSON_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+
+def fetch_json_data():
+    request = urllib.request.Request(KEV_JSON_URL)
+    for attempt in range(5):
+        try:
+            r = urllib.request.urlopen(request)
+
+            if (r.headers['content-encoding'] == 'gzip'):
+                buf = r.read()
+                raw_data = gzip.decompress(buf)
+            else:
+                raw_data = r.read().decode("utf-8")
+
+            r.close()
+        except Exception as e:
+            logger.debug(f"json file: received error ({e}), retrying")
+            time.sleep(6)
+            pass
+        else:
+            return json.loads(raw_data)
+    else:
+        # We failed at all attempts
+        return None
+
+def should_skip_fetch_json_file(json_file):
+    if json_file:
+        if os.path.exists(json_file):
+            if time.time() - os.path.getmtime(json_file) < 86400:
+                logger.info(f"Last database update is in 1day so skip Debian CVE database update")
+                return True
+
+    return False
+
+def fetch_kev_data(dl_dir):
+    logger.info("Update KEV database")
+    kev_json = f"{dl_dir}/known_exploited_vulnerabilities.json"
+    if should_skip_fetch_json_file(kev_json):
+        return kev_json
+
+    data = fetch_json_data()
+    if data is None:
+        return None
+
+    with open(kev_json, "w") as f:
+        json.dump(data, f)
+
+    return kev_json
+


### PR DESCRIPTION
# commit: [cvecheck: Remove unnecessary lines](https://github.com/miraclelinux/meta-emlinux/pull/407/commits/20de5382cfc09e84e02169e2c12928d99d87b6d4)

This commit removes unnecessary lines.

# commit: [cvecheck: Add KEV information support](https://github.com/miraclelinux/meta-emlinux/pull/407/commits/ee7cc5eac4f795c21f131bebdfbae047aaa3e726)
Import Known Exploited Vulnerabilities Catalog[1] data to cve-check result. Added "KEV" and "KNOWN RANSOMWARE CAMPAIGN USE" keys to support KEV information. The KEV key takes "None" when a CVE is not in the KEV otherwise "Found".
The "KNOWN RANSOMWARE CAMPAIGN USE" key takes "None" when a CVE is not in the KEV otherwise it takes "Unknown" or "Known". It this vulnerability is used in Ransomware Campaigns, it will be "Knwon" otherwise "Unknown". This key is shown when KEV value is "Found".

1: https://www.cisa.gov/known-exploited-vulnerabilities-catalog

# Text format result

## "KEV" is "Found" and "KNOWN RANSOMWARE CAMPAIGN USE" is Known

```
PACKAGE NAME: linux-cip
BINARY PACKAGE NAME: linux-image-cip
VERSION: 6.1.115-cip31+r0
CVE: CVE-2017-1000253
CVE STATUS: Patched
CVE SUMMARY: Linux distributions that have not patched their long-term kernels with https://git.kernel.org/linus/a87938b2e246b81b4fb713edb371a9fa3c5c3c86 (committed on April 14, 2015). This kernel v
ulnerability was fixed in April 2015 by commit a87938b2e246b81b4fb713edb371a9fa3c5c3c86 (backported to Linux 3.10.77 in May 2015), but it was not recognized as a security threat. With CONFIG_ARCH_BI
NFMT_ELF_RANDOMIZE_PIE enabled, and a normal top-down address allocation strategy, load_elf_binary() will attempt to map a PIE binary into an address range immediately below mm->mmap_base. Unfortuna
tely, load_elf_ binary() does not take account of the need to allocate sufficient space for the entire binary which means that, while the first PT_LOAD segment is mapped below mm->mmap_base, the sub
sequent PT_LOAD segment(s) end up being mapped above mm->mmap_base into the are that is supposed to be the "gap" between the stack and the binary.
CVSS v2 BASE SCORE: 7.2
CVSS v3 BASE SCORE: 7.8
VECTOR: LOCAL
VECTOR STRING: AV:L/AC:L/Au:N/C:C/I:C/A:C
KEV: Found
KNOWN RANSOMWARE CAMPAIGN USE: Known
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2017-1000253
```

## "KEV" is "Found"  and "KNOWN RANSOMWARE CAMPAIGN USE" is Unknown

```
PACKAGE NAME: bash
BINARY PACKAGE NAME: bash
VERSION: 5.2.15-2+b7
CVE: CVE-2014-6271
CVE STATUS: Patched
CVE SUMMARY: GNU Bash through 4.3 processes trailing strings after function definitions in the values of environment variables, which allows remote attackers to execute arbitrary code via a crafted 
environment, as demonstrated by vectors involving the ForceCommand feature in OpenSSH sshd, the mod_cgi and mod_cgid modules in the Apache HTTP Server, scripts executed by unspecified DHCP clients, 
and other situations in which setting the environment occurs across a privilege boundary from Bash execution, aka "ShellShock."  NOTE: the original fix for this issue was incorrect; CVE-2014-7169 ha
s been assigned to cover the vulnerability that is still present after the incorrect fix.
CVSS v2 BASE SCORE: 10.0
CVSS v3 BASE SCORE: 9.8
VECTOR: NETWORK
VECTOR STRING: AV:N/AC:L/Au:N/C:C/I:C/A:C
KEV: Found
KNOWN RANSOMWARE CAMPAIGN USE: Unknown
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2014-6271
```

## "KEV" is "Not Found"

```
PACKAGE NAME: bash
BINARY PACKAGE NAME: bash
VERSION: 5.2.15-2+b7
CVE: CVE-2014-6277
CVE STATUS: Patched
CVE SUMMARY: GNU Bash through 4.3 bash43-026 does not properly parse function definitions in the values of environment variables, which allows remote attackers to execute arbitrary code or cause a denial of service (uninitialized memory access, and untrusted-pointer read and write operations) via a crafted environment, as demonstrated by vectors involving the ForceCommand feature in OpenSSH sshd, the mod_cgi and mod_cgid modules in the Apache HTTP Server, scripts executed by unspecified DHCP clients, and other situations in which setting the environment occurs across a privilege boundary from Bash execution.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-6271 and CVE-2014-7169.
CVSS v2 BASE SCORE: 10.0
CVSS v3 BASE SCORE: 0.0
VECTOR: NETWORK
VECTOR STRING: AV:N/AC:L/Au:N/C:C/I:C/A:C
KEV: Not Found
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2014-6277

```

# JSON format result

## "KEV" is "Found" and "KNOWN RANSOMWARE CAMPAIGN USE" is Known

```
                {
                    "CVE": "CVE-2017-1000253",
                    "PACKAGE NAME": "linux-cip",
                    "BINARY PACKAGE NAME": [
                        "linux-image-cip"
                    ],
                    "VERSION": "6.1.115-cip31+r0",
                    "CVE STATUS": "Patched",
                    "CVE SUMMARY": "Linux distributions that have not patched their long-term kernels with https://git.kernel.org/linus/a87938b2e246b81b4fb713edb371a9fa3c5c3c86 (committed on April 1
4, 2015). This kernel vulnerability was fixed in April 2015 by commit a87938b2e246b81b4fb713edb371a9fa3c5c3c86 (backported to Linux 3.10.77 in May 2015), but it was not recognized as a security thre
at. With CONFIG_ARCH_BINFMT_ELF_RANDOMIZE_PIE enabled, and a normal top-down address allocation strategy, load_elf_binary() will attempt to map a PIE binary into an address range immediately below m
m->mmap_base. Unfortunately, load_elf_ binary() does not take account of the need to allocate sufficient space for the entire binary which means that, while the first PT_LOAD segment is mapped below
 mm->mmap_base, the subsequent PT_LOAD segment(s) end up being mapped above mm->mmap_base into the are that is supposed to be the \"gap\" between the stack and the binary.",
                    "CVSS v2 BASE SCORE": "7.2",
                    "CVSS v3 BASE SCORE": "7.8",
                    "VECTOR": "LOCAL",
                    "VECTOR STRING": "AV:L/AC:L/Au:N/C:C/I:C/A:C",
                    "KEV": "Found",
                    "MORE INFORMATION": "https://nvd.nist.gov/vuln/detail/CVE-2017-1000253",
                    "KNOWN RANSOMWARE CAMPAIGN USE": "Known"
                },
```

## "KEV" is "Found"  and "KNOWN RANSOMWARE CAMPAIGN USE" is Unknown

```
                {
                    "CVE": "CVE-2014-6271",
                    "PACKAGE NAME": "bash",
                    "BINARY PACKAGE NAME": [
                        "bash"
                    ],
                    "VERSION": "5.2.15-2+b7",
                    "CVE STATUS": "Patched",
                    "CVE SUMMARY": "GNU Bash through 4.3 processes trailing strings after function definitions in the values of environment variables, which allows remote attackers to execute arbitr
ary code via a crafted environment, as demonstrated by vectors involving the ForceCommand feature in OpenSSH sshd, the mod_cgi and mod_cgid modules in the Apache HTTP Server, scripts executed by uns
pecified DHCP clients, and other situations in which setting the environment occurs across a privilege boundary from Bash execution, aka \"ShellShock.\"  NOTE: the original fix for this issue was in
correct; CVE-2014-7169 has been assigned to cover the vulnerability that is still present after the incorrect fix.",
                    "CVSS v2 BASE SCORE": "10.0",
                    "CVSS v3 BASE SCORE": "9.8",
                    "VECTOR": "NETWORK",
                    "VECTOR STRING": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
                    "KEV": "Found",
                    "MORE INFORMATION": "https://nvd.nist.gov/vuln/detail/CVE-2014-6271",
                    "KNOWN RANSOMWARE CAMPAIGN USE": "Unknown"
                },
```

## "KEV" is "Not Found"

```
                {
                    "CVE": "CVE-2014-6277",
                    "PACKAGE NAME": "bash",
                    "BINARY PACKAGE NAME": [
                        "bash"
                    ],
                    "VERSION": "5.2.15-2+b7",
                    "CVE STATUS": "Patched",
                    "CVE SUMMARY": "GNU Bash through 4.3 bash43-026 does not properly parse function definitions in the values of environment variables, which allows remote attackers to execute arbitrary code or cause a denial of service (uninitialized memory access, and untrusted-pointer read and write operations) via a crafted environment, as demonstrated by vectors involving the ForceCommand feature in OpenSSH sshd, the mod_cgi and mod_cgid modules in the Apache HTTP Server, scripts executed by unspecified DHCP clients, and other situations in which setting the environment occurs across a privilege boundary from Bash execution.  NOTE: this vulnerability exists because of an incomplete fix for CVE-2014-6271 and CVE-2014-7169.",
                    "CVSS v2 BASE SCORE": "10.0",
                    "CVSS v3 BASE SCORE": "0.0",
                    "VECTOR": "NETWORK",
                    "VECTOR STRING": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
                    "KEV": "Not Found",
                    "MORE INFORMATION": "https://nvd.nist.gov/vuln/detail/CVE-2014-6277"
                },
```