### PR TITLE
Update kernel to v6.1.124-cip35

### DIFF
--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.119-cip33"
-PV = "6.1.119-cip33"
+LINUX_CIP_VERSION = "v6.1.124-cip35"
+PV = "6.1.124-cip35"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip;destsuffix=${P};protocol=https \
 "
@@ -26,6 +26,6 @@ SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
-SRCREV = "0c42523c715687c74002f687ae904143d259b7c6"
+SRCREV = "a95ad34cd9f7ac6b3c36e4aedd5e20317a7e1ecf"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.124-cip35

This pull request update the kernel to the following cip versions:
v6.1.124-cip35 with hash tag a95ad34cd9f7ac6b3c36e4aedd5e20317a7e1ecf
