### PR TITLE
Update kernel to v6.1.128-cip37-rt20

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_git.bb
+++ b/recipes-kernel/linux/linux-cip-rt_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.127-cip36-rt19"
-PV = "6.1.127-cip36-rt19"
+LINUX_CIP_VERSION = "v6.1.128-cip37-rt20"
+PV = "6.1.128-cip37-rt20"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip-rt;destsuffix=${P};protocol=https \
     file://preempt-rt.cfg \
@@ -23,6 +23,6 @@ SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
-SRCREV = "01b1c2fa67fa5bfe5403450fb59b93ea5aed1610"
+SRCREV = "9422a6e3a3ce62cdcbffa5c7bd1c1f5fd37936a4"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.128-cip37-rt20

This pull request update the kernel to the following cip versions:
v6.1.128-cip37-rt20 with hash tag 9422a6e3a3ce62cdcbffa5c7bd1c1f5fd37936a4
