### PR TITLE
Fix CVE check error

### DIFF
--- a/scripts/lib/python/cve/debian_cve.py
+++ b/scripts/lib/python/cve/debian_cve.py
@@ -19,7 +19,7 @@ logger = logging.getLogger("emlinux-cve-check")
 DEBIAN_CVE_TRACKER_JSON_URL = "https://security-tracker.debian.org/tracker/data/json"
 
 def remove_extra_suffix_in_version_string(version_str):
-    vs = version_str
+    vs = version_str.strip()
 
     # Some version string in NVD database contains additional suffix
     # such as _ubuntu1, _exp, and so of

--- a/scripts/lib/python/cve/nvd_cve.py
+++ b/scripts/lib/python/cve/nvd_cve.py
@@ -93,7 +93,13 @@ def update_db(conn, elt):
     accessVector = None
     vectorString = None
     cveId = elt['cve']['id']
-    vulnStatus = elt['cve']['vulnStatus']
+    logger.debug(f"Processing CVE {cveId}")
+
+    if 'vulnStatus' in elt['cve']:
+        vulnStatus = elt['cve']['vulnStatus']
+    else:
+        vulnStatus = ""
+
     cveDesc = ""
     for desc in elt['cve']['descriptions']:
         if desc['lang'] == 'en':


### PR DESCRIPTION
# Purpose

This PR contains 2 commits these commit fix errors in cve check process.

## Commit "lib/python/cve: Add check for vulnStatus attribute" 

According to the NVD CVE API Schema[1], it seems as if the vulnStatus always exists in a response. But we found CVE-2025-2682 does not contain it as of 2025-03-28.
Therefore, we need to check if the attribute is contained in response.

This commit fixes following error.

```
build@773442ee2ec4:~/work/build$ cve_check.py --image-name emlinux-image-base --output-format text,json
2025-03-27 23:27:02,763:INFO: Update NVD CVE database
Traceback (most recent call last):
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line 714, in <module>
    main(parse_options())
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line 637, in main
    update_result, db_file = nvd_cve.update_nvd_db(cve_data_dl_dir, args.nvd_api_key, predownload_url)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/lib/python/cve/nvd_cve.py", line 333, in update_nvd_db
    if fetch_all_cves(db_file, conn, last_modified, nvd_api_key):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/lib/python/cve/nvd_cve.py", line 204, in fetch_all_cves
    update_db(conn, cve)
  File "/home/build/work/repos/meta-emlinux/scripts/lib/python/cve/nvd_cve.py", line 96, in update_db
    vulnStatus = elt['cve']['vulnStatus']
                 ~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'vulnStatus'
```

## Commit scripts/lib/python/cve: Strip spaces from version string

We found some CVE contains space in version field such as fixed_version. If such data is saved to sqlite database, we got an error.  To avoid the error, strip version string before use.

NVD API returns following data  which contains a space before 5.10.35.

```
                    "versionEndIncluding": " 5.10.35",
```

This commit fixes following error.

```
2025-03-28 05:32:32,753:INFO: Checking CVEs ...
Traceback (most recent call last):
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line 714, in <module>
    main(parse_options())
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line 667, in main
    cves = create_cves_info(db_file, debian_cve_list, uniq_installed_pkgs, installed_pkgs, args.debian_codename, cve_products, linux_kernel_src_dir, cip_kernel_sec_dir, kev_list)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line 506, in create_cves_info
    installed_pkgs_cves_by_nvd_data = pkg_cve_fixed_check_by_nvd_data(uniq_installed_pkgs, installed_pkgs_cves_by_debian_data, db_file, cve_products)
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line 383, in pkg_cve_fixed_check_by_nvd_data
    affected, fixed = check_affected_upstream_version(conn, cveid, pkg, vendor, product)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line 356, in check_affected_upstream_version
    fixed = is_fixed_in_upstream_version(end_version, pkg["upstream_version"], op)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line 273, in is_fixed_in_upstream_version
    uver = debian_cve.parse_version(upstream_version)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/lib/python/cve/debian_cve.py", line 38, in parse_version
    v = debian.debian_support.Version(vs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/debian/debian_support.py", line 287, in __init__
    super(AptPkgVersion, self).__init__(version)
  File "/usr/lib/python3/dist-packages/debian/debian_support.py", line 168, in __init__
    self.full_version = version
    ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/debian/debian_support.py", line 197, in __setattr__
    self._set_full_version(str(value))
  File "/usr/lib/python3/dist-packages/debian/debian_support.py", line 174, in _set_full_version
    raise ValueError("Invalid version string %r" % version)
ValueError: Invalid version string ' 5.10.35'
```

# Test 

Run cve check.

# Test result

cve check finished without any errors.

```
build@7caf7e4e109f:~/work/build$ rm -fr downloads/CVE/
build@7caf7e4e109f:~/work/build$ cve_check.py --image-name emlinux-image-base --output-format text,json
2025-03-28 05:39:44,733:INFO: Update NVD CVE database
2025-03-28 06:03:01,695:INFO: Update last modified date
2025-03-28 06:03:01,707:INFO: Update debian CVE database
2025-03-28 06:03:05,432:INFO: Update KEV database
2025-03-28 06:03:05,854:INFO: clone cip-kernel-sec
2025-03-28 06:03:14,019:INFO: Checking CVEs ...
2025-03-28 06:03:49,985:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-arm64
```

