### PR TITLE
Update kernel to v4.19.325-cip119

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "897293ec51a382f6f3534a971e06a3440c7c92ca"
+LINUX_GIT_SRCREV ?= "c63e0d34ca9af8eb01e494e06579a11141a23715"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip118"
+LINUX_CIP_VERSION ??= "v4.19.325-cip119"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip119

This pull request update the kernel to the following cip versions:
v4.19.325-cip119 with hash tag c63e0d34ca9af8eb01e494e06579a11141a23715
