### PR TITLE
Add kernel CVEs to whitelist 202501

### DIFF
--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -68,6 +68,13 @@ do_shared_workdir_prepend () {
 # CVE-2023-52511: Vulnerable code not present.
 # CVE-2024-26648: Vulnerable code not present.
 # CVE-2024-50003: Vulnerable code not present.
+# CVE-2023-39179: This is false positive because vulnerable code not present.
+# CVE-2023-52479: This is false positive because vulnerable code not present.
+# CVE-2023-20941: This is false positive because it is an Android kernel issue.
+# CVE-2023-39176: This is false positive because vulnerable code not present.
+# CVE-2023-39180: This is false positive because vulnerable code not present.
+# CVE-2023-47210: This is false positive because it is a Firmware issue.
+# CVE-2023-52508: This is false positive because vulnerable code not present.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-43057 CVE-2015-8955 CVE-2020-8834 \
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
@@ -82,4 +89,7 @@ CVE_CHECK_WHITELIST = "\
     CVE-2022-20158 CVE-2022-26047 CVE-2024-46705 \
     CVE-2024-50242 CVE-2024-50246 CVE-2022-48950 \
     CVE-2023-52511 CVE-2024-26648 CVE-2024-50003 \
+    CVE-2023-39179 CVE-2023-52479 CVE-2023-20941 \
+    CVE-2023-39176 CVE-2023-39180 CVE-2023-47210 \
+    CVE-2023-52508 \
 "


### PR DESCRIPTION
# Purpose of pull request

Add CVEs to CVE_CHECK_WHITELIST which there is no vulnerable code in 5.10.

- CVE-2023-39179
- CVE-2023-52479
- CVE-2023-20941
- CVE-2023-39176
- CVE-2023-39180
- CVE-2023-47210
- CVE-2023-52508

# Test
## How to test
- local.conf setting
  ```
  INHERIT += " cve-check debian-cve-check kernel-cve-check"
  ```
- Run cve-check command
  ```
  $ bitbake linux-k510 -c cve_check
  $ cp tmp-glibc/work/qemuarm64-emlinux-linux/linux-k510/5.10-r0/temp/cve.log cve-linux-k510_1620f3c73bbc.log
  ```
  `1620f3c73bbc` means git hash of meta-emlinux repository.
- Check cve.log 

## Test result
### Before applying the patch

linux-k510:
```shell
$ grep --color -A 1 -e CVE-2023-39179 -e CVE-2023-52479 -e CVE-2023-20941 -e CVE-2023-39176 -e CVE-2023-39180 -e CVE-2023-47210 -e CVE-2023-52508 cve-linux-k510_1620f3c73bbc.log | grep ^CVE
CVE: CVE-2023-20941
CVE STATUS: Unpatched
CVE: CVE-2023-39176
CVE STATUS: Unpatched
CVE: CVE-2023-39179
CVE STATUS: Unpatched
CVE: CVE-2023-39180
CVE STATUS: Unpatched
CVE: CVE-2023-47210
CVE STATUS: Patched
CVE: CVE-2023-52479
CVE STATUS: Unpatched
CVE: CVE-2023-52508
CVE STATUS: Unpatched
```

### After applying the patch

linux-k510:
```shell
$ grep --color -A 1 -e CVE-2023-39179 -e CVE-2023-52479 -e CVE-2023-20941 -e CVE-2023-39176 -e CVE-2023-39180 -e CVE-2023-47210 -e CVE-2023-52508 cve-linux-k510_c371550c7ddf.log | grep ^CVE
CVE: CVE-2023-20941
CVE STATUS: Patched
CVE: CVE-2023-39176
CVE STATUS: Patched
CVE: CVE-2023-39179
CVE STATUS: Patched
CVE: CVE-2023-39180
CVE STATUS: Patched
CVE: CVE-2023-47210
CVE STATUS: Patched
CVE: CVE-2023-52479
CVE STATUS: Patched
CVE: CVE-2023-52508
CVE STATUS: Patched
CVE: CVE-2023-52511
CVE STATUS: Patched
```
