### PR TITLE
conf/machine: raspberrypi: Remove main only repo setting from DISTRO_APT_SOURCES

### DIFF
--- a/conf/machine/raspberrypi-64.inc
+++ b/conf/machine/raspberrypi-64.inc
@@ -7,7 +7,8 @@
 DISTRO_ARCH ?= "arm64"
 
 # Raspberry Pi needs non-free-firmware repository.
-DISTRO_APT_SOURCES:append = " conf/distro/emlinux-bookworm-full.list"
+DISTRO_APT_SOURCES:remove = " conf/distro/emlinux-bookworm.list"
+DISTRO_APT_SOURCES:prepend = " conf/distro/emlinux-bookworm-full.list "
 
 # wic file settings
 IMAGE_FSTYPES ?= "wic wic.xz tar.gz"


### PR DESCRIPTION
The conf/machine/raspberrypi-64.inc includes conf/distro/emlinux-bookworm.list and the conf/distro/emlinux-bookworm-full.list contains main, contrib, non-free, and non-free-firmware which causes following error because main is duplicated.

```
W: Target Sources (main/source/Sources) is configured multiple times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:2
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:18
W: Target Packages (main/binary-arm64/Packages) is configured multiple
times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:1
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:17
W: Target Packages (main/binary-all/Packages) is configured multiple
times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:1
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:17
W: Target Sources (main/source/Sources) is configured multiple times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:10
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:22
W: Target Packages (main/binary-arm64/Packages) is configured multiple
times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:9
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:21
W: Target Packages (main/binary-all/Packages) is configured multiple
times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:9
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:21
W: Target Sources (main/source/Sources) is configured multiple times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:2
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:18
W: Target Packages (main/binary-arm64/Packages) is configured multiple
times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:1
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:17
W: Target Packages (main/binary-all/Packages) is configured multiple
times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:1
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:17
W: Target Sources (main/source/Sources) is configured multiple times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:10
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:22
W: Target Packages (main/binary-arm64/Packages) is configured multiple
times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:9
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:21
W: Target Packages (main/binary-all/Packages) is configured multiple
times in
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:9
and
/home/build/work/build/tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/tempdir/mmdebstrap.vMDTpt3hKM/etc/apt/sources.list.d/0000bootstrap.list:21
E: apt-get update -oAPT::Status-Fd=<$fd> -oDpkg::Use-Pty=false failed
```

If user uses Debian bookworm, above warnings doesn't make an error but if user uses bullseye, it makes error.
To fix the error, remove conf/distro/emlinux-bookworm.list from DISTRO_APT_SOURCES to fix duplication.

## Test

Add following line in conf/local.conf then build emlinux-image-base. 

```
MACHINE = "raspberrypi3bplus-64"
```

Build succeeded.

```
build@8dfe65b9d425:~/work/build$ cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
build@8dfe65b9d425:~/work/build$ bitbake emlinux-image-base                                                 
Loading cache: 100% |                                                                       | ETA:  --:--:--
Loaded 0 entries from dependency cache.                                                                     
Parsing recipes: 100% |######################################################################| Time: 0:00:05
Parsing of 808 .bb files complete (0 cached, 808 parsed). 1448 targets, 0 skipped, 0 masked, 0 errors. 
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies                                                         
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 12 Local 0 Mirrors 0 Missed 12 Current 0 (0% match, 0% complete)      | ETA:  0:00:00
Initialising tasks: 100% |###################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 118 tasks of which 0 didn't need to be rerun and all succeeded.
```

The warning is not logged in log file.

```
build@8dfe65b9d425:~/work/build$ grep "W: Target Packages"  tmp/work/emlinux-bookworm-arm64/isar-mmdebstrap-target/1.0-r0/temp/log.do_bootstrap | wc -l
0
```