### PR TITLE
Improve emlinux-image-compact feature

### DIFF
--- a/classes/emlinux-compact.bbclass
+++ b/classes/emlinux-compact.bbclass
@@ -29,6 +29,12 @@ def create_replace_script(d):
     user_specified_install_pkgs = image_preinstall + image_install
     pinned_pkgs = []
 
+    if d.getVar("EMLINUX_IMAGE_COMPACT_USE_SYSTEMD") == "1":
+        d.setVar("EMLINUX_COMPACT_IMAGE_REMOVE_UTIL_LINUX", "")
+        d.setVar("EMLINUX_COMPACT_IMAGE_REMOVE_MOUNT", "")
+        d.setVar("EMLINUX_COMPACT_IMAGE_REMOVE_PAM", "")
+        d.setVar("EMLINUX_COMPACT_IMAGE_REMOVE_LIBGPG_ERROR", "")
+
     remove_candidate = d.getVar("EMLINUX_COMPACT_IMAGE_REMOVE_PAKCAGES").strip().split()
     remove_candidate_new = []
 
@@ -94,8 +100,10 @@ replace_packages() {
     sudo -E chroot "${ROOTFSDIR}" /bin/dash <<EOL
 export PATH=${EMLINUX_COMPACT_IMAGE_BUSYBOX_TMP_PATH}:${PATH}
 
-    # Remove systemd packages 
-    dpkg -P --force-all systemd libsystemd0 libsystemd-shared
+    # Remove systemd packages
+    if [ "${EMLINUX_IMAGE_COMPACT_USE_SYSTEMD}" != "1" ]; then
+        dpkg -P --force-all systemd libsystemd0 libsystemd-shared
+    fi
 
 busybox cp -a /${EMLINUX_IMAGE_COMPACT_BUSYBOX_TMP_DIR}/bin/* /bin/ || true
 busybox cp -a /${EMLINUX_IMAGE_COMPACT_BUSYBOX_TMP_DIR}/sbin/* /sbin/ || true
@@ -115,15 +123,17 @@ EOL
         dpkg -P --force-all ${EMLINUX_COMPACT_IMAGE_REMOVE_PERL}
 EOL
     fi
-       
-    # Install AMA0 setting to inittab.d/
-    sudo mkdir ${ROOTFSDIR}/etc/inittab.d
-    sudo sh -c "echo 'AMA0:12345:respawn:/sbin/getty 115200 ttyAMA0' >> ${ROOTFSDIR}/etc/inittab.d/ama0.tab"
-    sudo sh -c "echo 'S0:12345:respawn:/sbin/getty 115200 ttyS0' >> ${ROOTFSDIR}/etc/inittab.d/ttyS0.tab"
-    sudo sh -c "echo 'S1:12345:respawn:/sbin/getty 115200 ttyS1' >> ${ROOTFSDIR}/etc/inittab.d/ttyS1.tab"
-    # Comment out following line added by isar/meta/conf/distro/debian-configscript.sh
-    sudo sh -c "sed -i 's;^T0:23:respawn:/sbin/getty;#T0:23:respawn:/sbin/getty;' ${ROOTFSDIR}/etc/inittab"
-    sudo sh -c "sed -i 's;--noclear;;g' ${ROOTFSDIR}/etc/inittab"
+
+    if [ "${EMLINUX_IMAGE_COMPACT_USE_SYSTEMD}" != "1" ]; then
+        # Install AMA0 setting to inittab.d/
+        sudo mkdir ${ROOTFSDIR}/etc/inittab.d
+        sudo sh -c "echo 'AMA0:12345:respawn:/sbin/getty 115200 ttyAMA0' >> ${ROOTFSDIR}/etc/inittab.d/ama0.tab"
+        sudo sh -c "echo 'S0:12345:respawn:/sbin/getty 115200 ttyS0' >> ${ROOTFSDIR}/etc/inittab.d/ttyS0.tab"
+        sudo sh -c "echo 'S1:12345:respawn:/sbin/getty 115200 ttyS1' >> ${ROOTFSDIR}/etc/inittab.d/ttyS1.tab"
+        # Comment out following line added by isar/meta/conf/distro/debian-configscript.sh
+        sudo sh -c "sed -i 's;^T0:23:respawn:/sbin/getty;#T0:23:respawn:/sbin/getty;' ${ROOTFSDIR}/etc/inittab"
+        sudo sh -c "sed -i 's;--noclear;;g' ${ROOTFSDIR}/etc/inittab"
+    fi
 
     if [ "${EMLINUX_IMAGE_COMPACT_REMOVE_BOOT_DIR}" = "1" ]; then
       sudo -E chroot "${ROOTFSDIR}" /bin/busybox sh <<EOL

--- a/recipes-core/emlinux-customization/emlinux-customization.bb
+++ b/recipes-core/emlinux-customization/emlinux-customization.bb
@@ -20,3 +20,10 @@ SRC_URI = " \
     file://postinst \
 "
 
+do_install[cleandirs] += "${D}/etc/profile.d"
+do_install:append() {
+    if [ -n "${EMLINUX_ENVIRONMENT_VARIABLE_PS1}" ]; then
+        echo "PS1=\"${EMLINUX_ENVIRONMENT_VARIABLE_PS1}\"" > "${D}/etc/profile.d/ps1.sh"
+    fi
+}
+

--- a/recipes-core/images/emlinux-image-compact.bb
+++ b/recipes-core/images/emlinux-image-compact.bb
@@ -44,9 +44,7 @@ EMLINUX_SYSVINIT_INSTALL_PACKAGE = "\
   busybox-syslogd \
 "
 
-IMAGE_INSTALL:append = "\
-  ${EMLINUX_SYSVINIT_INSTALL_PACKAGE} \
-"
+IMAGE_INSTALL:append = "${@oe.utils.conditional('EMLINUX_IMAGE_COMPACT_USE_SYSTEMD', '1', '', ' ${EMLINUX_SYSVINIT_INSTALL_PACKAGE}', d)}"
 
 IMAGE_INSTALL:append = "\
   busybox \


### PR DESCRIPTION
This PR contains two commits to improve emlinux-image-compact feature.

# Support systemd as init system

Set following line to conf/local.conf changes systemd as default init program.

```
EMLINUX_IMAGE_COMPACT_USE_SYSTEMD="1"
```

Following table shows difference of storage usage compare to emlinux-image-compact with sysvinit and emlinux-image-compact with systemd.

| init system|default|Enable all EMLINUX_IMAGE_COMPACT_REMOVE_* options|
|---|---|---|
|sysvinit|242.9M|107.0M|
|systemd|271.3M|131.9M|

Abobe table shows systemd version increase around 30MB than sysvinit version.
 
# Add PS1 customization feature

This patch added to customize PS1 environment variable feature. When user defines PS1 string in the EMLINUX_ENVIRONMENT_VARIABLE_PS1 variable, create /etc/profile.d/ps1.sh to override default PS1 string.
    
To use this feature add following line in conf/local.conf 

```
EMLINUX_ENVIRONMENT_VARIABLE_PS1="PS1 string "
 ```
 
For example, show user name and directory.

```    
EMLINUX_ENVIRONMENT_VARIABLE_PS1="\\u@:\\w# "
```    

In the PS1 string, escaping "\" is required.


# Test result

## systemd support

Default build emlinx-image-compact with systemd.

```
EMLinux 3.3 EMLinux3 ttyAMA0
EMLinux3 login: root
Password: 

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.


BusyBox v1.35.0 (Debian 1:1.35.0-4) built-in shell (ash)
Enter 'help' for a list of built-in commands.

root@EMLinux3:~# ls -la /sbin/init
lrwxrwxrwx    1 root     root            20 Mar  4  2024 /sbin/init -> /lib/systemd/systemd
root@EMLinux3:~# df -h
Filesystem                Size      Used Available Use% Mounted on
udev                      3.9G         0      3.9G   0% /dev
tmpfs                   794.0M    484.0K    793.5M   0% /run
/dev/vda                350.9M    275.7M     52.0M  84% /
tmpfs                     3.9G         0      3.9G   0% /dev/shm
tmpfs                     5.0M         0      5.0M   0% /run/lock
```

Enable all EMLINUX_IMAGE_COMPACT_REMOVE_* options emlinux-image-compact with sytemd.

```
EMLinux 3.3 EMLinux3 ttyAMA0
EMLinux3 login: root 
Password: 

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.


BusyBox v1.35.0 (Debian 1:1.35.0-4) built-in shell (ash)
Enter 'help' for a list of built-in commands.

root@EMLinux3:~# ls -la /sbin/init
lrwxrwxrwx    1 root     root            20 Mar  4  2024 /sbin/init -> /lib/systemd/systemd
root@EMLinux3:~# df -h
Filesystem                Size      Used Available Use% Mounted on
udev                      3.9G         0      3.9G   0% /dev
tmpfs                   794.0M    488.0K    793.5M   0% /run
/dev/vda                214.1M    131.9M     66.5M  66% /
tmpfs                     3.9G         0      3.9G   0% /dev/shm
tmpfs                     5.0M         0      5.0M   0% /run/lock
```


## PS1 setting

emlinux-image-base default

```
EMLinux 3.3 EMLinux3 ttyAMA0
EMLinux3 login: root
Password: 
Linux EMLinux3 6.1.132-cip40 #1 SMP PREEMPT Thu, 01 Jan 1970 01:00:00 +0000 aarch64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
root@EMLinux3:~# 
```

emlinux-image-base with EMLINUX_ENVIRONMENT_VARIABLE_PS1

```
EMLinux 3.3 EMLinux3 ttyAMA0
EMLinux3 login: root
Password: 
Linux EMLinux3 6.1.132-cip40 #1 SMP PREEMPT Thu, 01 Jan 1970 01:00:00 +0000 aarch64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
root@:~# 
```

emlinux-image-compact default

```
EMLinux 3.3 EMLinux3 /dev/ttyAMA0
EMLinux3 login: root
Password: 

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.


BusyBox v1.35.0 (Debian 1:1.35.0-4) built-in shell (ash)
Enter 'help' for a list of built-in commands.

# 
```

emlinux-image-compact with env

```
EMLinux 3.3 EMLinux3 /dev/ttyAMA0
EMLinux3 login: root
Password: 

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.


BusyBox v1.35.0 (Debian 1:1.35.0-4) built-in shell (ash)
Enter 'help' for a list of built-in commands.

root@:~# 
```
