### PR TITLE
Add sample for go and rust project

### DIFF
--- a/doc/samples/recipes-sample/go-hello-world/files/debian/control.tmpl
+++ b/doc/samples/recipes-sample/go-hello-world/files/debian/control.tmpl
@@ -1,0 +1,13 @@
+Source: ${PN}
+Section: golang
+Priority: optional
+Standards-Version: ${PV}
+Build-Depends: debhelper-compat (=${DEBIAN_COMPAT}), ${DEBIAN_BUILD_DEPENDS}
+Maintainer: ${MAINTAINER}
+XS-Go-Import-Path: helloworld
+
+Package: ${PN}
+Architecture: ${DISTRO_ARCH}
+Depends: ${misc:Depends},
+         ${shlibs:Depends}
+Description: Hello World for Golang (program)

--- a/doc/samples/recipes-sample/go-hello-world/files/debian/rules.tmpl
+++ b/doc/samples/recipes-sample/go-hello-world/files/debian/rules.tmpl
@@ -1,0 +1,16 @@
+#!/usr/bin/make -f
+
+# See debhelper(7) (uncomment to enable)
+export DH_VERBOSE = 1
+export GOOS = linux
+export GOARCH = ${DISTRO_ARCH}
+
+%:
+	dh $@ --builddirectory=_build --buildsystem=golang --with=golang
+
+override_dh_auto_install:
+	## FIXME: dh-golang's dh_auto_build installs binaries to ${GOPATH}/bin, however
+	#         dh_auto_install expects binaries to exist in ${GOPATH}/bin/${GOOS}_${GOARCH}.
+	rsync -a --mkpath --remove-source-files _build/bin/ _build/bin/${GOOS}_${GOARCH}/
+
+	dh_auto_install -- --no-source

--- a/doc/samples/recipes-sample/go-hello-world/go-hello-world_4.6.0.bb.sample
+++ b/doc/samples/recipes-sample/go-hello-world/go-hello-world_4.6.0.bb.sample
@@ -1,0 +1,37 @@
+#
+# An example for building go project
+#
+# Copyright (c) Cyberturst Japan Co., Ltd. 2025
+#
+# Authors:
+#  Daisuke Yamane <daisuke.yamane@miraclelinux.com>
+#
+# SPDX-License-Identifier: MIT
+#
+
+inherit dpkg
+
+DEBIAN_BUILD_DEPENDS += "dh-golang, golang-any, rsync"
+
+TEMPLATE_FILES = "debian/rules.tmpl debian/control.tmpl"
+TEMPLATE_VARS += "MACHINE DEBIAN_BUILD_DEPENDS DESCRIPTION BOARD_TARGETS RCWDIR RCW_FOLDER RCWQSPI RCWSD RCW_SUFFIX DEPLOYDIR BOOTTYPE CHASISTYPE BLD_OPT PLATFORM EXTRA_OEMAKE COMBINED_FEATURES DISTRO_FEATURES　MAINTAINER BUILDDIR DISTRO_ARCH DEBIAN_COMPAT"
+
+SRC_URI = "\
+    git://github.com/go-training/helloworld.git;protocol=https;branch=master \
+    file://debian/ \
+    "
+SRCREV = "ba5f4379d78b0dbf4f58b0aec7af9bb7f645fa2e"
+
+DESCRIPTION = "An example for building go-lang project"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f37338b31c69eb5f0aae2fc8f49350f2"
+
+MAINTAINER = "Daisuke Yamane <daisuke.yamane@miraclelinux.com>"
+
+S = "${WORKDIR}/git"
+
+do_prepare_build() {
+    cp -r ${WORKDIR}/debian ${S}/
+
+    deb_add_changelog
+}

--- a/doc/samples/recipes-sample/rust-hello-world/files/debian/cargo-checksum.json
+++ b/doc/samples/recipes-sample/rust-hello-world/files/debian/cargo-checksum.json
@@ -1,0 +1,2 @@
+{"package":"Could not get crate checksum","files":{}}
+

--- a/doc/samples/recipes-sample/rust-hello-world/files/debian/control.tmpl
+++ b/doc/samples/recipes-sample/rust-hello-world/files/debian/control.tmpl
@@ -1,0 +1,10 @@
+Source: ${PN}
+Section: base
+Priority: optional
+Standards-Version: ${PV}
+Build-Depends: debhelper-compat (=${DEBIAN_COMPAT}), ${DEBIAN_BUILD_DEPENDS}
+Maintainer: ${MAINTAINER}
+
+Package: ${PN}
+Architecture: ${DISTRO_ARCH}
+Description: a simple example rust application which uses cargo

--- a/doc/samples/recipes-sample/rust-hello-world/files/debian/rules.tmpl
+++ b/doc/samples/recipes-sample/rust-hello-world/files/debian/rules.tmpl
@@ -1,0 +1,9 @@
+#!/usr/bin/make -f
+
+# See debhelper(7) (uncomment to enable)
+export DH_VERBOSE = 1
+export DEB_BUILD_OPTIONS="nocheck"
+
+%:
+	dh $@ --buildsystem cargo
+

--- a/doc/samples/recipes-sample/rust-hello-world/rust-hello-world_0.1.0.bb.sample
+++ b/doc/samples/recipes-sample/rust-hello-world/rust-hello-world_0.1.0.bb.sample
@@ -1,0 +1,37 @@
+#
+# An example for building rust project
+#
+# Copyright (c) Cyberturst Japan Co., Ltd. 2025
+#
+# Authors:
+#  Daisuke Yamane <daisuke.yamane@miraclelinux.com>
+#
+# SPDX-License-Identifier: MIT
+#
+
+inherit dpkg
+
+DEBIAN_BUILD_DEPENDS += "dh-cargo, debcargo, libstd-rust-dev"
+
+TEMPLATE_FILES = "debian/rules.tmpl debian/control.tmpl"
+TEMPLATE_VARS += "MACHINE DEBIAN_BUILD_DEPENDS DESCRIPTION BOARD_TARGETS RCWDIR RCW_FOLDER RCWQSPI RCWSD RCW_SUFFIX DEPLOYDIR BOOTTYPE CHASISTYPE BLD_OPT PLATFORM EXTRA_OEMAKE COMBINED_FEATURES DISTRO_FEATURES　MAINTAINER DEBIAN_COMPAT"
+
+SRC_URI = "\
+    git://github.com/meta-rust/rust-hello-world.git;protocol=https;branch=master \
+    file://debian/ \
+    "
+SRCREV = "e0fa23f1a3cb1eb1407165bd2fc36d2f6e6ad728"
+
+DESCRIPTION = "An example for building rust project"
+LICENSE = "MIT | Apache-2.0"
+LIC_FILES_CHKSUM="file://COPYRIGHT;md5=e6b2207ac3740d2d01141c49208c2147"
+
+MAINTAINER = "Daisuke Yamane <daisuke.yamane@miraclelinux.com>"
+
+S = "${WORKDIR}/git"
+
+do_prepare_build() {
+    cp -r ${WORKDIR}/debian ${S}/
+
+    deb_add_changelog
+}


### PR DESCRIPTION
# Description
This recipe is an example for building rust and golang project on isar

# How to test

1. enable recipe
```
$: cd meta-emlinux
$: mv doc/samples/recipes-sample .
$: mv recipes-sample/go-hello-world/go-hello-world_4.6.0.bb{.sample,} 
$: mv recipes-sample/rust-hello-world/rust-hello-world_0.1.0.bb{.sample,}
```

2. build

```
$: . setup-emlinux
$: cat << EOF >> conf/local.conf
MACHINE = "qemu-arm64"
IMAGE_INSTALL:append = " go-hello-world rust-hello-world"
EOF
$: bitbake emlinux-image-base
```

3. run go-hello-world and rust-hello-world

```
$: qemu-system-aarch64 \
-device virtio-net-device,netdev=net0,mac=52:54:00:12:35:02 \
-netdev user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::2323-:23,tftp=./tmp/deploy/images/qemuarm64 \
-drive id=disk0,file=./tmp/deploy/images/qemu-arm64/emlinux-image-base-emlinux-bookworm-qemu-arm64.ext4,if=none,format=raw \
-device virtio-blk-device,drive=disk0 -device VGA,edid=on \
-device qemu-xhci \
-device usb-tablet \
-device usb-kbd \
-object rng-random,filename=/dev/urandom,id=rng0 \
-device virtio-rng-pci,rng=rng0 \
-nographic \
-machine virt \
-cpu cortex-a57 \
-m 512 \
-serial mon:stdio \
-serial null \
-kernel ./tmp/deploy/images/qemu-arm64/emlinux-image-base-emlinux-bookworm-qemu-arm64-vmlinux \
-initrd ./tmp/deploy/images/qemu-arm64/emlinux-image-base-emlinux-bookworm-qemu-arm64-initrd.img \
-append 'root=/dev/vda rw highres=off console=ttyS0 mem=512M ip=dhcp console=ttyAMA0 '

...<snip>...
root@EMLinux3:~# helloworld
Hello World!!
root@EMLinux3:~# rust-hello-world
Hello, world!
```