### PR TITLE
linux: linux-k510: Add CVEs to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -85,6 +85,10 @@ do_shared_workdir_prepend () {
 # CVE-2024-50091: Vulnerable code not present.
 # CVE-2024-50111: Vulnerable code not present.
 # CVE-2024-50244: Vulnerable code not present.
+# CVE-2023-52596: Vulnerable code not present.
+# CVE-2024-36022: Vulnerable code not present.
+# CVE-2024-36948: Vulnerable code not present.
+# CVE-2024-26944: Vulnerable code not present.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-43057 CVE-2015-8955 CVE-2020-8834 \
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
@@ -104,5 +108,6 @@ CVE_CHECK_WHITELIST = "\
     CVE-2023-39176 CVE-2023-39180 CVE-2023-47210 \
     CVE-2023-52508 CVE-2024-26647 CVE-2024-26944 \
     CVE-2024-49939 CVE-2024-50090 CVE-2024-50091 \
-    CVE-2024-50111 CVE-2024-50244 \
+    CVE-2024-50111 CVE-2024-50244 CVE-2023-52596 \
+    CVE-2024-36022 CVE-2024-36948 CVE-2024-26944 \
 "


### PR DESCRIPTION
Add CVEs to CVE_CHECK_WHITELIST which there is no vulnerable code in 5.10.y.
- CVE-2023-52596
- CVE-2024-36022
- CVE-2024-36948
- CVE-2024-26944