### PR TITLE
conf: Use debootstrap as default rootfs bootstrap provider

### DIFF
--- a/conf/distro/emlinux-common.inc
+++ b/conf/distro/emlinux-common.inc
@@ -36,3 +36,7 @@ WKS_FILE ?= "${MACHINE}.wks"
 SDK_PREINSTALL += "bc"
 
 SDK_INSTALL += "linux-headers-${KERNEL_NAME}"
+
+# Use debootstrap as default rootfs bootstrap provider
+PREFERRED_PROVIDER_bootstrap-host ?= "isar-bootstrap-host"
+PREFERRED_PROVIDER_bootstrap-target ?= "isar-bootstrap-target"


### PR DESCRIPTION
# Purpose

The ISAR project has switched to mmdebstrap as the default bootstrap provider. However, since we need to investigate the impact of this change, we will add a configuration to continue using debootstrap as before.

As you can see default provider is isar-mmdebstrap-*.

```
$ bitbake emlinux-image-base -e | grep ^PREFERRED_PROVIDER_bootstrap
PREFERRED_PROVIDER_bootstrap-host="isar-mmdebstrap-host"
PREFERRED_PROVIDER_bootstrap-target="isar-mmdebstrap-target"
```

# Test

Use ISAR master branch (commit hash 87fbe0706a2b4947a9d06a51d660aeefea7dbaf1).

1. Check default provider
2. Build an image
3. Build an SDK

# Test result

Default provider is isar-bootstrap-*

```
build@a35530678740:~/work/build$ bitbake emlinux-image-base -e | grep ^PREFERRED_PROVIDER_bootstrap
PREFERRED_PROVIDER_bootstrap-host="isar-bootstrap-host"
PREFERRED_PROVIDER_bootstrap-target="isar-bootstrap-target"
```

Build an image is succeeded.

```
build@a35530678740:~/work/build$ bitbake emlinux-image-base
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Loaded 889 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 7 Local 0 Mirrors 0 Missed 7 Current 0 (0% match, 0% complete)#################################################################################                 | ETA:  0:00:00
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 63 tasks of which 0 didn't need to be rerun and all succeeded.
build@a35530678740:~/work/build$ 
```

Build an SDK is succeeded.

```
build@a35530678740:~/work/build$ bitbake emlinux-image-base -c populate_sdk
Loading cache: 100% |##################################################################################################################################################################| Time: 0:00:00
Loaded 889 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 4 Local 0 Mirrors 0 Missed 4 Current 7 (0% match, 63% complete)################################################################################                 | ETA:  0:00:00
Initialising tasks: 100% |#############################################################################################################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 97 tasks of which 58 didn't need to be rerun and all succeeded.
build@a35530678740:~/work/build$ 
```

