### PR TITLE
conf: cve_check_ignore: Add CVEs

### DIFF
--- a/conf/cve/cve_check_ignore.yml
+++ b/conf/cve/cve_check_ignore.yml
@@ -4,3 +4,7 @@
 # example.
 #linux-cip:
 #- CVE-2023-35825
+linux-cip:
+  - CVE-2016-3699
+  - CVE-2017-6264
+  - CVE-2019-14899


### PR DESCRIPTION
# Purpose

This PR adds 3 CVEs that are able to ignore.
 
CVE-2016-3699:
This CVE is not affected to mainline kernel. This bug is in downstream kernel bug[1].

CVE-2017-6264:
This CVE is not affected to mainline kernel. This bug is in 3rd party driver.

CVE-2019-14899:
This CVE is not a linux kernel bug.

1: https://github.com/mjg59/linux

# Test

Test step

1. Build emlinux-image-weston
2. Run cve-check.py
3. Check result

Before applying this PR,  above CVEs are reported as unpatched.

```
build@942a2d7efe60:~/work/build$ grep -A1 -e "CVE: CVE-2019-14899" -e "CVE: CVE-2016-3699" -e "CVE: CVE-2017-6264"  tmp/deploy/cve/emlinux-image-weston-emlinux-bookworm-qemu-arm64/text/linux-cip 
CVE: CVE-2016-3699
CVE STATUS: Unpatched
--
CVE: CVE-2017-6264
CVE STATUS: Unpatched
--
CVE: CVE-2019-14899
CVE STATUS: Unpatched
```

# Test result.

After applying this PR, CVEs are reported as ignored.

```
build@942a2d7efe60:~/work/build$ grep -A1 -e "CVE: CVE-2019-14899" -e "CVE: CVE-2016-3699" -e "CVE: CVE-2017-6264"  tmp/deploy/cve/emlinux-image-weston-emlinux-bookworm-qemu-arm64/text/linux-cip 
CVE: CVE-2016-3699
CVE STATUS: Ignored
--
CVE: CVE-2017-6264
CVE STATUS: Ignored
--
CVE: CVE-2019-14899
CVE STATUS: Ignored
```
