### PR TITLE
recipes-core/images: Refactor sshd-regen-keys install process

### DIFF
--- a/recipes-core/images/emlinux-image-common.inc
+++ b/recipes-core/images/emlinux-image-common.inc
@@ -3,11 +3,4 @@
 #
 # SPDX-License-Identifier: MIT
 #
-
-python() {
-    if bb.utils.contains('IMAGE_INSTALL', 'sshd-regen-keys', True, False, d):
-        return
-    if bb.utils.contains('IMAGE_PREINSTALL', 'openssh-server', True, False, d) or \
-       bb.utils.contains('IMAGE_INSTALL', 'openssh-server', True, False, d):
-        d.appendVar('IMAGE_INSTALL', ' sshd-regen-keys')
-}
+require emlinux-image-prepare-sshd.inc

--- a/recipes-core/images/emlinux-image-compact.bb
+++ b/recipes-core/images/emlinux-image-compact.bb
@@ -5,6 +5,7 @@
 #
 # SPDX-License-Identifier: MIT
 #
+require emlinux-image-prepare-sshd.inc
 
 FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files/compact:"
 

--- a/recipes-core/images/emlinux-image-prepare-sshd.inc
+++ b/recipes-core/images/emlinux-image-prepare-sshd.inc
@@ -1,0 +1,13 @@
+#
+# Copyright (c) Cybertrust Japan Co., Ltd.
+#
+# SPDX-License-Identifier: MIT
+#
+
+python() {
+    if bb.utils.contains('IMAGE_INSTALL', 'sshd-regen-keys', True, False, d):
+        return
+    if bb.utils.contains('IMAGE_PREINSTALL', 'openssh-server', True, False, d) or \
+       bb.utils.contains('IMAGE_INSTALL', 'openssh-server', True, False, d):
+        d.appendVar('IMAGE_INSTALL', ' sshd-regen-keys')
+}


### PR DESCRIPTION
This PR contains two commits.  

# 4054e669de3edd734f5d6ef43f816bb3369abcab

By separating the process of append sshd-regen-keys package into an independent file, it becomes easier to incorporate the functionality into other file. This commit doesn't change any functionality

# d704bec125cd9e14504597e7169ca73d82bcda39

Install sshd-regen-keys package if user added openssh-server package into IMAGE_INSTALL or IMAGE_PREINSTALL variables.

# Test

## regression test for emlinux-image-base

Add following line in conf/local.conf

```
IMAGE_PREINSTALL:append = " openssh-server"
```

Then build emlinux-image-base and check .manifest file.

```
build@6f40d598fc2e:~/work/build$ grep ssh tmp/deploy/images/qemu-arm64/emlinux-image-base-emlinux-bookworm-qemu-arm64.manifest 
openssh|1:9.2p1-2+deb12u6|openssh-client|1:9.2p1-2+deb12u6
openssh|1:9.2p1-2+deb12u6|openssh-server|1:9.2p1-2+deb12u6
openssh|1:9.2p1-2+deb12u6|openssh-sftp-server|1:9.2p1-2+deb12u6
sshd-regen-keys|0.5|sshd-regen-keys|0.5
```

sshd-regen-keys package is installed.

## package install test for emlinux-image-compact

### install sshd-regen-keys to emlinux-image-compact

Add following line in conf/local.conf

```
IMAGE_PREINSTALL:append = " openssh-server"
```

Then build emlinux-image-compact and check .manifest file.

```
build@6f40d598fc2e:~/work/build$ grep ssh tmp/deploy/images/qemu-arm64/emlinux-image-compact-emlinux-bookworm-qemu-arm64.manifest 
openssh|1:9.2p1-2+deb12u6|openssh-client|1:9.2p1-2+deb12u6
openssh|1:9.2p1-2+deb12u6|openssh-server|1:9.2p1-2+deb12u6
openssh|1:9.2p1-2+deb12u6|openssh-sftp-server|1:9.2p1-2+deb12u6
sshd-regen-keys|0.5|sshd-regen-keys|0.5
```

### sshd-regen-keys is not installed if openssh-server is not in installed.

Make sure openssh-server is not listed in IMAGE_PREINSTALL and IMAGE_INSTALL variables.
Then build emlinux-image-compact.

```
build@6f40d598fc2e:~/work/build$ grep ssh tmp/deploy/images/qemu-arm64/emlinux-image-compact-emlinux-bookworm-qemu-arm64.manifest 
build@6f40d598fc2e:~/work/build$ 
```

