### PR TITLE
Update kernel to v5.10.236-cip59

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "8d46dd408e190ac3aa377d4136d2beebc37c7d46"
-LINUX_CVE_VERSION ??= "5.10.235"
-LINUX_CIP_VERSION ?= "v5.10.235-cip58"
+LINUX_GIT_SRCREV ?= "dd908a8bc2a5540570d8e47f852d108d7e31f56d"
+LINUX_CVE_VERSION ??= "5.10.236"
+LINUX_CIP_VERSION ?= "v5.10.236-cip59"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.236-cip59

This pull request update the kernel to the following cip versions:
v5.10.236-cip59 with hash tag dd908a8bc2a5540570d8e47f852d108d7e31f56d
