### PR TITLE
script: Change DEBIAN_SECURITY_UPDATE_MIRROR to archive

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -59,11 +59,9 @@ if [ -z "$TEMPLATECONF" ] && [ "${EML_BUILDDIR_SETUP_DONE}" = "false" ]; then
     # Add debian repository
     echo "DEBIAN_MIRROR=\"http://archive.debian.org/debian/pool\"" >> conf/local.conf
     # Add debian security updates repository
-    echo "DEBIAN_SECURITY_UPDATE_MIRROR=\"http://security.debian.org/debian-security/pool/updates\"" >> conf/local.conf
+    echo "DEBIAN_SECURITY_UPDATE_MIRROR=\"http://archive.debian.org/debian-security/pool/updates\"" >> conf/local.conf
     # Add ELTS updates repository
     echo "DEBIAN_ELTS_SECURITY_UPDATE_MIRROR=\"http://deb.freexian.com/extended-lts/pool\"" >> conf/local.conf
-    # Add repository mirrors
-    echo 'MIRRORS+="${DEBIAN_SECURITY_UPDATE_MIRROR}    http://archive.debian.org/debian-security/pool/updates \n"' >> conf/local.conf
 
     if [ -d "${EML_HOOKS}" ]; then
 	for hook in $(\ls ${EML_HOOKS}); do


### PR DESCRIPTION
# Purpose of pull request

The buster repository on security.debian.org will be moved to archive.debian.org, so change the URL of DEBIAN_SECURITY_UPDATE_MIRROR variable.

# Test
## How to test
1. Run setup-emlinux script

   ```
   $ source setup-emlinux
   ```

   Then, check DEBIAN_SECURITY_UPDATE_MIRROR variable in conf/local.conf.

   ```
   build$ grep -n DEBIAN_SECURITY_UPDATE_MIRROR conf/local.conf
   ```

2. Build qemuarm64 image

   Add the following to local.conf and build qemuarm64 image.
   ```
   MACHINE = "qemuarm64"
   ```

   ```
   $ bitbake core-image-minimal
   ```

3. Check package update
   Add the following to local.conf.
   ```
   DEBIAN_SOURCE_ENABLED = "1"
   DEBIAN_SRC_FORCE_REGEN = "1"
   DEBIAN_SECURITY_UPDATE_ENABLED = "1"
   ```
   And run following command.
   ```
   $ bitbake core-image-minimal -c cleanall
   ```

## Test result
### Run setup-emlinux script

Confirmed that the URL of 'DEBIAN_SECURITY_UPDATE_MIRROR' variable in local.conf is set to 'archive.debian.org'.
```
$ . setup-emlinux 
...<snip>...
build$ grep -n DEBIAN_SECURITY_UPDATE_MIRROR conf/local.conf
265:DEBIAN_SECURITY_UPDATE_MIRROR="http://archive.debian.org/debian-security/pool/updates"
```

### Build qemuarm64 image

The build was successful.
```
build$ bitbake core-image-minimal
Parsing recipes: 100% |################################################################################################| Time: 0:00:06
Parsing of 1359 .bb files complete (0 cached, 1359 parsed). 2379 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "HEAD:deb4fa66614339c0ed834b027dcfcf9e6462b930"
meta-emlinux         = "change-debian-security-updates-repository-to-archive:d628a657a228b4ff46bfee024c05ab892c165614"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |#############################################################################################| Time: 0:00:00
Sstate summary: Wanted 864 Found 0 Missed 864 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3050 tasks of which 5 didn't need to be rerun and all succeeded.
```

### Check package update

Confirmed log to fetched `http://archive.debian.org/debian-security/dists/buster/updates/main/source/Sources.gz`.
```
build$ bitbake core-image-minimal -c cleanall
WARNING: debian security update repository is enabled
WARNING: debian ELTS security update repository is enabled
Checking Debian Release ... http://deb.freexian.com/extended-lts/dists/buster-lts/Release
Fetching Debian Sources.gz ... http://deb.freexian.com/extended-lts/dists/buster-lts/main/source/Sources.gz;md5sum=200c57e6f23b5d8d784c450c07be1b6b
Parsing Debian Sources.gz ...
WARNING: Source code for package "u-boot" has been updated from "2019.01+dfsg-7" to "2019.01+dfsg-7+deb10u1"
WARNING: Source code for package "icu" has been updated from "63.1-6+deb10u3" to "63.1-6+deb10u4"
WARNING: Source code for package "clamav" has been updated from "0.103.9+dfsg-0+deb10u1" to "1.0.7+dfsg-1~deb10u1"
WARNING: Source code for package "python-tornado" has been updated from "5.1.1-4+deb10u1" to "5.1.1-4+deb10u2"
Checking Debian Release ... http://archive.debian.org/debian-security/dists/buster/updates/Release
Fetching Debian Sources.gz ... http://archive.debian.org/debian-security/dists/buster/updates/main/source/Sources.gz;md5sum=e3bb28be0cf1fb769d3c63c037fc5bf8
Parsing Debian Sources.gz ...
Checking Debian Release ... http://archive.debian.org/debian/dists/buster/Release
Fetching Debian Sources.gz ... http://archive.debian.org/debian/dists/buster/main/source/Sources.gz;md5sum=60b1a2c60363095f2871f4a056e36980
Parsing Debian Sources.gz ...
...<snip>...
```

**For reference, the logs before this PR:**
```
Checking Debian Release ... http://security.debian.org/debian-security/dists/buster/updates/Release
WARNING: Failed to check Debian Release. (HTTP Error 404: Not Found)
```