### PR TITLE
recipes-core/cve-update: Check vulnStatus key before use

### DIFF
--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -359,12 +359,13 @@ def update_db(conn, elt):
 
     accessVector = None
     cveId = elt['cve']['id']
-    if elt['cve']['vulnStatus'] ==  "Rejected":
-        c = conn.cursor()
-        c.execute("delete from PRODUCTS where ID = ?;", [cveId])
-        c.execute("delete from NVD where ID = ?;", [cveId])
-        c.close()
-        return
+    if 'vulnStatus' in elt['cve']:
+        if elt['cve']['vulnStatus'] ==  "Rejected":
+            c = conn.cursor()
+            c.execute("delete from PRODUCTS where ID = ?;", [cveId])
+            c.execute("delete from NVD where ID = ?;", [cveId])
+            c.close()
+            return
     cveDesc = ""
     for desc in elt['cve']['descriptions']:
         if desc['lang'] == 'en':


### PR DESCRIPTION
According to the NVD CVE API Schema[1], it seems as if the vulnStatus always exists in a response. But we found CVE-2025-2682 does not contain it as of 2025-03-28[1].
This key has been added as of 2025-04-01 however it would be nice to check the value is in the API result before use to prevent future error.

1: https://github.com/miraclelinux/meta-emlinux/pull/452/commits/babb7fad8800f301dc8cac6e1953589d6bd7ec83

cve-check task worked correctly.

```
$ bitbake core-image-minimal                                                                                                          
Loading cache: 100% |####################################################################################################| Time: 0:00:00
Loaded 2382 entries from dependency cache.                                                                                              
NOTE: Resolving any missing task queue dependencies                                                                                     
                                                                                                                                        
Build Configuration:                                                                                                                    
BB_VERSION           = "1.42.0"                                                                                                         
BUILD_SYS            = "x86_64-linux"                                                                                                   
NATIVELSBSTRING      = "universal"                                                                                                      
TARGET_SYS           = "aarch64-emlinux-linux"                                                                                          
MACHINE              = "qemuarm64"                                                                                                      
DISTRO               = "emlinux"                                                                                                        
DISTRO_VERSION       = "2.11"                                                                                                           
TUNE_FEATURES        = "aarch64 armv8a crc"                                                                                             
TARGET_FPU           = ""                                                                                                               
meta                                                                                                                                    
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"                                                                  
meta-debian          = "deb10.13-2:3b934cc0a03bac1b1f247d9f37e7e59b7633a656"                                                            
meta-debian-extended = "HEAD:644bc70b7ba7bc553f30c688e7a4a9119411b105"                                                                  
meta-emlinux         = "eml2-check-vulnstatus:b3d28c0f39d1b54f89dd2d82b7a09e854b211820"                                                 
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"                                                                  
                                                                                                                                        
Initialising tasks: 100% |###############################################################################################| Time: 0:00:01
Sstate summary: Wanted 2 Found 0 Missed 2 Current 877 (0% match, 99% complete)                                                          
NOTE: Executing SetScene Tasks                                                                                                          
NOTE: Executing RunQueue Tasks                                                                                                          
WARNING: bison-3.3.2-r0 do_cve_check: Found unpatched CVE (CVE-2020-14150), for more information check /home/build/work/emlinux/latest-d
ev/build/tmp-glibc/work/aarch64-emlinux-linux/bison/3.3.2-r0/temp/cve.log  
>>> snip <<<
Image CVE report stored in: /home/build/work/emlinux/latest-dev/build/tmp-glibc/deploy/images/qemuarm64/core-image-minimal-qemuarm64-20250401010300.rootfs.cve
NOTE: Tasks Summary: Attempted 3366 tasks of which 2900 didn't need to be rerun and all succeeded.

Summary: There were 50 WARNING messages shown.
Summary: There was 1 ERROR message shown, returning a non-zero exit code.
```