### PR TITLE
classes: Add increment_bbappend_pr.bbclass

### DIFF
--- a/classes/increment_bbappend_pr.bbclass
+++ b/classes/increment_bbappend_pr.bbclass
@@ -1,0 +1,37 @@
+#
+# This class handles the addition of PR values by ADD_PR
+#
+# When multiple .bbappend files exist for a single package, defining PR values
+# in each .bbappend file will cause inconsistencies.
+# Therefore, the .bbappend file manages "additive values" and adds them to the
+# PR values.
+#
+# - The ADD_PR variable defines the "additive values" in the .bbappend file
+# - After modifying the .bbappend file, increment the "add value
+#
+# Example definition in .bbappend file:
+#   ```
+#   ADD_PR += "1"
+#   ```
+#
+
+python() {
+    add_pr = d.getVar("ADD_PR")
+    if add_pr is not None:
+        import re
+        if re.match("^[0-9. ]+$", add_pr) is None:
+            bb.fatal("The ADD_PR variable specified in .bbappend must be a string that can be converted to an int or float type.")
+
+        def to_float(s):
+            try:
+                return float(s)
+            except ValueError:
+                return float(0)
+
+        pr = to_float(d.getVar("PR").replace("r", ""))
+        for add in add_pr.split(' '):
+            pr += to_float(add)
+        if pr.is_integer():
+            pr = int(pr)
+        d.setVar("PR", "r%s" % pr)
+}

--- a/conf/distro/include/emlinux.inc
+++ b/conf/distro/include/emlinux.inc
@@ -79,3 +79,6 @@ BB_HASHBASE_WHITELIST_append = " DEBIAN_UNPACK_DIR"
 require conf/distro/include/yocto-uninative.inc
 require conf/distro/include/no-static-libs.inc
 INHERIT += "uninative"
+
+# In .bbappend, enable PR value addition using the ADD_PR variable.
+INHERIT += "increment_bbappend_pr"


### PR DESCRIPTION
# Purpose of pull request

This class handles the addition of PR values by ADD_PR.

When multiple .bbappend files exist for a single package, defining PR values in each .bbappend file will cause inconsistencies.
Therefore, the .bbappend file manages "additive values" and adds them to the PR values.

# Test

1. Build test
2. Check variables

## How to build test

Add the following to local.conf and build qemuarm64 image
```
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " openssh"
```
```
$ bitbake core-image-minimal
```

And check INHERIT variable.
```
$ bitbake core-image-minimal -e | grep '^INHERIT='
```

## How to check variables

To test, add the ADD_PR definition to .bbappend file on local PC and check the bitbake variables.
This test uses the openssh package.

Check variable command:
```
$ bitbake openssh -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
```

1. Test case 1

    Do not change bbappend.

2. Test case 2

   Add ADD_PR definition to openssh_debian.bbappend in meta-debian-extended.
   ./meta-debian-extended/recipes-debian/openssh/openssh_debian.bbappend:
   ``` diff
   + ADD_PR += "1”
   ```

3. Test case 3

   In addition to the conditions of test case 2, add ADD_PR definition to openssh_debian.bbappend in meta-emlinux.
   ./meta-emlinux/recipes-debian/openssh/openssh_debian.bbappend:
   ``` diff
   + ADD_PR += "2”
   ```

4. Test case 4

   Based on the conditions of test case 3, modify openssh_debian.bbappend in meta-emlinux as follows.
   ./meta-emlinux/recipes-debian/openssh/openssh_debian.bbappend:
   ``` diff
   - ADD_PR += "2”
   + ADD_PR += "0.2”
   ```

5. Test case 5

   Based on the conditions of test case 4, modify openssh_debian.bbappend in meta-emlinux as follows.
   ./meta-emlinux/recipes-debian/openssh/openssh_debian.bbappend:
   ``` diff
   - ADD_PR += "0.2”
   + ADD_PR += "r3”
   ```

## Test result

### Build test
The build was successful.
```
$ bitbake core-image-minimal
NOTE: Bitbake server didn't start within 5 seconds, waiting for 90
Parsing recipes: 100% |#################################################################################################| Time: 0:00:06
Parsing of 1359 .bb files complete (0 cached, 1359 parsed). 2379 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:1c0fc43138cd2d44f58de0176065940c8ca116d5"
meta-debian-extended = "HEAD:0b73aaced0902deff4d68e1c4e3e3dfefed2fe34"
meta-emlinux         = "add-increment_bbappend_pr.bbclass:c72a995dddbf62258b4fb5f44854bd3ffe7b55fe"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:03
Sstate summary: Wanted 894 Found 0 Missed 894 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3136 tasks of which 5 didn't need to be rerun and all succeeded.
```

Confirmed  INHERIT variable contain increment_bbappend_pr.
```
$ bitbake core-image-minimal -e | grep '^INHERIT='
INHERIT=" debian-source uninative increment_bbappend_pr package_deb buildstats image-mklibs image-prelink debian devshell sstate license remove-libtool blacklist sanity"
```

### Check variables
All test case of the results were as expected.

Test case 1:
```
$ bitbake openssh -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
PF="openssh-7.9p1-r0"
PN="openssh"
PR="r0"
```

Test case 2:
```
$ bitbake openssh -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
ADD_PR=" 1"
PF="openssh-7.9p1-r1"
PN="openssh"
PR="r1"
```

Test case 3:
```
$ bitbake openssh -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
ADD_PR=" 1 2"
PF="openssh-7.9p1-r3"
PN="openssh"
PR="r3"
```

Test case 4:
```
$ bitbake openssh -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
ADD_PR=" 1 0.2"
PF="openssh-7.9p1-r1.2"
PN="openssh"
PR="r1.2"
```

Test case 5:
```
$ bitbake openssh -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
ERROR: /home/build/work/build/../repos/meta-debian/recipes-debian/openssh/openssh_debian.bb: The ADD_PR variable specified in .bbappend must be a string that can be converted to an int or float type.
ERROR: Failed to parse recipe: /home/build/work/build/../repos/meta-debian/recipes-debian/openssh/openssh_debian.bb
```

### For reference

The manifest created by building the qemuarm64 image in test case 3 is as follows:
```
$ grep openssh ./tmp-glibc/deploy/images/qemuarm64/core-image-minimal-qemuarm64.manifest 
openssh aarch64 7.9p1-r3
openssh-keygen aarch64 7.9p1-r3
openssh-scp aarch64 7.9p1-r3
openssh-ssh aarch64 7.9p1-r3
openssh-sshd aarch64 7.9p1-r3
```