### PR TITLE
Update kernel to v4.19.325-cip117

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "6e07bbcb7050f0840638c734437cc842a855dd10"
+LINUX_GIT_SRCREV ?= "2601508bd51c960b81522d6ab4f3f80dc9e4fcef"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip116"
+LINUX_CIP_VERSION ??= "v4.19.325-cip117"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip117

This pull request update the kernel to the following cip versions:
v4.19.325-cip117 with hash tag 2601508bd51c960b81522d6ab4f3f80dc9e4fcef
