### PR TITLE
recipes-core/cve-update: Add error handling for invalid CVE_DB_UPDATE_INTERVAL

### DIFF
--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -106,7 +106,10 @@ python do_populate_cve_db() {
     # Allow the user to force-update
     try:
         import time
-        update_interval = int(d.getVar("CVE_DB_UPDATE_INTERVAL"))
+        try:
+            update_interval = int(d.getVar("CVE_DB_UPDATE_INTERVAL"))
+        except ValueError:
+            bb.fatal("CVE_DB_UPDATE_INTERVAL is not a numeric value. '%s'" % d.getVar("CVE_DB_UPDATE_INTERVAL"))
         if update_interval < 0:
             bb.note("CVE database update skipped")
             return


### PR DESCRIPTION
# Purpose of pull request

If an invalid value is specified for CVE_DB_UPDATE_INTERVAL, bitbake immediately exit with bb.fatal().

# Test
## How to test
1. local.conf setting
   Add the following to local.conf.
   ```
   DISTRO = "emlinux"
   MACHINE = "qemuarm64"
   CVE_DB_UPDATE_INTERVAL = " "
   INHERIT += " cve-check"
   ```

2. Build linux-base and check log
   ```
   bitbake bash -c cve_check
   ```

## Test results
No backtrace is output.  
The ERROR message outputs the CVE_DB_UPDATE_INTERVAL value and bitbake exits.
```
build$ bitbake bash -c cve_check
Loading cache: 100% |###################################################################################################| Time: 0:00:00
Loaded 2382 entries from dependency cache.
Parsing recipes: 100% |#################################################################################################| Time: 0:00:00
Parsing of 1360 .bb files complete (1359 cached, 1 parsed). 2382 targets, 79 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:0ac2e65099342d0de5868db4032047f663aa65c4"
meta-debian-extended = "HEAD:b855e299476b5a56cd05e9223271c30effafa4e8"
meta-emlinux         = "add-error-handling-of-update-interval:97397e8e211c2b478faaca5e43708fd934286f5f"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
ERROR: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: CVE_DB_UPDATE_INTERVAL is not a numeric value. ' '
ERROR: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: 
ERROR: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Function failed: do_populate_cve_db
ERROR: Logfile of failure stored in: <PATH-TO>/build/tmp-glibc/work/x86_64-linux/cve-update-nvd2-native/1.0-r0/temp/log.do_populate_cve_db.426
ERROR: Task (<PATH-TO>/build/../repos/meta-emlinux/recipes-core/cve-update/cve-update-nvd2-native.bb:do_populate_cve_db) failed with exit code '1'
NOTE: Tasks Summary: Attempted 1 tasks of which 0 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  <PATH-TO>/build/../repos/meta-emlinux/recipes-core/cve-update/cve-update-nvd2-native.bb:do_populate_cve_db
Summary: There were 3 ERROR messages shown, returning a non-zero exit code.
```

## Before this PR results
Before this PR, the following error occurred:
```
build$ bitbake bash -c cve_check
Parsing recipes: 100% |#################################################################################################| Time: 0:00:05
Parsing of 1360 .bb files complete (0 cached, 1360 parsed). 2382 targets, 79 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:0ac2e65099342d0de5868db4032047f663aa65c4"
meta-debian-extended = "HEAD:b855e299476b5a56cd05e9223271c30effafa4e8"
meta-emlinux         = "HEAD:80a82b6edf23dc9bef95416f5d69e5f12b4d4769"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
ERROR: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Error executing a python function in exec_python_func() autogenerated:

The stack trace of python calls that resulted in this exception/failure was:
File: 'exec_python_func() autogenerated', lineno: 2, function: <module>
     0001:
 *** 0002:do_populate_cve_db(d)
     0003:
File: '<PATH-TO>/build/../repos/meta-emlinux/recipes-core/cve-update/cve-update-nvd2-native.bb', lineno: 109, function: do_populate_cve_db
     0105:    # The NVD database changes once a day, so no need to update more frequently
     0106:    # Allow the user to force-update
     0107:    try:
     0108:        import time
 *** 0109:        update_interval = int(d.getVar("CVE_DB_UPDATE_INTERVAL"))
     0110:        if update_interval < 0:
     0111:            bb.note("CVE database update skipped")
     0112:            return
     0113:        elif d.getVar("CVE_DB_PREDOWNLOAD") == "1":
Exception: ValueError: invalid literal for int() with base 10: ' '

ERROR: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: invalid literal for int() with base 10: ' '
ERROR: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Function failed: do_populate_cve_db
ERROR: Logfile of failure stored in: <PATH-TO>/build/tmp-glibc/work/x86_64-linux/cve-update-nvd2-native/1.0-r0/temp/log.do_populate_cve_db.165
ERROR: Task (<PATH-TO>/build/../repos/meta-emlinux/recipes-core/cve-update/cve-update-nvd2-native.bb:do_populate_cve_db) failed with exit code '1'
NOTE: Tasks Summary: Attempted 1 tasks of which 0 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  <PATH-TO>/build/../repos/meta-emlinux/recipes-core/cve-update/cve-update-nvd2-native.bb:do_populate_cve_db
Summary: There were 3 ERROR messages shown, returning a non-zero exit code.
```