### PR TITLE
linux: Set LIBSSL_DEP as libssl3t64 for armhf trixie

### DIFF
--- a/recipes-kernel/linux/linux-cip-common.inc
+++ b/recipes-kernel/linux/linux-cip-common.inc
@@ -15,3 +15,5 @@ SRC_URI += " \
 SRC_URI[sha256sum] = "1caa1b8e24bcfdd55c3cffd8f147f3d33282312989d85c82fc1bc39b808f3d6b"
 
 KBUILD_DEPENDS:append = ", zstd"
+
+LIBSSL_DEP:armhf:trixie = "libssl3t64"


### PR DESCRIPTION
The libssl3t64 package is a replacement for the libssl3 package to prevent the Year 2038 problem. Debian trixie distributes no longer the libssl3 package but the libssl3t64 package instead for armhf.