### PR TITLE
Update kernel to v6.1.145-cip44

### DIFF
--- a/recipes-kernel/linux/linux-cip_6.1.bb
+++ b/recipes-kernel/linux/linux-cip_6.1.bb
@@ -12,8 +12,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files/6.1:"
 
 require recipes-kernel/linux/linux-cip-common.inc
 
-LINUX_CIP_VERSION = "v6.1.141-cip43"
-PV = "6.1.141-cip43"
+LINUX_CIP_VERSION = "v6.1.145-cip44"
+PV = "6.1.145-cip44"
 BRANCH = "linux-6.1.y-cip"
 
 SRC_URI:append:qemu-arm64 = " file://qemu-arm64_defconfig"
@@ -23,4 +23,4 @@ SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi3bplus-64 = " file://raspberrypi3-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
-SRCREV = "63685e8e8122881a1e5eec654bf602d262b595f7"
+SRCREV = "d31d18a3a01aec488157b5c8aca68f22a8afe3ba"


### PR DESCRIPTION
Update kernel to v6.1.145-cip44

This pull request update the kernel to the following cip versions:
v6.1.145-cip44 with hash tag d31d18a3a01aec488157b5c8aca68f22a8afe3ba
