### PR TITLE
Update kernel to v6.12.36-cip4

### DIFF
--- a/recipes-kernel/linux/linux-cip_6.12.bb
+++ b/recipes-kernel/linux/linux-cip_6.12.bb
@@ -9,14 +9,10 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files/6.12:"
 
 require recipes-kernel/linux/linux-cip-common.inc
 
-LINUX_CIP_VERSION = "v6.12.32-cip2"
-PV = "6.12.32-cip2"
+LINUX_CIP_VERSION = "v6.12.36-cip4"
+PV = "6.12.36-cip4"
 BRANCH = "linux-6.12.y-cip"
 
 SRC_URI:append:qemu-arm64 = " file://qemu-arm64_defconfig"
-SRC_URI:append:qemu-arm = " file://qemu-arm_defconfig"
-SRC_URI:append:qemu-amd64 = " file://qemu-amd64_defconfig"
-SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
-SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
-SRCREV = "0645c849aadd029e3382b5ab5dd785b2007cd9bf"
+SRCREV = "24cd8155efab47b262747fcae9db7404333c9312"


### PR DESCRIPTION
Update kernel to v6.12.36-cip4

This pull request update the kernel to the following cip versions:
v6.12.36-cip4 with hash tag 24cd8155efab47b262747fcae9db7404333c9312
