### PR TITLE
Update kernel to v5.10.239-cip62

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "65fb4abcfb5dd50e63101c206c32c3fe87733380"
-LINUX_CVE_VERSION ??= "5.10.238"
-LINUX_CIP_VERSION ?= "v5.10.238-cip61"
+LINUX_GIT_SRCREV ?= "50e86929b6d357b2419f4c84cc82c4d16e16af72"
+LINUX_CVE_VERSION ??= "5.10.239"
+LINUX_CIP_VERSION ?= "v5.10.239-cip62"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.239-cip62

This pull request update the kernel to the following cip versions:
v5.10.239-cip62 with hash tag 50e86929b6d357b2419f4c84cc82c4d16e16af72
