### PR TITLE
Update kernel to v5.10.237-cip60

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "dd908a8bc2a5540570d8e47f852d108d7e31f56d"
-LINUX_CVE_VERSION ??= "5.10.236"
-LINUX_CIP_VERSION ?= "v5.10.236-cip59"
+LINUX_GIT_SRCREV ?= "f32dc72d4e2a5cadfdfca58f84404d51cae038a0"
+LINUX_CVE_VERSION ??= "5.10.237"
+LINUX_CIP_VERSION ?= "v5.10.237-cip60"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.237-cip60

This pull request update the kernel to the following cip versions:
v5.10.237-cip60 with hash tag f32dc72d4e2a5cadfdfca58f84404d51cae038a0
