### PR TITLE
scripts: Fix cve-check if package is installed from different debian verson

### DIFF
--- a/scripts/cve_check.py
+++ b/scripts/cve_check.py
@@ -286,11 +286,11 @@ def is_fixed_in_upstream_version(upstream_version, debian_upstream_version, oper
     if operator == "=":
         return uver == dver
     elif operator == "<":
-        return uver < dver
+        return uver <= dver
     elif operator == "<=":
         return uver <= dver
     elif operator == ">":
-        return dver > uver
+        return dver >= uver
     elif operator == ">=":
         return dver >= uver
     return False # unknown operator
@@ -308,11 +308,11 @@ def is_affected_upstream_version(upstream_version, debian_upstream_version, oper
     if operator == "=":
         return uver == dver
     elif operator == "<":
-        return dver < uver
+        return dver <= uver
     elif operator == "<=":
         return dver <= uver
     elif operator == ">":
-        return dver > uver
+        return dver >= uver
     elif operator == ">=":
         return dver >= uver
 

--- a/scripts/cve_check.py
+++ b/scripts/cve_check.py
@@ -157,6 +157,11 @@ def create_debian_pkg_cve_info(pkgname, bin_pkgname, installed_version, debian_c
     for cveid in cve_ids:
         fixed = False
         if cveid in debian_cveinfo:
+            if not codename in debian_cveinfo[cveid]["releases"]:
+                # Package may be installed from other debian version.
+                logger.debug(f"pkg:{pkgname}: {cveid} for {codename} is not found")
+                return None
+
             dc = debian_cveinfo[cveid]["releases"][codename]
             if dc["status"] == "resolved":
                 for repo in dc["repositories"]:
@@ -207,7 +212,12 @@ def merge_cve_data(uniq_installed_pkgs, installed_pkgs_cves_by_debian_data, cve_
                 nvd_cveinfo = {}
 
         bin_pkgname = uniq_installed_pkgs[pkgname]["bin_pkgs"]
-        cveinfo[pkgname] = create_debian_pkg_cve_info(pkgname, bin_pkgname, installed_version, debian_cveinfo, nvd_cveinfo, codename)
+
+        tmpret = create_debian_pkg_cve_info(pkgname, bin_pkgname, installed_version, debian_cveinfo, nvd_cveinfo, codename)
+        if not tmpret is None:
+            cveinfo[pkgname] = tmpret
+        else:
+            cve_not_in_debian.append(pkgname)
 
     for pkgname in cve_not_in_debian:
         installed_version = uniq_installed_pkgs[pkgname]["version"]


### PR DESCRIPTION
# Purpose

This PR contains 2 commits.

# commit 7e51e3cf8022beb98a5dd6d6f92e846439bf821c

This commit fixed comparison operator.

If upstream version and debian package version is same, it returns wrong result. Ff compare same number with ">" or "<", it returns False like following output.

```
Python 3.10.12 (main, May 27 2025, 17:12:29) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 1 < 1
False
>>> 1 > 1
False
```

 So, we use ">=" and "<=" for comparison operation.

# commit 973226f1f3073a8f0dcedb645854c1976bf89c16

This commit fixed an issue that caused an error when a package was installed from a different debian version than the DISTRO.
e.g. DISTRO is emlinux-bookworm, some package is built from debian trixie.

This commit fixes following error.

```
2025-08-04 06:54:25,212:INFO: Checking CVEs ...
Traceback (most recent call last):
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line
721, in <module>
    main(parse_options())
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line
674, in main
    cves = create_cves_info(db_file, debian_cve_list,
uniq_installed_pkgs, installed_pkgs, args.debian_codename, cve_products, linux_kernel_src_dir, cip_kernel_sec_dir, kev_list)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line
508, in create_cves_info
    cves = merge_cve_data(uniq_installed_pkgs,
installed_pkgs_cves_by_debian_data, cve_not_in_debian, installed_pkgs_cves_by_nvd_data, codename)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line
210, in merge_cve_data
    cveinfo[pkgname] = create_debian_pkg_cve_info(pkgname, bin_pkgname,
installed_version, debian_cveinfo, nvd_cveinfo, codename)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/cve_check.py", line
160, in create_debian_pkg_cve_info
    dc = debian_cveinfo[cveid]["releases"][codename]
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'bookworm'
```

# Test

## Prepare test oracle.

1. Checkout  commit 74d7403
2. Set DISTRO="emlinux-bookworm" in conf/local.conf
3. Build emlinux-image-weston
4. Run cve-check
5. copy tmp/deploy/cve directory to somewhere . e.g. cve_result_orig

## Test with new commit

1. Prepare meta-emlinux with this PR's commit
2. Set DISTRO="emlinux-bookworm" in conf/local.conf
3. Apply following patch to add jetty12 package to installed packages list.

```
diff --git a/scripts/cve_check.py b/scripts/cve_check.py
index c514ab3..d04e6de 100755
--- a/scripts/cve_check.py
+++ b/scripts/cve_check.py
@@ -672,6 +672,14 @@ def main(args):
     cve_products = get_cve_products(args.extra_cve_product)
     cve_ignore_list = get_cve_ignore(args.extra_cve_check_ignore)
 
+    jetty12 = {
+        'package': 'jetty12',
+        'source': 'jetty12',
+        'upstream_version': debian.debian_support.Version('12.0.17'),
+        'version': debian.debian_support.Version('12.0.17-3')
+    }
+    installed_pkgs.append(jetty12)
+
     uniq_installed_pkgs = create_unique_package(installed_pkgs)
     linux_kernel_src_dir = os.path.abspath(bitbakeinfo["kernel_srcdir"])
     cves = create_cves_info(db_file, debian_cve_list, uniq_installed_pkgs, installed_pkgs, args.debian_codename, cve_products, linux_kernel_src_dir, cip_kernel_sec_dir, kev_list)
```

4. Prepare product file for jetty12. Create jetty.yaml file with following data

```
jetty12:
  vendor: eclipse
  product: jetty
```

5. Build emlinux-image-weston
6. Run cve-check
7. copy tmp/deploy/cve directory to somewhere.  e.g. cve_result_new

## Check diff

```
diff -Naru cve_result_orig/ cve_result_new | diffstat
```

# Test result

## Create test oracle.

```
build@50e8b8020cfe:~/work/repos/meta-emlinux$ git log --oneline  | head -n 1
74d7403 Merge pull request #516 from masami256/add_cves_to_ignore
build@50e8b8020cfe:~/work/build$ rm -fr tmp/deploy/cve/ ; cve_check.py --image emlinux-image-weston --output-format text,json --nvd-api-key <your api key> --verbose
2025-08-04 07:33:13,616:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-08-04 07:33:13,616:INFO: Last database update is in 1day so skip NVD database update
2025-08-04 07:33:13,616:INFO: Update debian CVE database
2025-08-04 07:33:13,617:INFO: Last database update is in 1day so skip Debian CVE database update
2025-08-04 07:33:13,617:INFO: Update KEV database
2025-08-04 07:33:13,617:INFO: Last database update is in 1day so skip Debian CVE database update
2025-08-04 07:33:13,617:INFO: Update cip-kernel-sec
2025-08-04 07:33:14,464:INFO: Checking CVEs ...
2025-08-04 07:34:10,222:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-weston-emlinux-bookworm-qemu-amd64
build@50e8b8020cfe:~/work/build$ mv tmp/deploy/cve cve_result_orig
```

## Test this PR

```
build@50e8b8020cfe:~/work/build$ rm -fr tmp/deploy/cve/ ; cve_check.py --image emlinux-image-weston --output-format text,json --nvd-api-key <your api key> --verbose --cve-product ./jetty.yaml 
2025-08-04 09:42:40,061:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-08-04 09:42:40,061:INFO: Last database update is in 1day so skip NVD database update
2025-08-04 09:42:40,061:INFO: Update debian CVE database
2025-08-04 09:42:40,061:INFO: Last database update is in 1day so skip Debian CVE database update
2025-08-04 09:42:40,061:INFO: Update KEV database
2025-08-04 09:42:40,061:INFO: Last database update is in 1day so skip Debian CVE database update
2025-08-04 09:42:40,061:INFO: Update cip-kernel-sec
2025-08-04 09:42:40,854:INFO: Checking CVEs ...
2025-08-04 09:43:16,542:DEBUG: pkg:jetty12: CVE-2024-13009 for bookworm is not found
2025-08-04 09:43:36,454:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-weston-emlinux-bookworm-qemu-amd64
build@50e8b8020cfe:~/work/build$ mv tmp/deploy/cve/ cve_result_new
```

## Check diff

There are only difference in jetty12 package.

```
build@50e8b8020cfe:~/work/build$  diff -Naru cve_result_orig/ cve_result_new/ | diffstat
 emlinux-image-weston-emlinux-bookworm-qemu-amd64_cve      |  560 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 emlinux-image-weston-emlinux-bookworm-qemu-amd64_cve.json |  688 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 json/jetty12_cve.json                                     |  693 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 text/jetty12                                              |  560 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 2501 insertions(+)
```

## Diff in json file

save following diff as json-diff.txt.

```
build@50e8b8020cfe:~/work/build$ diff -u ./cve_result_orig/emlinux-image-weston-emlinux-bookworm-qemu-amd64/emlinux-image-weston-emlinux-bookworm-qemu-amd64_cve.json ./cve_result_new/emlinux-image-weston-emlinux-bookworm-qemu-amd64/emlinux-image-weston-emlinux-bookworm-qemu-amd64_cve.json  | grep '"CVE":'
+                    "CVE": "CVE-2009-5045",
+                    "CVE": "CVE-2009-5046",
+                    "CVE": "CVE-2015-2080",
+                    "CVE": "CVE-2016-4800",
+                    "CVE": "CVE-2017-7656",
+                    "CVE": "CVE-2017-7657",
+                    "CVE": "CVE-2017-7658",
+                    "CVE": "CVE-2017-9735",
+                    "CVE": "CVE-2018-12536",
+                    "CVE": "CVE-2018-12538",
+                    "CVE": "CVE-2018-12545",
+                    "CVE": "CVE-2019-10241",
+                    "CVE": "CVE-2019-10246",
+                    "CVE": "CVE-2019-10247",
+                    "CVE": "CVE-2019-17632",
+                    "CVE": "CVE-2019-17638",
+                    "CVE": "CVE-2020-27216",
+                    "CVE": "CVE-2020-27218",
+                    "CVE": "CVE-2020-27223",
+                    "CVE": "CVE-2021-28163",
+                    "CVE": "CVE-2021-28164",
+                    "CVE": "CVE-2021-28165",
+                    "CVE": "CVE-2021-28169",
+                    "CVE": "CVE-2021-34428",
+                    "CVE": "CVE-2021-34429",
+                    "CVE": "CVE-2022-2047",
+                    "CVE": "CVE-2022-2048",
+                    "CVE": "CVE-2022-2191",
+                    "CVE": "CVE-2023-26048",
+                    "CVE": "CVE-2023-26049",
+                    "CVE": "CVE-2023-36478",
+                    "CVE": "CVE-2023-36479",
+                    "CVE": "CVE-2023-40167",
+                    "CVE": "CVE-2023-41900",
+                    "CVE": "CVE-2023-44487",
+                    "CVE": "CVE-2024-13009",
+                    "CVE": "CVE-2024-22201",
+                    "CVE": "CVE-2024-6762",
+                    "CVE": "CVE-2024-6763",
+                    "CVE": "CVE-2024-8184",
+                    "CVE": "CVE-2024-9823",
+                    "CVE": "CVE-2025-1948",
```

## Diff in text file

save following diff as text-diff.txt

```
build@50e8b8020cfe:~/work/build$ diff -u ./cve_result_orig/emlinux-image-weston-emlinux-bookworm-qemu-amd64/emlinux-image-weston-emlinux-bookworm-qemu-amd64_cve ./cve_result_new/emlinux-image-weston-emlinux-bookworm-qemu-amd64/emlinux-image-weston-emlinux-bookworm-qemu-amd64_cve  | grep "CVE:" 
+CVE: CVE-2009-5045
+CVE: CVE-2009-5046
+CVE: CVE-2015-2080
+CVE: CVE-2016-4800
+CVE: CVE-2017-7656
+CVE: CVE-2017-7657
+CVE: CVE-2017-7658
+CVE: CVE-2017-9735
+CVE: CVE-2018-12536
+CVE: CVE-2018-12538
+CVE: CVE-2018-12545
+CVE: CVE-2019-10241
+CVE: CVE-2019-10246
+CVE: CVE-2019-10247
+CVE: CVE-2019-17632
+CVE: CVE-2019-17638
+CVE: CVE-2020-27216
+CVE: CVE-2020-27218
+CVE: CVE-2020-27223
+CVE: CVE-2021-28163
+CVE: CVE-2021-28164
+CVE: CVE-2021-28165
+CVE: CVE-2021-28169
+CVE: CVE-2021-34428
+CVE: CVE-2021-34429
+CVE: CVE-2022-2047
+CVE: CVE-2022-2048
+CVE: CVE-2022-2191
+CVE: CVE-2023-26048
+CVE: CVE-2023-26049
+CVE: CVE-2023-36478
+CVE: CVE-2023-36479
+CVE: CVE-2023-40167
+CVE: CVE-2023-41900
+CVE: CVE-2023-44487
+CVE: CVE-2024-13009
+CVE: CVE-2024-22201
+CVE: CVE-2024-6762
+CVE: CVE-2024-6763
+CVE: CVE-2024-8184
+CVE: CVE-2024-9823
+CVE: CVE-2025-1948
```

Run following command.
```
cut -d' ' -f2 text-diff.txt | sort > text-diff2.txt
cut -d'"' -f4 json-diff.txt | sort > json-diff2.txt
```

We don't have any difference between text and json files.
```
$ diff -u json-diff2.txt text-diff2.txt | wc -l
0
```

## Check CVE info

We use text-diff2.txt to run sqlite3.

```
build@50e8b8020cfe:~/work/build$ while read id; do echo "SELECT * FROM PRODUCTS WHERE ID=\"$id\" AND PRODUCT='jetty' AND VENDOR='eclipse';" | sqlite3 ./downloads/CVE/nvd_cve_db.db ; done<text-diff2.txt  > sql_result.txt
```

Check unique number of CVEs in sql_result.txt.

```
build@50e8b8020cfe:~/work/build$ cut -f1 -d'|' sql_result.txt  | sort | uniq | wc -l
42
```

Check unique number of CVEs in text-diff2.txt.

```
build@50e8b8020cfe:~/work/build$ wc -l text-diff2.txt 
42 text-diff2.txt
```

We have same number of CVEs.

Here is complete sql log. It looks fine.

[sql_result.txt](https://github.com/user-attachments/files/21575306/sql_result.txt)

