### PR TITLE
classes: Update emlinux-compact class task order

### DIFF
--- a/classes/emlinux-compact.bbclass
+++ b/classes/emlinux-compact.bbclass
@@ -164,5 +164,5 @@ python do_make_emlinux_compact_rootfs() {
     bb.build.exec_func("replace_packages", d)
 }
 
-addtask make_emlinux_compact_rootfs before do_rootfs_finalize after do_rootfs_postprocess
+addtask make_emlinux_compact_rootfs before do_rootfs_finalize after do_generate_initramfs
 


### PR DESCRIPTION
Since commit b091330 ("Delay creation of initrd until end of rootfs install") in ISAR, generating initramfs task order has been changed. It causes building emlinux-image-compact failure. Because some commands are missing in the image to create initramfs. Therefore setup comact image after do_generate_initramfs task.

# Test

Build emlinux-image-compact and run the image.

Building emlinux-image-compact was succeeded.

```
build@6e6c88dce0f9:~/work/build$ bitbake emlinux-image-compact                                              
Loading cache: 100% |                                                                       | ETA:  --:--:--
Loaded 0 entries from dependency cache.                                                                     
Parsing recipes: 100% |######################################################################| Time: 0:00:03
Parsing of 808 .bb files complete (0 cached, 808 parsed). 1296 targets, 6 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies 
Sstate summary: Wanted 11 Local 0 Mirrors 0 Missed 11 Current 0 (0% match, 0% complete)      | ETA:  0:00:00
Initialising tasks: 100% |###################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 102 tasks of which 0 didn't need to be rerun and all succeeded.
```

Run qemu then logged in to console successfully.

```
Synthesizing the initial hotplug events (subsystems)...done.
Synthesizing the initial hotplug events (devices)...done.
Waiting for /dev to be fully populated...done.
Starting boot logger: bootlogd[   16.782670] EXT4-fs (vda): re-mounted. Quota mode: none.

EMLinux 3.3 EMLinux3 /dev/ttyAMA0
EMLinux3 login: root
Password: 

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.


BusyBox v1.35.0 (Debian 1:1.35.0-4) built-in shell (ash)
Enter 'help' for a list of built-in commands.

# uname -a
Linux EMLinux3 6.1.141-cip43 #1 SMP PREEMPT Thu, 01 Jan 1970 01:00:00 +0000 aarch64 GNU/Linux
```
