### PR TITLE
Update kernel to v6.1.119-cip33-rt18

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_git.bb
+++ b/recipes-kernel/linux/linux-cip-rt_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.112-cip30-rt17"
-PV = "6.1.112-cip30-rt17"
+LINUX_CIP_VERSION = "v6.1.119-cip33-rt18"
+PV = "6.1.119-cip33-rt18"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip-rt;destsuffix=${P};protocol=https \
     file://preempt-rt.cfg \
@@ -23,6 +23,6 @@ SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
-SRCREV = "325f1b87774845b62b7e7207afc9cc237ef80495"
+SRCREV = "9ea9b9b749591e135dd115da2123ccd1938d0c30"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.119-cip33-rt18

This pull request update the kernel to the following cip versions:
v6.1.119-cip33-rt18 with hash tag 9ea9b9b749591e135dd115da2123ccd1938d0c30
