### PR TITLE
Update kernel to v6.1.141-cip43-rt23

### DIFF
--- a/recipes-kernel/linux/linux-cip-rt_6.1.bb
+++ b/recipes-kernel/linux/linux-cip-rt_6.1.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files/6.1:"
 
 require recipes-kernel/linux/linux-cip-common.inc
 
-LINUX_CIP_VERSION = "v6.1.134-cip41-rt22"
-PV = "6.1.134-cip41-rt22"
+LINUX_CIP_VERSION = "v6.1.141-cip43-rt23"
+PV = "6.1.141-cip43-rt23"
 BRANCH = "linux-6.1.y-cip-rt"
 SRC_URI += " file://preempt-rt.cfg"
 
@@ -21,4 +21,4 @@ SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
-SRCREV = "81a973415a42276b2c939c40c166cf42f512dd32"
+SRCREV = "449a79932bbacaf5cd660398fa3bfbfa0b3626ee"


### PR DESCRIPTION
Update kernel to v6.1.141-cip43-rt23

This pull request update the kernel to the following cip versions:
v6.1.141-cip43-rt23 with hash tag 449a79932bbacaf5cd660398fa3bfbfa0b3626ee
