### PR TITLE
Update kernel to v4.19.325-cip120

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "c63e0d34ca9af8eb01e494e06579a11141a23715"
+LINUX_GIT_SRCREV ?= "33b79fc4625daef9e71c91db90a0808d2bc1ae23"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip119"
+LINUX_CIP_VERSION ??= "v4.19.325-cip120"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip120

This pull request update the kernel to the following cip versions:
v4.19.325-cip120 with hash tag 33b79fc4625daef9e71c91db90a0808d2bc1ae23
