### PR TITLE
docker: Isolate Docker images per user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
 FROM debian:bookworm
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NOWARNINGS yes
 
 ARG uid
 ARG http_proxy
@@ -40,20 +42,19 @@ RUN apt-get install --fix-missing -y \
   sqlite3 \
   umoci \
   skopeo \
-  mmdebstrap
+  mmdebstrap \
+  locales
 
-RUN useradd -m build -u $uid
+RUN useradd -s /bin/bash -m build -u $uid
 RUN gpasswd -a build sbuild
-RUN apt-get install -y sudo
 RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers
 RUN echo  "Defaults env_keep += \" http_proxy https_proxy no_proxy\"" | tee -a /etc/sudoers
 
 # Fix error "Please use a locale setting which supports utf-8."
 # See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
-RUN apt-get install -y locales
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
         echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
-        dpkg-reconfigure --frontend=noninteractive locales && \
+        dpkg-reconfigure --frontend=noninteractive locales 2>/dev/null && \
         update-locale LANG=en_US.UTF-8
 
 ENV LC_ALL en_US.UTF-8
@@ -72,12 +73,9 @@ RUN bash -c 'if test -n "$http_proxy"; then git config --global http.proxy "$htt
 RUN bash -c 'if test -n "$https_proxy"; then git config --global https.proxy "$https_proxy"; fi'
 RUN bash -c 'if test -n "$no_proxy"; then git config --global core.noproxy "$no_proxy"; fi'
 
-RUN pip install --user 'cyclonedx-python-lib>=7.3.2,<=7.5.1' --break-system-packages
-RUN pip install --user jsonschema==4.21.1 --break-system-packages
-RUN pip install --user spdx-tools==0.8.2 --break-system-packages
+RUN pip install --user 'cyclonedx-python-lib>=7.3.2,<=7.5.1' --break-system-packages --no-warn-script-location
+RUN pip install --user jsonschema==4.21.1 --break-system-packages --no-warn-script-location
+RUN pip install --user spdx-tools==0.8.2 --break-system-packages --no-warn-script-location
 
 RUN mkdir work
 WORKDIR /home/build/work
-
-CMD "/bin/bash"
-

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   emlinux3-build:
-    image: emlinux3-build
+    image: "emlinux3-build-${host_user_name}"
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -17,10 +17,14 @@ if [ $# = 1 ]; then
 fi
 
 host_user_id=$(id -u)
+host_user_name=$(id -un)
 export host_user_id="${host_user_id}"
+export host_user_name="${host_user_name}"
 
 if [ "${mode}" = "build" ]; then
   $docker_compose_cmd build --no-cache
 elif [ "${mode}" = "run" ]; then
   $docker_compose_cmd run --rm emlinux3-build
+elif [ "${mode}" = "clean" ]; then
+  docker rmi -f "emlinux3-build-${host_user_name}"
 fi

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
 
+script_dir=$(dirname $0)
 docker_compose_cmd="docker compose"
-docker compose version >/dev/null
+docker compose version > /dev/null 2>&1
 if [ $? != 0 ]; then
-    docker-compose version >/dev/null
+    docker-compose version > /dev/null 2>&1
     if [ $? != 0 ]; then
-	echo "[*] docker compose or docker-compose command is not found. Please install newer version of docker engine (or docker-compose)."
-	exit 1
+        echo "[*] docker compose or docker-compose command is not found."
+        echo "    Please install newer version of docker engine (or docker-compose)."
+        exit 1
     fi
     docker_compose_cmd="docker-compose"
 fi
 
 mode="run"
 if [ $# = 1 ]; then
-  mode="${1}"
+    mode="${1}"
 fi
 
 host_user_id=$(id -u)
@@ -21,10 +23,11 @@ host_user_name=$(id -un)
 export host_user_id="${host_user_id}"
 export host_user_name="${host_user_name}"
 
+cd ${script_dir}
 if [ "${mode}" = "build" ]; then
-  $docker_compose_cmd build --no-cache
+    ${docker_compose_cmd} build --no-cache emlinux3-build
 elif [ "${mode}" = "run" ]; then
-  $docker_compose_cmd run --rm emlinux3-build
+    ${docker_compose_cmd} run --rm emlinux3-build
 elif [ "${mode}" = "clean" ]; then
-  docker rmi -f "emlinux3-build-${host_user_name}"
+    docker rmi -f "emlinux3-build-${host_user_name}"
 fi


### PR DESCRIPTION
# Purpose of pull request

- 0d8ac57 docker: Isolate Docker images per user
  Add the username to the Docker image name, considering in case  user wants to temporarily change the Docker image.
  And add clean subcommand to remove Docker image.

- fa6c33d docker: Minor improvements
  Found minor issue in testing to works Docker container, so improve it.
    
  Improve to run.sh as follow:
  - Fix indent
  - Suppress unnecessary logs
  - Make it executable outside the current directory
    
  And, improve to Dockerfile as follow:
  - Remove duplicate package installation
  - Specify bash as the shell for the build user
  - Suppress warning output when docker build

# Test
## How to test
1. Run script to enter docker container
   ```
   repos/meta-emlinux$ docker/run.sh
   ```

2. Build to emlinux-image-base in docker container
   ```
   ~/work$ . setup-emlinux
   ~/work/build$ bitbake emlinux-image-base
   ```
   When the build is complete, exit the docker container.
   ```
   ~/work/build$ exit
   ```

3. Run script to clean up docker image
   ```
   repos/meta-emlinux$ docker image ls | grep emlinux3
   repos/meta-emlinux$ docker/run.sh clean
   repos/meta-emlinux$ docker image ls | grep emlinux3
   ```

## Test result

The Docker image name includes the username.
```
repos/meta-emlinux$ ./docker/run.sh 
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
Building emlinux3-build
Step 1/30 : FROM debian:bookworm
...<snip>...
Successfully tagged emlinux3-build-terada:latest
WARNING: Image for service emlinux3-build was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating docker_emlinux3-build_run ... done
build@641fcf4b5133:~/work$ 
```

Building emlinux-image-base was successful.
```
build@641fcf4b5133:~/work$ . setup-emlinux
### Shell environment set up for builds. ###

You can now run 'bitbake <target>'

Common targets are:
    mc:qemuarm-bookworm:isar-image-base
    mc:qemuarm64-bookworm:isar-image-base
    mc:qemuamd64-bookworm:isar-image-base
build@641fcf4b5133:~/work/build$ bitbake emlinux-image-base
build@641fcf4b5133:~/work/build$ bitbake emlinux-image-base
Loading cache: 100% |                                                                                                                                                                                                                                           | ETA:  --:--:--
Loaded 0 entries from dependency cache.
Parsing recipes: 100% |##########################################################################################################################################################################################################################################| Time: 0:00:02
Parsing of 808 .bb files complete (0 cached, 808 parsed). 1223 targets, 6 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 7 Local 0 Mirrors 0 Missed 7 Current 0 (0% match, 0% complete)####################################################################################################################################################                        | ETA:  0:00:00
Removing 3 stale sstate objects for arch amd64: 100% |###########################################################################################################################################################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 58 tasks of which 31 didn't need to be rerun and all succeeded.
build@641fcf4b5133:~/work/build$ exit
exit
```

The Docker image was deleted successfully.
```
repos/meta-emlinux$ docker image ls | grep emlinux3
emlinux3-build-terada    latest     2e0a3aaaea14   17 minutes ago   2.69GB
repos/meta-emlinux$ ./docker/run.sh clean
Untagged: emlinux3-build-terada:latest
Deleted: sha256:...<snip>...
...<snip>...
repos/meta-emlinux$ docker image ls | grep emlinux3
repos/meta-emlinux$
```
