### PR TITLE
Update kernel to v5.10.240-cip63

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "50e86929b6d357b2419f4c84cc82c4d16e16af72"
-LINUX_CVE_VERSION ??= "5.10.239"
-LINUX_CIP_VERSION ?= "v5.10.239-cip62"
+LINUX_GIT_SRCREV ?= "aed025ea2b4be27479946d3fd09245877fa68357"
+LINUX_CVE_VERSION ??= "5.10.240"
+LINUX_CIP_VERSION ?= "v5.10.240-cip63"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.240-cip63

This pull request update the kernel to the following cip versions:
v5.10.240-cip63 with hash tag aed025ea2b4be27479946d3fd09245877fa68357
