### PR TITLE
Update kernel to v4.19.323-cip114

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -4,7 +4,8 @@ DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
 LINUX_GIT_SRCREV ?= "4bc566200edfd8e9dc784404bc3a51aa156677d5"
-LINUX_CVE_VERSION ??= "4.19.323"
+LINUX_CVE_VERSION ??= "4.19.323
+"
 LINUX_CIP_VERSION ??= "v4.19.323-cip114"
 #
 # If you want to use latest revision of the kernel, append the following line


### PR DESCRIPTION
Update kernel to v4.19.323-cip114

This pull request update the kernel to the following cip versions:
v4.19.323-cip114 with hash tag 4bc566200edfd8e9dc784404bc3a51aa156677d5
