### PR TITLE
conf/distro: Add missing version specification for kernel kbuild packages

### DIFF
--- a/conf/distro/emlinux-common.inc
+++ b/conf/distro/emlinux-common.inc
@@ -16,6 +16,9 @@ INHERIT += "sdk-installer"
 DISTRO_KERNELS ?= "linux-cip"
 KERNEL_NAME ?= "cip"
 
+PREFERRED_VERSION_linux-cip-native ?= "${PREFERRED_VERSION_linux-cip}"
+PREFERRED_VERSION_linux-cip-kbuildtarget ?= "${PREFERRED_VERSION_linux-cip}"
+
 IMAGER_INSTALL:wic = "parted \
   gdisk \
   util-linux \


### PR DESCRIPTION
According to isar-cip-core's distro configuration, we seem to have to specify all the following package verions in order to set a specific kernel version. This change is for the remaining two packages.

* linux-cip
* linux-cip-native
* linux-cip-kbuildtarget