### PR TITLE
emlinux-image-compact: Restore apt.conf.d directory

### DIFF
--- a/classes/emlinux-compact.bbclass
+++ b/classes/emlinux-compact.bbclass
@@ -150,7 +150,8 @@ EOL
         linuxdir=$(find "${ROOTFSDIR}/usr/lib" -type d -a -name 'linux-image*')
         sudo rm -fr "${linuxdir}"
     fi
-    
+ 
+    sudo mkdir -p "${ROOTFSDIR}/etc/apt/sources.list.d"
     sudo rm -fr "${ROOTFSDIR}/${EMLINUX_IMAGE_COMPACT_WORK_DIR}"
 }
 


### PR DESCRIPTION
This commit added a kind of workaround to fix following error in do_rootfs_finalize task.

```
ERROR: emlinux-image-compact-1.0-r0 do_rootfs_finalize: ExecutionError('/home/build/work/build/tmp/work/emlinux-bookworm-amd64/emlinux-image-compact-qemu-amd64/1.0-r0/temp/run.do_rootfs_finalize.38826', 1, None, None)
ERROR: Logfile of failure stored in:
/home/build/work/build/tmp/work/emlinux-bookworm-amd64/emlinux-image-compact-qemu-amd64/1.0-r0/temp/log.do_rootfs_finalize.38826 Log data follows:
| DEBUG: Executing shell function do_rootfs_finalize | find:
'/home/build/work/build/tmp/work/emlinux-bookworm-amd64/emlinux-image-compact-qemu-amd64/1.0-r0/rootfs/etc/apt/sources.list.d/': No such file or directory
| WARNING: exit code 1 from a shell command.
ERROR: Task
(/home/build/work/build/../repos/meta-emlinux/recipes-core/images/emlinux-image-compact.bb:do_rootfs_finalize) failed with exit code '1'
NOTE: Tasks Summary: Attempted 88 tasks of which 38 didn't need to be rerun and 1 failed.
```

It seems as if do_rootfs_finalize task was updated by 1e33b12 ("image: Account for differences with mmdebstrap") that causes above error.

# Test

Build emlinux-image-compact with this fix succeeded without any warnings.

```
build@6870925bd6e3:~/work/build$ bitbake emlinux-image-compact                                              
Loading cache: 100% |                                                                       | ETA:  --:--:--
Loaded 0 entries from dependency cache.                                                                     
Parsing recipes: 100% |######################################################################| Time: 0:00:01
Parsing of 616 .bb files complete (0 cached, 616 parsed). 848 targets, 5 skipped, 0 masked, 0 errors.       
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 9 Local 0 Mirrors 0 Missed 9 Current 0 (0% match, 0% complete)#       | ETA:  0:00:00
Initialising tasks: 100% |###################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 95 tasks of which 0 didn't need to be rerun and all succeeded.
```