### PR TITLE
Correct pr value of bbappend

### DIFF
--- a/recipes-debian/busybox/busybox_debian.bbappend
+++ b/recipes-debian/busybox/busybox_debian.bbappend
@@ -1,3 +1,10 @@
+# In busybox, ADD_PR was set to 2 because of the following two modifications:
+#- busybox: Add patch to fix CVE-2022-48174 (meta-debian-extended#470)
+#- busybox: remove patch to fix CVE-2022-48174 (meta-debian-extended#498)
+# As a result, the busybox_%.bbappend file in meta-debian-extended was deleted,
+# so set it on meta-emlinux.
+ADD_PR += "2"
+
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://runtest-setup-resolve-conf.patch \

--- a/recipes-debian/openssh/openssh_debian.bbappend
+++ b/recipes-debian/openssh/openssh_debian.bbappend
@@ -1,3 +1,7 @@
+# In openssh, ADD_PR was set to 1 because of the following one modification:
+# - openssh: Add CVE-2025-32728.patch (meta-emlinux#493)
+ADD_PR += "1"
+
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += " \
            file://CVE-2025-32728.patch \


### PR DESCRIPTION
# Purpose of pull request

The management of PR values by changing bbappend is managed by "additive values"    in EMLinux. (See: classes/increment_bbappend_pr.bbclass)

A recent fix did not update the PR value, so corrected it.
- 43c13b1 busybox
- 9dd8cc5 openssh

# Test
## How to test
1. Build image

   Add the following to local.conf and build qemuarm64 image.
   ```
   MACHINE = "qemuarm64"
   IMAGE_INSTALL_append = " busybox openssh"
   ```
   ```
   $ bitbake core-image-minimal
   ```

2. Check PR value with manifest file

   ```
   $ grep -e 'busybox ' -e 'openssh ' ./tmp-glibc/deploy/images/qemuarm64/core-image-minimal-qemuarm64.manifest
   ```

3. Check bitbake variable

   for busybox:
   ```
   $ bitbake busybox -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
   ```

   for openssh:
   ```
   $ bitbake openssh -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
   ```

## Test result

### Build image

The build was successful.
```
build$ bitbake core-image-minimal
Parsing recipes: 100% |#################################################################################################| Time: 0:00:06
Parsing of 1359 .bb files complete (0 cached, 1359 parsed). 2379 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:1c0fc43138cd2d44f58de0176065940c8ca116d5"
meta-debian-extended = "HEAD:0b73aaced0902deff4d68e1c4e3e3dfefed2fe34"
meta-emlinux         = "correct-PR-value-of-bbappend:9dd8cc55f782fceeee3db828499ecb0cc85402db"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 894 Found 0 Missed 894 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3136 tasks of which 5 didn't need to be rerun and all succeeded.
```

### Check PR value with manifest file

PR values are added as specified in ADD_PR.
```
build$ grep -e 'busybox ' -e 'openssh ' ./tmp-glibc/deploy/images/qemuarm64/core-image-minimal-qemuarm64.manifest
busybox aarch64 1.30.1-r2
openssh aarch64 7.9p1-r1
```

**For reference, before this PR:**
```
build$ grep -e 'busybox ' -e 'openssh ' ./tmp-glibc/deploy/images/qemuarm64/core-image-minimal-qemuarm64.manifest
busybox aarch64 1.30.1-r0
openssh aarch64 7.9p1-r0
```


### Check bitbake variable

The bitbake variable was as specified.
```
build$ bitbake busybox -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
ADD_PR=" 2"
PF="busybox-1.30.1-r2"
PN="busybox"
PR="r2"
```
```
build$ bitbake openssh -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
ADD_PR=" 1"
PF="openssh-7.9p1-r1"
PN="openssh"
PR="r1"
```

**For reference, before this PR:**
```
build$ bitbake busybox -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
PF="busybox-1.30.1-r0"
PN="busybox"
PR="r0"
```
```
build$ bitbake openssh -e | grep -e '^PN=' -e '^PR=' -e '^PF=' -e '^ADD_PR='
PF="openssh-7.9p1-r0"
PN="openssh"
PR="r0"
```
