### PR TITLE
Add new image emlinux-image-minimal

### DIFF
--- a/classes/emlinux-minimal.bbclass
+++ b/classes/emlinux-minimal.bbclass
@@ -1,0 +1,162 @@
+do_make_emlinux_minimal_rootfs[network] = "${TASK_USE_SUDO}"
+
+EMLINUX_IMAGE_MINIMAL_WORK_DIR="emlinux-work"
+EMLINUX_IMAGE_MINIMAL_SETUP_SCRIPTS_DIR="${EMLINUX_IMAGE_MINIMAL_WORK_DIR}/scripts/setup"
+EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR="${EMLINUX_IMAGE_MINIMAL_WORK_DIR}/busybox-tmp"
+EMLINUX_IMAGE_MINIMAL_BUSYBOX_PREPARE_SCRIPT="prepare-busybox.sh"
+EMLINUX_MINIMAL_IMAGE_BUSYBOX_TMP_PATH="${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/bin:${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/sbin:${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/usr/bin:${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/usr/sbin"
+
+def create_replace_script(d):
+    import yaml
+    import os
+
+    files = []
+    busybox_cmds = {}
+
+    workdir = d.getVar("WORKDIR")
+    for f in os.listdir(workdir):
+         if f.startswith("minimal-image-replace-") and f.endswith(".yml"):
+            files.append(f"{workdir}/{f}")
+
+    for f in files:
+        with open(f) as yml:
+            data = yaml.safe_load(yml)
+            busybox_cmds.update(data)
+
+    image_preinstall = d.getVar("IMAGE_PREINSTALL").strip().split()
+    image_install = d.getVar("IMAGE_INSTALL").strip().split()
+    
+    user_specified_install_pkgs = image_preinstall + image_install
+    pinned_pkgs = []
+
+    remove_candidate = d.getVar("EMLINUX_MINIMAL_IMAGE_REMOVE_PAKCAGES").strip().split()
+    remove_candidate_new = []
+
+    for pkg in remove_candidate:
+        if pkg in user_specified_install_pkgs:
+            bb.note(f"{pkg} is user specified install package. Do not remove")
+        else:
+            if not pkg in remove_candidate_new:
+                remove_candidate_new.append(pkg)
+
+    d.setVar("EMLINUX_MINIMAL_IMAGE_REMOVE_PAKCAGES", " ".join(remove_candidate_new))
+
+    replace_target = []
+    tmp_replace_targets = remove_candidate_new
+    for t in tmp_replace_targets:
+        if t in busybox_cmds:
+            replace_target.append(t)
+
+    tmp_install_dir = d.getVar("EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR")
+    script = f"{d.getVar('WORKDIR')}/{d.getVar('EMLINUX_IMAGE_MINIMAL_BUSYBOX_PREPARE_SCRIPT')}"
+    with open(script, "w") as f:
+        f.write("#!/bin/sh -x\n")
+        for target in replace_target:
+            bb.note(f"replace: {target}")
+            for cmd in busybox_cmds[target]["cmds"]:
+                f.write(f"ln -s /bin/busybox /{tmp_install_dir}{cmd}\n")
+
+    
+setup_make_minimal_image() {
+    if [ -d "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_WORK_DIR}/" ]; then
+        sudo rm -fr "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_WORK_DIR}/"
+    fi
+
+    sudo mkdir "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_WORK_DIR}/"
+    sudo mkdir -p "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_SETUP_SCRIPTS_DIR}/"
+    sudo mkdir "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}"
+    sudo mkdir "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/bin"
+    sudo mkdir "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/sbin"
+    sudo mkdir "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/usr"
+    sudo mkdir "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/usr/bin"
+    sudo mkdir "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/usr/sbin"
+
+    sudo -E chroot "${ROOTFSDIR}" \
+        /usr/sbin/usermod -s /bin/sh root
+}
+
+prepare_busybox() {
+    sudo cp  "${WORKDIR}/${EMLINUX_IMAGE_MINIMAL_BUSYBOX_PREPARE_SCRIPT}" "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_SETUP_SCRIPTS_DIR}/."
+
+    sudo -E chroot "${ROOTFSDIR}" /bin/sh <<EOL
+/bin/sh /emlinux-work/scripts/setup/prepare-busybox.sh
+EOL
+}
+
+remove_packages() {
+    sudo -E chroot "${ROOTFSDIR}" /bin/dash <<EOL
+export PATH=${EMLINUX_MINIMAL_IMAGE_BUSYBOX_TMP_PATH}:${PATH}
+dpkg -P --force-all ${EMLINUX_MINIMAL_IMAGE_REMOVE_PAKCAGES}
+EOL
+}
+
+replace_packages() {
+    sudo -E chroot "${ROOTFSDIR}" /bin/dash <<EOL
+export PATH=${EMLINUX_MINIMAL_IMAGE_BUSYBOX_TMP_PATH}:${PATH}
+
+    # Remove systemd packages 
+    dpkg -P --force-all systemd libsystemd0 libsystemd-shared
+
+busybox cp -a /${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/bin/* /bin/ || true
+busybox cp -a /${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/sbin/* /sbin/ || true
+busybox cp -a /${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/usr/bin/* /usr/bin/ || true
+busybox cp -a /${EMLINUX_IMAGE_MINIMAL_BUSYBOX_TMP_DIR}/usr/sbin/* /usr/sbin/ || true
+EOL
+
+    # Replace dash to busybox shell
+    sudo -E chroot "${ROOTFSDIR}" /bin/busybox sh <<EOL
+export PATH=${EMLINUX_MINIMAL_IMAGE_BUSYBOX_TMP_PATH}:${PATH}
+/bin/busybox ln -sf /bin/busybox /bin/sh
+EOL
+
+    if [ "${EMLINUX_IMAGE_MINIMAL_REMOVE_PERL}" = "1" ]; then
+      sudo -E chroot "${ROOTFSDIR}" /bin/busybox sh <<EOL
+        export PATH=${EMLINUX_MINIMAL_IMAGE_BUSYBOX_TMP_PATH}:${PATH}
+        dpkg -P --force-all ${EMLINUX_MINIMAL_IMAGE_REMOVE_PERL}
+EOL
+    fi
+       
+    # Install AMA0 setting to inittab.d/
+    sudo mkdir ${ROOTFSDIR}/etc/inittab.d
+    sudo sh -c "echo 'AMA0:12345:respawn:/sbin/getty 115200 ttyAMA0' >> ${ROOTFSDIR}/etc/inittab.d/ama0.tab"
+    sudo sh -c "echo 'S0:12345:respawn:/sbin/getty 115200 ttyS0' >> ${ROOTFSDIR}/etc/inittab.d/ttyS0.tab"
+    sudo sh -c "echo 'S1:12345:respawn:/sbin/getty 115200 ttyS1' >> ${ROOTFSDIR}/etc/inittab.d/ttyS1.tab"
+    # Comment out following line added by isar/meta/conf/distro/debian-configscript.sh
+    sudo sh -c "sed -i 's;^T0:23:respawn:/sbin/getty;#T0:23:respawn:/sbin/getty;' ${ROOTFSDIR}/etc/inittab"
+    sudo sh -c "sed -i 's;--noclear;;g' ${ROOTFSDIR}/etc/inittab"
+
+    if [ "${EMLINUX_IMAGE_MINIMAL_REMOVE_BOOT_DIR}" = "1" ]; then
+      sudo -E chroot "${ROOTFSDIR}" /bin/busybox sh <<EOL
+rm -fr /boot/System.map-* /boot/config-* /boot/vmlinux-* /boot/initrd* || true
+rm -fr /initrd.img /initrd.img.old /vmlinuz /vmlinuz.old || true
+EOL
+    fi
+ 
+    if [ "${EMLINUX_IMAGE_MINIMAL_REMOVE_MAN}" = "1" ]; then
+      sudo rm -fr "${ROOTFSDIR}/usr/share/man"
+    fi
+
+    if [ "${EMLINUX_IMAGE_MINIMAL_REMOVE_DTB}" = "1" ]; then
+        linuxdir=$(find "${ROOTFSDIR}/usr/lib" -type d -a -name 'linux-image*')
+        sudo rm -fr "${linuxdir}"
+    fi
+    
+    sudo rm -fr "${ROOTFSDIR}/${EMLINUX_IMAGE_MINIMAL_WORK_DIR}"
+}
+
+python do_make_emlinux_minimal_rootfs() {
+    pn = d.getVar("PN")
+    if pn.endswith("-sdk"):
+        bb.note(f"pn is {pn} skip")
+        return
+
+    bb.note("Create minimal image")
+    bb.build.exec_func("setup_make_minimal_image", d)
+    create_replace_script(d)
+    bb.build.exec_func("prepare_busybox", d)
+    bb.build.exec_func("remove_packages", d)
+    bb.build.exec_func("replace_packages", d)
+}
+
+addtask make_emlinux_minimal_rootfs before do_rootfs_finalize after do_rootfs_postprocess
+

--- a/recipes-core/busybox/busybox.bb
+++ b/recipes-core/busybox/busybox.bb
@@ -1,0 +1,34 @@
+#
+# Copyright (c) Cybertrust Japan Co., Ltd. 
+#
+# SPDX-License-Identifier: MIT
+#
+
+inherit dpkg
+
+SRC_URI = "apt://${PN}"
+
+DEB_BUILD_PROFILES += "nocheck"
+
+PACKAGES += "${PN}-syslogd"
+
+do_prepare_build() {
+    # Enable -delete option for find command.
+    sed -i 's/# CONFIG_FEATURE_FIND_DELETE is not set/CONFIG_FEATURE_FIND_DELETE=y/' "${S}/debian/config/pkg/deb"
+
+    # Enable passwd command
+    sed -i 's/# CONFIG_PASSWD is not set/CONFIG_PASSWD=y/' "${S}/debian/config/pkg/deb"
+    sed -i 's/# CONFIG_USE_BB_CRYPT is not set/CONFIG_USE_BB_CRYPT=y/' "${S}/debian/config/pkg/deb"
+    sed -i 's/# CONFIG_USE_BB_CRYPT_SHA is not set/CONFIG_USE_BB_CRYPT_SHA=y/' "${S}/debian/config/pkg/deb"
+
+    # Enable user management commands
+    sed -i 's/# CONFIG_ADDUSER is not set/CONFIG_ADDUSER=y/' "${S}/debian/config/pkg/deb"
+    sed -i 's/# CONFIG_ADDGROUP is not set/CONFIG_ADDGROUP=y/' "${S}/debian/config/pkg/deb"
+    sed -i 's/# CONFIG_CHPASSWD is not set/CONFIG_CHPASSWD=y/' "${S}/debian/config/pkg/deb"
+    sed -i 's/# CONFIG_DELUSER is not set/CONFIG_DELUSER=y/' "${S}/debian/config/pkg/deb"
+    sed -i 's/# CONFIG_DELGROUP is not set/CONFIG_DELGROUP=y/' "${S}/debian/config/pkg/deb"
+
+    # Enable util-linux commands
+    sed -i 's/# CONFIG_MOUNTPOINT is not set/CONFIG_MOUNTPOINT=y/' "${S}/debian/config/pkg/deb"
+    
+}

--- a/recipes-core/images/emlinux-image-minimal.bb
+++ b/recipes-core/images/emlinux-image-minimal.bb
@@ -1,0 +1,215 @@
+#
+# EMLinux minimal rootfs image
+#
+# Copyright (c) Cybertrust Japan Co., Ltd. 
+#
+# SPDX-License-Identifier: MIT
+#
+
+FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files/minimal:"
+
+SRC_URI = "\
+    file://minimal-image-replace-basic-list.yml \
+"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${LAYERDIR_core}/licenses/COPYING.MIT;md5=838c366f69b72c5df05c96dff79b35f2"
+
+PV = "1.0"
+
+ISAR_RELEASE_CMD = "git -C ${LAYERDIR_emlinux} describe --tags --dirty --always --match 'v[0-9].[0-9]*'"
+
+IMAGE_INSTALL:append = " emlinux-customization"
+
+# Remove kernel, initramfs, and etc in /boot
+EMLINUX_IMAGE_MINIMAL_REMOVE_BOOT_DIR ??= "0"
+
+# Remove man pages
+EMLINUX_IMAGE_MINIMAL_REMOVE_MAN ??= "0"
+
+# Remove perl packages
+EMLINUX_IMAGE_MINIMAL_REMOVE_PERL ??= "0"
+
+# Remove dtb files in /usr/lib/linux-image-<linux version>
+EMLINUX_IMAGE_MINIMAL_REMOVE_DTB ??= "0"
+
+# It is needed to build and install essential packages
+ROOTFS_APT_ARGS:append = " --allow-downgrades"
+
+EMLINUX_SYSVINIT_INSTALL_PACKAGE = "\
+  sysvinit-core \
+  sysv-rc \
+  sysvinit-utils \
+  bootlogd \
+  busybox-syslogd \
+"
+
+IMAGE_INSTALL:append = "\
+  ${EMLINUX_SYSVINIT_INSTALL_PACKAGE} \
+"
+
+IMAGE_INSTALL:append = "\
+  busybox \
+  debianutils \
+"
+
+inherit image emlinux-minimal
+
+DEPENDS:class-sdk:append = " ${IMAGE_INSTALL}"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_LIBSTDCPLUSPLUS ?= " libstdc++6"
+EMLINUX_MINIMAL_IMAGE_REMOVE_COREUTILS ?= " \
+coreutils \
+initramfs-tools-core \
+initramfs-tools \
+klibc-utils \
+libklibc \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_PERL ?= " \
+perl-modules-5.36 \
+libperl5.36 perl \
+perl-base \
+libnumber-compare-perl \
+libtext-glob-perl \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_SHELLS ?= " bash"
+EMLINUX_MINIMAL_IMAGE_REMOVE_UTILS ?= " \
+pinentry-curses \
+mawk \
+cpio \
+diffutils \
+grep \
+gzip \
+findutils \
+hostname \
+sed \
+tar \
+usr-is-merged \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_APT ?= " \
+apt \
+libapt-pkg6.0 \
+debian-archive-keyring \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_LOCALE ?= " locales"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_UTIL_LINUX ?= " \
+util-linux \
+util-linux-extra \
+libsmartcols1 \
+libuuid1 \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_MOUNT ?= " mount libmount1"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_BSDUTILS ?= " bsdutils"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_SELINUX ?= " \
+libsemanage2 \
+libsemanage-common \
+libsepol2 \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_GNUPG ?= " \
+gpgv \
+dirmngr \
+gnupg-l10n \
+gnupg-utils \
+gpg-wks-server \
+gpgconf \
+gpgsm \
+gnupg \
+gpg \
+gpg-agent \
+gpg-wks-client \
+libassuan0 \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_AUTH_UTILS ?= " \
+login \
+passwd \
+adduser \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_FILE_SYSTEM_UTILS ?= " \
+e2fsprogs \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_PROCESS_UTILS ?= " \
+procps \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_LIBGPG_ERROR ?= " \
+libgpg-error0 \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_GNUTLS ?= " \
+libgnutls30 \
+libidn2-0 \
+libunistring2 \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_SQLITE3 ?= " libsqlite3-0"
+EMLINUX_MINIMAL_IMAGE_REMOVE_LIBLDAP ?= " \
+libldap-2.5-0 \
+libsasl2-2 \
+libsasl2-modules-db \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_LIBXXHASH ?= " libxxhash0"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_PAM ?= " \
+libpam-modules \
+libpam-modules-bin \
+libpam-runtime \
+libpam0g \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_LIBNTPH ?= " libnpth0"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_NCURSES ?= " \
+ncurses-base \
+ncurses-bin \
+libncursesw6 \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_READLINE ?= " \
+readline-common \
+libreadline8 \
+"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_SENSIBLE_UTIL ?= " sensible-utils"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_LSB ?= " lsb-base"
+
+EMLINUX_MINIMAL_IMAGE_REMOVE_PAKCAGES ?= " \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_COREUTILS} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_SHELLS} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_UTILS} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_APT} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_AUTH_UTILS} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_GNUPG} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_FILE_SYSTEM_UTILS} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_PROCESS_UTILS} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_LIBGPG_ERROR} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_UTIL_LINUX} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_BSDUTILS} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_MOUNT} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_GNUTLS} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_SELINUX} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_SQLITE3} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_LIBLDAP} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_LIBSTDCPLUSPLUS} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_LIBXXHASH} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_PAM} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_LIBNTPH} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_LOCALE} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_NCURSES} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_READLINE} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_SENSIBLE_UTIL} \
+${EMLINUX_MINIMAL_IMAGE_REMOVE_LSB} \
+"

--- a/recipes-core/images/files/minimal/minimal-image-replace-basic-list.yml
+++ b/recipes-core/images/files/minimal/minimal-image-replace-basic-list.yml
@@ -1,0 +1,207 @@
+adduser:
+  cmds:
+    - /usr/sbin/addgroup
+    - /usr/sbin/adduser
+    - /usr/sbin/delgroup
+    - /usr/sbin/deluser
+bsdutils:
+  cmds:
+    - /usr/bin/logger
+    - /usr/bin/renice
+coreutils:
+  cmds: 
+    - /bin/cat
+    - /bin/chgrp
+    - /bin/chmod
+    - /bin/chown
+    - /bin/cp
+    - /bin/date
+    - /bin/dd
+    - /bin/df
+    - /bin/dir
+    - /bin/echo
+    - /bin/false
+    - /bin/ln
+    - /bin/ls
+    - /bin/mkdir
+    - /bin/mknod
+    - /bin/mktemp
+    - /bin/mv
+    - /bin/pwd
+    - /bin/readlink
+    - /bin/rm
+    - /bin/rmdir
+    - /bin/sleep
+    - /bin/stty
+    - /bin/sync
+    - /bin/touch
+    - /bin/true
+    - /bin/uname
+    - /bin/vdir
+    - /bin/[
+    - /bin/arch
+    - /bin/b2sum
+    - /bin/base32
+    - /bin/base64
+    - /bin/basename
+    - /bin/basenc
+    - /bin/chcon
+    - /bin/cksum
+    - /bin/comm
+    - /bin/csplit
+    - /bin/cut
+    - /bin/dircolors
+    - /bin/dirname
+    - /bin/du
+    - /bin/env
+    - /bin/expand
+    - /bin/expr
+    - /bin/factor
+    - /bin/fmt
+    - /bin/fold
+    - /bin/groups
+    - /bin/head
+    - /bin/hostid
+    - /bin/id
+    - /bin/install
+    - /bin/join
+    - /bin/link
+    - /bin/logname
+    - /bin/md5sum
+    - /bin/mkfifo
+    - /bin/nice
+    - /bin/nl
+    - /bin/nohup 
+    - /bin/nproc
+    - /bin/numfmt
+    - /bin/od
+    - /bin/paste
+    - /bin/pathchk
+    - /bin/pinky
+    - /bin/pr
+    - /bin/printenv
+    - /bin/printf
+    - /bin/ptx
+    - /bin/realpath
+    - /bin/runcon
+    - /bin/seq
+    - /bin/sha1sum
+    - /bin/sha224sum
+    - /bin/sha256sum
+    - /bin/sha384sum
+    - /bin/sha512sum
+    - /bin/shred
+    - /bin/shuf
+    - /bin/sort
+    - /bin/split
+    - /bin/stat
+    - /bin/stdbuf
+    - /bin/sum
+    - /bin/tac
+    - /bin/tail
+    - /bin/tee
+    - /bin/test
+    - /bin/timeout
+    - /bin/tr
+    - /bin/truncate
+    - /bin/tsort
+    - /bin/tty
+    - /bin/unexpand
+    - /bin/uniq
+    - /bin/unlink
+    - /bin/users
+    - /bin/wc
+    - /bin/who
+    - /bin/whoami
+    - /bin/yes
+    - /bin/chroot
+cpio:
+  cmds:
+    - /bin/cpio
+diffutils:
+  cmds:
+    - /bin/cmp
+    - /bin/diff
+e2fsprogs:
+  cmds:
+    - /sbin/mke2fs
+grep:
+  cmds:
+    - /bin/grep
+    - /bin/egrep
+    - /bin/fgrep
+findutils:
+  cmds:
+    - /bin/find
+    - /bin/xargs
+gzip:
+  cmds:
+    - /bin/gunzip
+    - /bin/gzip
+    - /bin/uncompress
+    - /bin/zcat
+hostname:
+  cmds:
+    - /bin/hostname
+    - /bin/dnsdomainname
+login:
+  cmds:
+    - /bin/login
+    - /usr/sbin/nologin
+mawk:
+  cmds:
+    - /usr/bin/awk
+mount:
+  cmds:
+    - /bin/mount
+    - /bin/losetup
+    - /bin/umount
+    - /sbin/swapoff
+    - /sbin/swapon
+passwd:
+  cmds:
+    - /usr/bin/passwd
+procps:
+  cmds:
+    - /bin/kill
+    - /bin/ps
+    - /sbin/sysctl
+    - /usr/bin/free
+    - /usr/bin/top
+    - /usr/bin/uptime
+    - /usr/bin/w
+    - /usr/bin/watch
+sed:
+  cmds:
+    - /bin/sed
+tar:
+  cmds:
+    - /bin/tar
+util-linux:
+  cmds:
+    - /bin/dmesg
+    - /bin/more
+    - /sbin/blkdiscard
+    - /sbin/blkid
+    - /sbin/blockdev
+    - /sbin/findfs
+    - /sbin/fsfreeze
+    - /sbin/fstrim
+    - /sbin/getty
+    - /sbin/mkswap
+    - /sbin/pivot_root
+    - /sbin/switch_root
+    - /usr/bin/fallocate
+    - /usr/bin/getopt
+    - /usr/bin/ionice
+    - /usr/bin/last
+    - /usr/bin/mountpoint
+    - /usr/bin/nsenter
+    - /usr/bin/rev
+    - /usr/bin/setpriv
+    - /usr/bin/setsid
+    - /usr/bin/taskset
+    - /usr/bin/unshare
+util-linux-extra:
+  cmds:
+    - /sbin/hwclock

--- a/recipes-core/sysvinit/sysvinit.bb
+++ b/recipes-core/sysvinit/sysvinit.bb
@@ -1,0 +1,32 @@
+#
+# Copyright (c) Cybertrust Japan Co., Ltd. 
+#
+# SPDX-License-Identifier: MIT
+#
+
+# This recipe replaces bootclean.sh with one that works with busybox commands.
+# It replaced find command option in the clean_tmp() to use -user option instead of -uid option.
+
+inherit dpkg
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = " \
+apt://${PN} \
+file://custom-debian \
+"
+
+DEB_BUILD_PROFILES += "nocheck"
+
+PROVIDES += " \
+  sysvinit-core \
+  sysv-rc \
+  sysvinit-utils \
+  bootlogd \
+  busybox-syslogd \
+"
+
+do_move_debian_files() {
+    cp -r ${WORKDIR}/custom-debian/* ${S}/debian/
+}
+addtask move_debian_files after do_prepare_build before do_dpkg_build

--- a/recipes-core/sysvinit/sysvinit/custom-debian/src/initscripts/lib/init/bootclean.sh
+++ b/recipes-core/sysvinit/sysvinit/custom-debian/src/initscripts/lib/init/bootclean.sh
@@ -1,0 +1,188 @@
+# bootclean
+#
+# Clean /tmp, /run and /var/lock if not mounted as tmpfs
+#
+# DO NOT RUN AFTER S:55bootmisc.sh and do not run this script directly
+# in runlevel S. Instead write an initscript to call it.
+#
+
+. /lib/init/vars.sh
+. /lib/lsb/init-functions
+
+# Should be called outside verbose message block
+mkflagfile()
+{
+	# Prevent symlink attack  (See #264234.)
+	[ -L "$1" ] && log_warning_msg "bootclean: Deleting symbolic link '$1'."
+	rm -f "$1" || { log_failure_msg "bootclean: Failure deleting '$1'." ; return 1 ; }
+	# No user processes should be running, so no one should be
+	# able to introduce a symlink here.  As an extra precaution,
+	# set noclobber.
+	set -o noclobber
+	true > "$1" || { log_failure_msg "bootclean: Failure creating '$1'." ; return 1 ; }
+	return 0
+}
+
+checkflagfile()
+{
+	if [ -f $1/.clean ]
+	then
+		which stat >/dev/null 2>&1 && cleanuid="$(stat -c %u $1/.clean)"
+		# Poor's man stat %u, since stat (and /usr) might not
+		# be available in some bootup stages
+		[ "$cleanuid" ] || cleanuid="$(find $1/.clean -printf %U)"
+		[ "$cleanuid" ] || { log_failure_msg "bootclean: Could not stat '$1/.clean'." ; return 1 ; }
+		if [ "$cleanuid" -ne 0 ]
+		then
+			rm -f $1/.clean || { log_failure_msg "bootclean: Could not delete '$1/.clean'." ; return 1 ; }
+		fi
+	fi
+	return 0
+}
+
+	report_err()
+	{
+		dir="$1"
+		if [ "$VERBOSE" = no ]
+		then
+			log_failure_msg "bootclean: Failure cleaning ${dir}."
+		else
+			log_action_end_msg 1 "bootclean: Failure cleaning ${dir}"
+		fi
+	}
+
+clean_tmp() {
+	if test -h /tmp; then
+		# will be created by mount_tmp if it does not exist
+		test -d /tmp || return 0
+		# but we'll clean it if it does
+	fi
+
+	# Does not exist
+	[ -d /tmp ] || return 1
+	# tmpfs does not require cleaning
+	[ -f /tmp/.tmpfs ] && return 0
+	# Can clean?
+	checkflagfile /tmp || return 0
+	# Already cleaned
+	[ -f /tmp/.clean ] && return 0
+	# Can't clean yet?
+	which find >/dev/null 2>&1 || return 1
+
+	cd /tmp || { log_failure_msg "bootclean: Could not cd to /tmp." ; return 1 ; }
+
+	#
+	# Only clean out /tmp if it is world-writable. This ensures
+	# it really is a/the temp directory we're cleaning.
+	#
+	[ "$(find . -maxdepth 0 -perm -002)" = "." ] || return 0
+
+	if [ ! "$TMPTIME" ]
+	then
+		log_warning_msg "Using default TMPTIME 0."
+		TMPTIME=0
+	fi
+
+	[ "$VERBOSE" = no ] || log_action_begin_msg "Cleaning /tmp"
+
+	#
+	# Remove regardless of TMPTIME setting
+	#
+	rm -f .X*-lock
+
+	#
+	# Don't clean remaining files if TMPTIME is negative or 'infinite'
+	#
+	case "$TMPTIME" in
+	  -*|infinite|infinity)
+		[ "$VERBOSE" = no ] || log_action_end_msg 0 "skipped"
+		return 0
+		;;
+	esac
+
+	#
+	# Wipe /tmp, excluding system files, but including lost+found
+	#
+	# If TMPTIME is set to 0, we do not use any ctime expression
+	# at all, so we can also delete files with timestamps
+	# in the future!
+	#
+	if [ "$TMPTIME" = 0 ]
+	then
+		TEXPR=""
+		DEXPR=""
+	else
+		TEXPR="-mtime +$TMPTIME -ctime +$TMPTIME -atime +$TMPTIME"
+		DEXPR="-mtime +$TMPTIME -ctime +$TMPTIME"
+	fi
+
+	EXCEPT='! -name .
+		! ( -path ./lost+found -user 0 )
+		! ( -path ./quota.user -user 0 )
+		! ( -path ./aquota.user -user 0 )
+		! ( -path ./quota.group -user 0 )
+		! ( -path ./aquota.group -user 0 )
+		! ( -path ./.journal -user 0 )
+		! ( -path ./.sujournal -user 0 )
+		! ( -path ./.clean -user 0 )
+		! ( -path './...security*' -user 0 )'
+
+	mkflagfile /tmp/.clean || return 1
+
+	#
+	# First remove all old files...
+	#
+	find . -depth -xdev $TEXPR $EXCEPT ! -type d -delete \
+		|| { report_err "/tmp"; return 1 ; }
+
+	#
+	# ...and then all empty directories
+	#
+	find . -depth -xdev $DEXPR $EXCEPT -type d -empty -delete \
+		|| { report_err "/tmp"; return 1 ; }
+
+	[ "$VERBOSE" = no ] || log_action_end_msg 0
+	log_progress_msg "/tmp"
+	return 0
+}
+
+clean() {
+	dir="$1"
+	findopts="$2"
+
+	# Does not exist
+	[ -d "$dir" ] || return 1
+	# tmpfs does not require cleaning
+	[ -f "$dir/.tmpfs" ] && return 0
+	# Can clean?
+	checkflagfile "$dir" || return 0
+	# Already cleaned
+	[ -f "${dir}/.clean" ] && return 0
+	# Can't clean yet?
+	which find >/dev/null 2>&1 || return 1
+
+	cd "$dir" || { log_action_end_msg 1 "bootclean: Could not cd to ${dir}." ; return 1 ; }
+
+	[ "$VERBOSE" = no ] || log_action_begin_msg "Cleaning $dir"
+
+	find . $findopts -delete \
+		|| { report_err "$dir"; return 1 ; }
+	[ "$VERBOSE" = no ] || log_action_end_msg 0
+	mkflagfile "${dir}/.clean" || return 1
+	log_progress_msg "$dir"
+	return 0
+}
+
+clean_all()
+{
+	which find >/dev/null 2>&1 || return 0
+	log_begin_msg "Cleaning up temporary files..."
+	ES=0
+	clean_tmp || ES=1
+	clean /run "! -xtype d ! -name utmp ! -name innd.pid" || ES=1
+	clean /run/lock "! -type d" || ES=1
+	clean /run/shm "! -type d" || ES=1
+	log_end_msg $ES
+	return $ES
+}
+

--- a/recipes-support/debianutils/debianutils.bb
+++ b/recipes-support/debianutils/debianutils.bb
@@ -1,0 +1,28 @@
+#
+# Copyright (c) Cybertrust Japan Co., Ltd. 
+#
+# SPDX-License-Identifier: MIT
+#
+
+inherit dpkg
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI = "\
+  apt://${PN} \
+  file://debian/patches/savelog_do_not_use_reference_option.patch \
+  file://debian/patches/do_not_use_reference_option_when_update_shell.patch \
+  file://debian/patches/do_no_use_Z_option.patch \
+"
+
+DEB_BUILD_PROFILES += "nocheck"
+
+do_dpkg_source:prepend() {
+    cp -r ${WORKDIR}/debian ${S}
+    echo "savelog_do_not_use_reference_option.patch" >> ${S}/debian/patches/series
+    echo "do_not_use_reference_option_when_update_shell.patch" >> ${S}/debian/patches/series
+    echo "do_no_use_Z_option.patch" >> ${S}/debian/patches/series
+   
+    # patch file was installed into the ${S}/patches which directory is not needed.
+    rm -fr ${S}/patches
+}

--- a/recipes-support/debianutils/files/debian/patches/do_no_use_Z_option.patch
+++ b/recipes-support/debianutils/files/debian/patches/do_no_use_Z_option.patch
@@ -1,0 +1,36 @@
+diff -Npur debianutils-1.0.orig/add-shell debianutils-1.0/add-shell
+--- debianutils-1.0.orig/add-shell	2024-10-07 05:49:16.000000000 +0000
++++ debianutils-1.0/add-shell	2024-10-07 05:52:57.595587069 +0000
+@@ -41,7 +41,7 @@ done
+ chmod $(stat -c %a "${file}") "${tmpfile}"
+ chown $(stat -c %U "${file}") "${tmpfile}"
+ 
+-mv -Z "${tmpfile}" "${file}" || mv "${tmpfile}" "${file}"
++mv "${tmpfile}" "${file}"
+ 
+ trap "" EXIT
+ exit 0
+diff -Npur debianutils-1.0.orig/remove-shell debianutils-1.0/remove-shell
+--- debianutils-1.0.orig/remove-shell	2024-10-07 05:49:16.000000000 +0000
++++ debianutils-1.0/remove-shell	2024-10-07 05:53:23.239250075 +0000
+@@ -41,7 +41,7 @@ done
+ chmod $(stat -c %a "${file}") "${tmpfile}"
+ chown $(stat -c %U "${file}") "${tmpfile}"
+ 
+-mv -Z "${tmpfile}" "${file}" || mv "${tmpfile}" "${file}"
++mv "${tmpfile}" "${file}"
+ 
+ trap "" EXIT
+ exit 0
+diff -Npur debianutils-1.0.orig/update-shells debianutils-1.0/update-shells
+--- debianutils-1.0.orig/update-shells	2024-10-07 05:49:16.000000000 +0000
++++ debianutils-1.0/update-shells	2024-10-07 05:53:13.799005990 +0000
+@@ -144,7 +144,7 @@ if [ "$NOACT" = 0 ]; then
+ 	chmod $(stat -c %a "${SOURCE_ETC_FILE}") "${NEW_ETC_FILE}"
+ 	chown $(stat -c %U "${SOURCE_ETC_FILE}") "${NEW_ETC_FILE}"
+ 	sync -d "$NEW_ETC_FILE" "$NEW_STATE_FILE"
+-	mv -Z "${NEW_ETC_FILE}" "${TARGET_ETC_FILE}" || mv "${NEW_ETC_FILE}" "${TARGET_ETC_FILE}"
++	mv "${NEW_ETC_FILE}" "${TARGET_ETC_FILE}"
+ 	sync "$TARGET_ETC_FILE"
+ 	sync "$(dirname "$TARGET_ETC_FILE")"
+ 	mv "$NEW_STATE_FILE" "$STATE_FILE"

--- a/recipes-support/debianutils/files/debian/patches/do_not_use_reference_option_when_update_shell.patch
+++ b/recipes-support/debianutils/files/debian/patches/do_not_use_reference_option_when_update_shell.patch
@@ -1,0 +1,49 @@
+diff -Npur debianutils-5.7.orig/add-shell debianutils-5.7/add-shell
+--- debianutils-5.7.orig/add-shell	2022-01-21 08:58:25.000000000 +0000
++++ debianutils-5.7/add-shell	2024-10-04 05:16:31.305334563 +0000
+@@ -38,8 +38,8 @@ do
+         done
+ done
+ 
+-chmod --reference="${file}" "${tmpfile}" || chmod $(stat -c %a "${file}") "${tmpfile}"
+-chown --reference="${file}" "${tmpfile}" || chown $(stat -c %U "${file}") "${tmpfile}"
++chmod $(stat -c %a "${file}") "${tmpfile}"
++chown $(stat -c %U "${file}") "${tmpfile}"
+ 
+ mv -Z "${tmpfile}" "${file}" || mv "${tmpfile}" "${file}"
+ 
+diff -Npur debianutils-5.7.orig/remove-shell debianutils-5.7/remove-shell
+--- debianutils-5.7.orig/remove-shell	2022-01-21 08:58:25.000000000 +0000
++++ debianutils-5.7/remove-shell	2024-10-04 05:16:44.053657944 +0000
+@@ -38,8 +38,8 @@ do
+         done
+ done
+ 
+-chmod --reference="${file}" "${tmpfile}" || chmod $(stat -c %a "${file}") "${tmpfile}"
+-chown --reference="${file}" "${tmpfile}" || chown $(stat -c %U "${file}") "${tmpfile}"
++chmod $(stat -c %a "${file}") "${tmpfile}"
++chown $(stat -c %U "${file}") "${tmpfile}"
+ 
+ mv -Z "${tmpfile}" "${file}" || mv "${tmpfile}" "${file}"
+ 
+diff -Npur debianutils-5.7.orig/update-shells debianutils-5.7/update-shells
+--- debianutils-5.7.orig/update-shells	2022-01-21 08:58:25.000000000 +0000
++++ debianutils-5.7/update-shells	2024-10-04 05:17:14.731436902 +0000
+@@ -133,13 +133,13 @@ done
+ 
+ if [ "$NOACT" = 0 ]; then
+ 	if [ -e "$STATE_FILE" ]; then
+-		chmod --reference="${STATE_FILE}" "${NEW_STATE_FILE}" || chmod $(stat -c %a "${STATE_FILE}") "${NEW_STATE_FILE}"
+-		chown --reference="${STATE_FILE}" "${NEW_STATE_FILE}" || chown $(stat -c %U "${STATE_FILE}") "${NEW_STATE_FILE}"
++		chmod $(stat -c %a "${STATE_FILE}") "${NEW_STATE_FILE}"
++		chown $(stat -c %U "${STATE_FILE}") "${NEW_STATE_FILE}"
+ 	else
+ 		chmod 0644 "$NEW_STATE_FILE"
+ 	fi
+-	chmod --reference="${SOURCE_ETC_FILE}" "${NEW_ETC_FILE}" || chmod $(stat -c %a "${SOURCE_ETC_FILE}") "${NEW_ETC_FILE}"
+-	chown --reference="${SOURCE_ETC_FILE}" "${NEW_ETC_FILE}" || chown $(stat -c %U "${SOURCE_ETC_FILE}") "${NEW_ETC_FILE}"
++	chmod $(stat -c %a "${SOURCE_ETC_FILE}") "${NEW_ETC_FILE}"
++	chown $(stat -c %U "${SOURCE_ETC_FILE}") "${NEW_ETC_FILE}"
+ 	sync -d "$NEW_ETC_FILE" "$NEW_STATE_FILE"
+ 	mv -Z "${NEW_ETC_FILE}" "${TARGET_ETC_FILE}" || mv "${NEW_ETC_FILE}" "${TARGET_ETC_FILE}"
+ 	sync "$TARGET_ETC_FILE"

--- a/recipes-support/debianutils/files/debian/patches/savelog_do_not_use_reference_option.patch
+++ b/recipes-support/debianutils/files/debian/patches/savelog_do_not_use_reference_option.patch
@@ -1,0 +1,18 @@
+Index: debianutils-5.7/savelog
+===================================================================
+--- debianutils-5.7.orig/savelog
++++ debianutils-5.7/savelog
+@@ -315,8 +315,11 @@ while [ $# -gt 0 ]; do
+ 	if [ -n "$preserve" ]; then
+ 		(umask 077
+ 		 touch -- "$filename.new"
+-		 chown --reference="$filename" -- "$filename.new"
+-		 chmod --reference="$filename" -- "$filename.new")
++		 u=$(stat -c "%U" "$filename")
++		 g=$(stat -c "%G" "$filename")
++		 a=$(stat -c "%a" "$filename")
++		 chown "$u:$g" -- "$filename.new"
++		 chmod "$a" -- "$filename.new")
+ 		filenew=1
+ 	elif [ -n "$touch$user$group$mode" ]; then
+ 		touch -- "$filename.new"


### PR DESCRIPTION
This image support to create small footprint image. It uses busybox for basic commands instead of coreutils, util-linux, and so on.

Features:

- Use busybox commands instead of coreutils
- Use sysvinit as init system
- Remove packages from emlinux-image-base

To use the busybox as default commands following packages were modified.

- sysvinit
- debianutils

Above packages have shell scripts and use commands with options that doesn't supported by busybox.
Therefore, we needed to modify command line to work with busybox without breaking functionality.

Limitations:

- This image disrupts the Debian system features expected by ISAR
- When you want to update an image, you need to run "bitbake emlinux-image-minimal -c cleanall" first
- SDK doesn't support minimal image

To build emlinux-image-minimal, it runs following steps.

1. Create emlinux-image-base
2. Replace commands to busybox from coreutils, util-linux, and etc
3. Remove packages to reduce footprint

Options:

There are some options to reduce footprint.

- EMLINUX_IMAGE_MINIMAL_REMOVE_PERL 
If set to 1, remove perl packages.

- EMLINUX_IMAGE_MINIMAL_REMOVE_BOOT_DIR
If set to 1, remove files in /boot directory.
EMLinux's rootfs contains /boot in it, however if your system boot from u-boot, /boot is not needed so this option remove files in /boot to reduce footprint.

- EMLINUX_IMAGE_MINIMAL_REMOVE_MAN 
If set to 1, remove man files.

- EMLINUX_IMAGE_MINIMAL_REMOVE_DTB
If set to 1, remove dtb files in /usr/lib/linux-image-<kernel version>.


# footprint

Tested on qemu-arm64.

|image|size|
|---|---|
|emlinux-image-base|345M|
|emlinux-image-minimal|242.9M|
|emlinux-image-minimal with EMLINUX_IMAGE_MINIMAL_REMOVE-* options|107.0M|

According to the above table, emlinux-image-minimal image reduces maximum 69% disk size.

## details
The emlinux-image-base used 345M by default.

```
root@EMLinux3:~# du -sh /* | sort -nr
du: cannot access '/proc/266': No such file or directory
du: cannot access '/proc/267/task/267/fd/3': No such file or directory
du: cannot access '/proc/267/task/267/fdinfo/3': No such file or directory
du: cannot access '/proc/267/fd/3': No such file or directory
du: cannot access '/proc/267/fdinfo/3': No such file or directory
492K    /run
410K    /etc
283M    /usr
51M     /boot
12K     /lost+found
11M     /var
5.0K    /tmp
4.0K    /root
1.0K    /srv
1.0K    /opt
1.0K    /mnt
1.0K    /media
1.0K    /home
0       /vmlinuz.old
0       /vmlinuz
0       /sys
0       /sbin
0       /proc
0       /lib
0       /initrd.img.old
0       /initrd.img
0       /dev
0       /bin
root@EMLinux3:~# df -h /
Filesystem      Size  Used Avail Use% Mounted on
/dev/vda        434M  345M   62M  85% /
```

Default emlinux-image-minimal uses 242.9M.

```
# du -sh /* | sort -nr
336.0K  /run
241.0K  /etc
189.6M  /usr
50.3M   /boot
12.0K   /lost+found
3.0K    /root
2.7M    /var
1.0K    /tmp
1.0K    /srv
1.0K    /opt
1.0K    /mnt
1.0K    /media
1.0K    /home
0       /vmlinuz.old
0       /vmlinuz
0       /sys
0       /sbin
0       /proc
0       /lib
0       /initrd.img.old
0       /initrd.img
0       /dev
0       /bin
# df -h /
Filesystem                Size      Used Available Use% Mounted on
/dev/vda                313.5M    242.9M     49.4M  83% /
```

When sets following variables, image size is 107.0M.

- EMLINUX_IMAGE_MINIMAL_REMOVE_PERL
- EMLINUX_IMAGE_MINIMAL_REMOVE_BOOT_DIR
- EMLINUX_IMAGE_MINIMAL_REMOVE_MAN
- EMLINUX_IMAGE_MINIMAL_REMOVE_DTB

```
# du -sh /* | sort -nr
336.0K  /run
238.0K  /etc
104.4M  /usr
12.0K   /lost+found
3.0K    /root
2.3M    /var
1.0K    /tmp
1.0K    /srv
1.0K    /opt
1.0K    /mnt
1.0K    /media
1.0K    /home
1.0K    /boot
0       /sys
0       /sbin
0       /proc
0       /lib
0       /dev
0       /bin
# df -h /
Filesystem                Size      Used Available Use% Mounted on
/dev/vda                179.7M    107.0M     58.9M  65% /
```