### PR TITLE
Update kernel to v6.12.32-cip2

### DIFF
--- a/recipes-kernel/linux/linux-cip_6.12.bb
+++ b/recipes-kernel/linux/linux-cip_6.12.bb
@@ -9,10 +9,10 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files/6.12:"
 
 require recipes-kernel/linux/linux-cip-common.inc
 
-LINUX_CIP_VERSION = "v6.12.29-cip1"
-PV = "6.12.29-cip1"
+LINUX_CIP_VERSION = "v6.12.32-cip2"
+PV = "6.12.32-cip2"
 BRANCH = "linux-6.12.y-cip"
 
 SRC_URI:append:qemu-arm64 = " file://qemu-arm64_defconfig"
 
-SRCREV = "af4062852978b4a204076202d0ff1293987354b9"
+SRCREV = "0645c849aadd029e3382b5ab5dd785b2007cd9bf"


### PR DESCRIPTION
Update kernel to v6.12.32-cip2

This pull request update the kernel to the following cip versions:
v6.12.32-cip2 with hash tag 0645c849aadd029e3382b5ab5dd785b2007cd9bf
