### PR TITLE
Update kernel to v6.1.134-cip41-rt22

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_git.bb
+++ b/recipes-kernel/linux/linux-cip-rt_git.bb
@@ -1,0 +1,28 @@
+#
+# EMLinux kernel recipe
+#
+# Copyright (c) Cybertrust Japan Co., Ltd.
+#
+# Authors:
+#  Hirotaka Motai <hirotaka.motai@miraclelinux.com>
+#
+# SPDX-License-Identifier: MIT
+#
+FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files:"
+
+require recipes-kernel/linux/linux-custom.inc
+
+LINUX_CIP_VERSION = "v6.1.134-cip41-rt22"
+PV = "6.1.134-cip41-rt22"
+SRC_URI += " \
+    git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=linux-6.1.y-cip-rt;destsuffix=${P};protocol=https \
+    file://preempt-rt.cfg \
+"
+
+SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
+SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
+SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
+
+SRCREV = "81a973415a42276b2c939c40c166cf42f512dd32"
+
+KBUILD_DEPENDS:append = ", zstd"


### PR DESCRIPTION
Update kernel to v6.1.134-cip41-rt22

This pull request update the kernel to the following cip versions:
v6.1.134-cip41-rt22 with hash tag 81a973415a42276b2c939c40c166cf42f512dd32
