### PR TITLE
Add fixes-poky.bbclass and backport to fix host-user-contaminated issue

### DIFF
--- a/classes/fixes-poky.bbclass
+++ b/classes/fixes-poky.bbclass
@@ -2,3 +2,142 @@
 #
 # This class fixes Poky's bbclass bugs by overwriting functions.
 #
+
+##################################################
+# Overwrite poky/meta/classes/insane.bbclass.
+# - def package_qa_check_buildpaths
+# - python do_package_qa
+##################################################
+def package_qa_check_buildpaths(path, name, d, elf, messages):
+    """
+    Check for build paths inside target files and error if not found in the whitelist
+    """
+    # Ignore .debug files, not interesting
+    if path.find(".debug") != -1:
+        return
+
+    # Ignore symlinks
+    if os.path.islink(path):
+        return
+
+    # Ignore ipk and deb's CONTROL dir
+    if path.find(name + "/CONTROL/") != -1 or path.find(name + "/DEBIAN/") != -1:
+        return
+
+    tmpdir = bytes(d.getVar('TMPDIR'), encoding="utf-8")
+    with open(path, 'rb') as f:
+        file_content = f.read()
+        if tmpdir in file_content:
+            package_qa_add_message(messages, "buildpaths", "File %s in package contained reference to tmpdir" % package_qa_clean_path(path,d))
+
+# The PACKAGE FUNC to scan each package
+python do_package_qa () {
+    import subprocess
+    import oe.packagedata
+
+    bb.note("DO PACKAGE QA")
+
+    bb.build.exec_func("read_subpackage_metadata", d)
+
+    # Check non UTF-8 characters on recipe's metadata
+    package_qa_check_encoding(['DESCRIPTION', 'SUMMARY', 'LICENSE', 'SECTION'], 'utf-8', d)
+
+    logdir = d.getVar('T')
+    pn = d.getVar('PN')
+
+    # Check the compile log for host contamination
+    compilelog = os.path.join(logdir,"log.do_compile")
+
+    if os.path.exists(compilelog):
+        statement = "grep -e 'CROSS COMPILE Badness:' -e 'is unsafe for cross-compilation' %s > /dev/null" % compilelog
+        if subprocess.call(statement, shell=True) == 0:
+            msg = "%s: The compile log indicates that host include and/or library paths were used.\n \
+        Please check the log '%s' for more information." % (pn, compilelog)
+            package_qa_handle_error("compile-host-path", msg, d)
+
+    # Check the install log for host contamination
+    installlog = os.path.join(logdir,"log.do_install")
+
+    if os.path.exists(installlog):
+        statement = "grep -e 'CROSS COMPILE Badness:' -e 'is unsafe for cross-compilation' %s > /dev/null" % installlog
+        if subprocess.call(statement, shell=True) == 0:
+            msg = "%s: The install log indicates that host include and/or library paths were used.\n \
+        Please check the log '%s' for more information." % (pn, installlog)
+            package_qa_handle_error("install-host-path", msg, d)
+
+    # Scan the packages...
+    pkgdest = d.getVar('PKGDEST')
+    packages = set((d.getVar('PACKAGES') or '').split())
+
+    cpath = oe.cachedpath.CachedPath()
+    global pkgfiles
+    pkgfiles = {}
+    for pkg in packages:
+        pkgfiles[pkg] = []
+        for walkroot, dirs, files in cpath.walk(pkgdest + "/" + pkg):
+            for file in files:
+                pkgfiles[pkg].append(walkroot + os.sep + file)
+
+    # no packages should be scanned
+    if not packages:
+        return
+
+    import re
+    # The package name matches the [a-z0-9.+-]+ regular expression
+    pkgname_pattern = re.compile(r"^[a-z0-9.+-]+$")
+
+    taskdepdata = d.getVar("BB_TASKDEPDATA", False)
+    taskdeps = set()
+    for dep in taskdepdata:
+        taskdeps.add(taskdepdata[dep][0])
+
+    def parse_test_matrix(matrix_name):
+        testmatrix = d.getVarFlags(matrix_name) or {}
+        g = globals()
+        warnchecks = []
+        for w in (d.getVar("WARN_QA") or "").split():
+            if w in skip:
+               continue
+            if w in testmatrix and testmatrix[w] in g:
+                warnchecks.append(g[testmatrix[w]])
+
+        errorchecks = []
+        for e in (d.getVar("ERROR_QA") or "").split():
+            if e in skip:
+               continue
+            if e in testmatrix and testmatrix[e] in g:
+                errorchecks.append(g[testmatrix[e]])
+        return warnchecks, errorchecks
+
+    for package in packages:
+        skip = set((d.getVar('INSANE_SKIP') or "").split() +
+                   (d.getVar('INSANE_SKIP_' + package) or "").split())
+        if skip:
+            bb.note("Package %s skipping QA tests: %s" % (package, str(skip)))
+
+        bb.note("Checking Package: %s" % package)
+        # Check package name
+        if not pkgname_pattern.match(package):
+            package_qa_handle_error("pkgname",
+                    "%s doesn't match the [a-z0-9.+-]+ regex" % package, d)
+
+        warn_checks, error_checks = parse_test_matrix("QAPATHTEST")
+        package_qa_walk(warn_checks, error_checks, package, d)
+
+        warn_checks, error_checks = parse_test_matrix("QAPKGTEST")
+        package_qa_package(warn_checks, error_checks, package, d)
+
+        package_qa_check_rdepends(package, pkgdest, skip, taskdeps, packages, d)
+        package_qa_check_deps(package, pkgdest, d)
+
+    warn_checks, error_checks = parse_test_matrix("QARECIPETEST")
+    package_qa_recipe(warn_checks, error_checks, pn, d)
+
+    if 'libdir' in d.getVar("ALL_QA").split():
+        package_qa_check_libdir(d)
+
+    qa_sane = d.getVar("QA_SANE")
+    if not qa_sane:
+        bb.fatal("QA run found fatal errors. Please consider fixing them.")
+    bb.note("DONE with PACKAGE QA")
+}

--- a/classes/fixes-poky.bbclass
+++ b/classes/fixes-poky.bbclass
@@ -69,14 +69,13 @@ python do_package_qa () {
     pkgdest = d.getVar('PKGDEST')
     packages = set((d.getVar('PACKAGES') or '').split())
 
-    cpath = oe.cachedpath.CachedPath()
     global pkgfiles
     pkgfiles = {}
     for pkg in packages:
         pkgfiles[pkg] = []
-        for walkroot, dirs, files in cpath.walk(pkgdest + "/" + pkg):
+        for walkroot, dirs, files in os.walk(os.path.join(pkgdest, pkg)):
             for file in files:
-                pkgfiles[pkg].append(walkroot + os.sep + file)
+                pkgfiles[pkg].append(os.path.join(walkroot, file))
 
     # no packages should be scanned
     if not packages:

--- a/classes/fixes-poky.bbclass
+++ b/classes/fixes-poky.bbclass
@@ -20,10 +20,6 @@ def package_qa_check_buildpaths(path, name, d, elf, messages):
     if os.path.islink(path):
         return
 
-    # Ignore ipk and deb's CONTROL dir
-    if path.find(name + "/CONTROL/") != -1 or path.find(name + "/DEBIAN/") != -1:
-        return
-
     tmpdir = bytes(d.getVar('TMPDIR'), encoding="utf-8")
     with open(path, 'rb') as f:
         file_content = f.read()
@@ -73,7 +69,14 @@ python do_package_qa () {
     pkgfiles = {}
     for pkg in packages:
         pkgfiles[pkg] = []
-        for walkroot, dirs, files in os.walk(os.path.join(pkgdest, pkg)):
+        pkgdir = os.path.join(pkgdest, pkg)
+        for walkroot, dirs, files in os.walk(pkgdir):
+            # Don't walk into top-level CONTROL or DEBIAN directories as these
+            # are temporary directories created by do_package.
+            if walkroot == pkgdir:
+                for control in ("CONTROL", "DEBIAN"):
+                    if control in dirs:
+                        dirs.remove(control)
             for file in files:
                 pkgfiles[pkg].append(os.path.join(walkroot, file))
 

--- a/classes/fixes-poky.bbclass
+++ b/classes/fixes-poky.bbclass
@@ -1,0 +1,4 @@
+# fixes-poky.bbclass
+#
+# This class fixes Poky's bbclass bugs by overwriting functions.
+#

--- a/conf/distro/include/emlinux.inc
+++ b/conf/distro/include/emlinux.inc
@@ -80,5 +80,9 @@ require conf/distro/include/yocto-uninative.inc
 require conf/distro/include/no-static-libs.inc
 INHERIT += "uninative"
 
+# fixes-poky.bbclass is fixes Poky's bbclass bugs by overwriting functions
+# Add it at the very end of the INHERIT definition.
+INHERIT_append += "fixes-poky"
+
 # In .bbappend, enable PR value addition using the ADD_PR variable.
 INHERIT += "increment_bbappend_pr"


### PR DESCRIPTION
# Purpose of pull request

For fix host-user-contaminated issue [1], add a new poky-fixes.bbclass and backport the fix patch from Poky-dunfell.
The poky-fixes.bbclass is a file for fixes Poky's bbclass bugs, and is used to overwrite buggy functions with fixed ones.

The following patches backported from Poky-dunfell to the poky-fixes.bbclass:
- [adcc017443](https://git.yoctoproject.org/poky/commit/?h=dunfell&id=adcc017443f3e580a0246938f89a45e47d96b0f0) insane: don't use cachedpath
- [20521e2219](https://git.yoctoproject.org/poky/commit/?h=dunfell&id=20521e221942f21f65d045622056b6b9f98e5753) insane: consolidate skipping of temporary do_package files

[1]:  host-user-contaminated issue error log:
```
ERROR: u-boot-1_v2021.10+gitAUTOINC+7fcc1fdc25-r0 do_package_qa: QA Issue: u-boot: /u-boot-dbg/DEBIAN/control is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination [host-user-contaminated]
ERROR: u-boot-1_v2021.10+gitAUTOINC+7fcc1fdc25-r0 do_package_qa: QA run found fatal errors. Please consider fixing them.
ERROR: u-boot-1_v2021.10+gitAUTOINC+7fcc1fdc25-r0 do_package_qa: 
ERROR: u-boot-1_v2021.10+gitAUTOINC+7fcc1fdc25-r0 do_package_qa: Function failed: do_package_qa
ERROR: Logfile of failure stored in: /buildbot/build_daily_emlinux_ek874_rc/build/build_ek874_emlinux_core-image-weston/tmp-glibc/work/ek874-emlinux-linux/u-boot/1_v2021.10+gitAUTOINC+7fcc1fdc25-r0/temp/log.do_package_qa.3443559
NOTE: recipe u-boot-1_v2021.10+gitAUTOINC+7fcc1fdc25-r0: task do_package_qa: Failed
ERROR: Task (/buildbot/build_daily_emlinux_ek874_rc/build/build_ek874_emlinux_core-image-weston/../repos/meta-emlinux-ext-rzg2/recipes-bsp/u-boot/u-boot_2021.10.bb:do_package_qa) failed with exit code '1'
```

# Description of changes

This PR has the following commits:
- 1957cd3 classes: Add fixes-poky.bbclass to fix Poky's bbclass bugs
  Add fixes-poky.bbclass and make it available on EMLinux.
- 05194aa fixes-poky: Copy functions of insane.bbclass
  Copy the functions to be fixed for the host-user-contaminated issue into fixes-poky.bbclass. 
- c88261c fixes-poky: insane: don't use cachedpath
- 9766d86 fixes-poky: insane: consolidate skipping of temporary do_package files


# Test
1. Check build for qemuarm64
2. Check build for ek874
3. Reproduction test

## How to test
### Check build for qemuarm64
1. local.conf setting

   Add the following to local.conf.
   ```
   MACHINE = "qemuarm64"
   ```

2. Build core-image-weston and SDK

   ```
   $ bitbake core-image-weston
   $ bitbake core-image-weston-sdk -c populate_sdk
   ```

### Check build for ek874
1. Setup build environment
   ```
   $ mkdir ek874
   $ cd ek874/
   ek874$ repo init -u https://gitlab.miraclelinux.com/emlinux/emlinux-manifests.git -b warrior -m testing/rzg2/rzg2-rc.xml
   ek874$ repo sync
   ek874$ ln -s ../repos/meta-emlinux-ext-rzg2/scripts/add-layer-emlinux-ext-rzg2 setup-hooks/30-add-layer-emlinux-ext-rzg2
   ek874$ . setup-emlinux
   ```

2. local.conf setting

   Run the following command:
   ```
   build$ ../repos/meta-emlinux-ext-rzg2/scripts/setup-ek874-config
   ```

3. Build core-image-weston and SDK

   ```
   $ bitbake core-image-weston
   $ bitbake core-image-weston-sdk -c populate_sdk
   ```

### Reproduction test

Check the results before and after this PR.

After building core-image-minimal for qemuarm64, perform the following test step:

1. Clean all and build of bash

   ```
   $ bitbake bash -c cleanall
   $ bitbake bash
   ```

2. Contaminate packages-split of bash-dbg for reproduction

   Run the following command:
   ```
   $ mkdir -p ./tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/packages-split/bash-dbg/CONTROL
   $ touch ./tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/packages-split/bash-dbg/CONTROL/testfile
   ```

3. Force rebuild only the do_package_qa task of bash

   ```
   $ bitbake bash -f -c do_package_qa
   ```

## Test result
### Check build for qemuarm64

For qemuarm64, build core-image-weston and SDK  was succeeded.
```
build$ bitbake core-image-weston
Parsing recipes: 100% |#################################################################################################| Time: 0:00:05
Parsing of 1359 .bb files complete (0 cached, 1359 parsed). 2379 targets, 81 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "HEAD:ccf89a071ee4452e0c6d4921666005e4d688eed9"
meta-emlinux         = "add-fixes-poky-bbclass:9766d867923585ef5e0b83d729916f804182d8e0"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 1574 Found 0 Missed 1574 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 5195 tasks of which 5 didn't need to be rerun and all succeeded.
```
```
build$ bitbake core-image-weston-sdk -c populate_sdk
Loading cache: 100% |###################################################################################################| Time: 0:00:00
Loaded 2379 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "HEAD:ccf89a071ee4452e0c6d4921666005e4d688eed9"
meta-emlinux         = "add-fixes-poky-bbclass:9766d867923585ef5e0b83d729916f804182d8e0"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 356 Found 0 Missed 356 Current 916 (0% match, 72% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 5227 tasks of which 4045 didn't need to be rerun and all succeeded.
```

### Check build for ek874

For ek874, build core-image-weston and SDK  was succeeded.
```
build$ bitbake core-image-weston
Parsing recipes: 100% |#################################################################################################| Time: 0:00:06
Parsing of 1372 .bb files complete (0 cached, 1372 parsed). 2392 targets, 83 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "ek874"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 cortexa53 crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "HEAD:ccf89a071ee4452e0c6d4921666005e4d688eed9"
meta-emlinux         = "add-fixes-poky-bbclass:9766d867923585ef5e0b83d729916f804182d8e0"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"
meta-emlinux-ext-rzg2 = "HEAD:67cf24efb109e09b91178a0487915bef4e058b64"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 1587 Found 0 Missed 1587 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 5218 tasks of which 5 didn't need to be rerun and all succeeded.
```
```
build$ bitbake core-image-weston-sdk -c populate_sdk
Loading cache: 100% |###################################################################################################| Time: 0:00:00
Loaded 2392 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "ek874"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 cortexa53 crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "HEAD:ccf89a071ee4452e0c6d4921666005e4d688eed9"
meta-emlinux         = "add-fixes-poky-bbclass:9766d867923585ef5e0b83d729916f804182d8e0"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"
meta-emlinux-ext-rzg2 = "HEAD:67cf24efb109e09b91178a0487915bef4e058b64"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 365 Found 0 Missed 365 Current 895 (0% match, 71% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 5173 tasks of which 3968 didn't need to be rerun and all succeeded.
```

### Reproduction test

Confirmed that the issue does not reproduce after this PR.

#### Before this PR

The warning log "host-user-contaminated" was output.
```
build$ mkdir -p ./tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/packages-split/bash-dbg/CONTROL
build$ touch ./tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/packages-split/bash-dbg/CONTROL/testfile
build$ bitbake bash -f -c do_package_qa
Loading cache: 100% |###################################################################################################| Time: 0:00:00
Loaded 2379 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "HEAD:ccf89a071ee4452e0c6d4921666005e4d688eed9"
meta-emlinux         = "HEAD:010d4aab5b7696652b321a0501a4abc145c162bf"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

NOTE: Tainting hash to force rebuild of task /home/build/work/build/../repos/meta-debian/recipes-debian/bash/bash_debian.bb, do_package_qa
WARNING: /home/build/work/build/../repos/meta-debian/recipes-debian/bash/bash_debian.bb.do_package_qa is tainted from a forced run00:00
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 1 Found 0 Missed 1 Current 103 (0% match, 99% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: bash-5.0-r0 do_package_qa: QA Issue: bash: /bash-dbg/CONTROL/testfile is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination [host-user-contaminated]
NOTE: Tasks Summary: Attempted 727 tasks of which 726 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```

#### After this PR

The warning log "host-user-contaminated" was not output.

```
build$ mkdir -p ./tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/packages-split/bash-dbg/CONTROL
build$ touch ./tmp-glibc/work/aarch64-emlinux-linux/bash/5.0-r0/packages-split/bash-dbg/CONTROL/testfile
build$ bitbake bash -f -c do_package_qa
Loading cache: 100% |###################################################################################################| Time: 0:00:00
Loaded 2379 entries from dependency cache.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "HEAD:ccf89a071ee4452e0c6d4921666005e4d688eed9"
meta-emlinux         = "add-fixes-poky-bbclass:9766d867923585ef5e0b83d729916f804182d8e0"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"

NOTE: Tainting hash to force rebuild of task /home/build/work/build/../repos/meta-debian/recipes-debian/bash/bash_debian.bb, do_package_qa
WARNING: /home/build/work/build/../repos/meta-debian/recipes-debian/bash/bash_debian.bb.do_package_qa is tainted from a forced run00:00
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 1 Found 0 Missed 1 Current 103 (0% match, 99% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 727 tasks of which 726 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```