### PR TITLE
Update kernel to v4.19.325-cip122

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "3237eeb37d4b43b59ddbb9d45fcce28a18e43e68"
+LINUX_GIT_SRCREV ?= "019ba39c16cf7bf1e244899b97634f11923d4aa7"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip121"
+LINUX_CIP_VERSION ??= "v4.19.325-cip122"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip122

This pull request update the kernel to the following cip versions:
v4.19.325-cip122 with hash tag 019ba39c16cf7bf1e244899b97634f11923d4aa7
