### PR TITLE
Update kernel to v6.12.41-cip6

### DIFF
--- a/recipes-kernel/linux/linux-cip_6.12.bb
+++ b/recipes-kernel/linux/linux-cip_6.12.bb
@@ -9,8 +9,8 @@ FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files/6.12:"
 
 require recipes-kernel/linux/linux-cip-common.inc
 
-LINUX_CIP_VERSION = "v6.12.36-cip4"
-PV = "6.12.36-cip4"
+LINUX_CIP_VERSION = "v6.12.41-cip6"
+PV = "6.12.41-cip6"
 BRANCH = "linux-6.12.y-cip"
 
 SRC_URI:append:qemu-arm64 = " file://qemu-arm64_defconfig"
@@ -19,4 +19,4 @@ SRC_URI:append:qemu-amd64 = " file://qemu-amd64_defconfig"
 SRC_URI:append:generic-x86-64 = " file://generic-x86-64_defconfig"
 SRC_URI:append:raspberrypi4b-64 = " file://raspberrypi4-64_defconfig"
 
-SRCREV = "24cd8155efab47b262747fcae9db7404333c9312"
+SRCREV = "90d753ffff95206265b517c1e36880510c03c2cb"


### PR DESCRIPTION
Update kernel to v6.12.41-cip6

This pull request update the kernel to the following cip versions:
v6.12.41-cip6 with hash tag 90d753ffff95206265b517c1e36880510c03c2cb
