### PR TITLE
recipes-sample: openssl-apt: Add a missing security patch to this package's series file

### DIFF
--- a/doc/samples/recipes-sample/openssl-apt/files/custom-debian/patches/series
+++ b/doc/samples/recipes-sample/openssl-apt/files/custom-debian/patches/series
@@ -7,4 +7,5 @@ Configure-allow-to-enable-ktls-if-target-does-not-start-w.patch
 Remove-the-provider-section.patch
 conf-Serialize-allocation-free-of-ssl_names.patch
 Fix-tests-for-new-default-security-level.patch
+Harden-BN_GF2m_poly2arr-against-misuse.patch
 0001-for-checking-customization-test.patch


### PR DESCRIPTION
A new security patch has been added by the openssl version in bookworm being updated since this recipe was introduced. This change avoids omitting it.