### PR TITLE
Update kernel to v4.19.324-cip115

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "4bc566200edfd8e9dc784404bc3a51aa156677d5"
-LINUX_CVE_VERSION ??= "4.19.323"
-LINUX_CIP_VERSION ??= "v4.19.323-cip114"
+LINUX_GIT_SRCREV ?= "2ec3818a63f4fb8b0ca8ce3b40631133165c0b58"
+LINUX_CVE_VERSION ??= "4.19.324"
+LINUX_CIP_VERSION ??= "v4.19.324-cip115"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.324-cip115

This pull request update the kernel to the following cip versions:
v4.19.324-cip115 with hash tag 2ec3818a63f4fb8b0ca8ce3b40631133165c0b58
