### PR TITLE
Update kernel to v6.1.134-cip41

### DIFF
--- a/recipes-kernel/linux/linux-cip_git.bb
+++ b/recipes-kernel/linux/linux-cip_git.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
 
 require recipes-kernel/linux/linux-custom.inc
 
-LINUX_CIP_VERSION = "v6.1.132-cip40"
-PV = "6.1.132-cip40"
+LINUX_CIP_VERSION = "v6.1.134-cip41"
+PV = "6.1.134-cip41"
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip;destsuffix=${P};protocol=https \
 "
@@ -26,6 +26,6 @@ SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
-SRCREV = "e423d82c34b97a74229e4c139d8bafa422a086f8"
+SRCREV = "38336ea2d1beb9af557adcc91b04e82478f539bc"
 
 KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.134-cip41

This pull request update the kernel to the following cip versions:
v6.1.134-cip41 with hash tag 38336ea2d1beb9af557adcc91b04e82478f539bc
