### PR TITLE
sdk: Run patchelf twice on the listed binaries

### DIFF
--- a/classes/sdk-installer.bbclass
+++ b/classes/sdk-installer.bbclass
@@ -39,8 +39,9 @@ fi
 
 answer=""
 target_sdk_dir="/opt"
+repatch_list=""
 
-while getopts ":yd:" OPT; do
+while getopts ":yd:l:" OPT; do
     case $OPT in
     y)
         answer="Y"
@@ -48,6 +49,8 @@ while getopts ":yd:" OPT; do
     d)
         target_sdk_dir=$OPTARG
         ;;
+    l)
+        repatch_list=$OPTARG
     esac
 done
 
@@ -73,7 +76,12 @@ sdk_installed_dir="${sdk_install_target_dir}/${EMLINUX_SDK_BASE_NAME}"
 echo "Installing EMLinux SDK to ${sdk_install_target_dir} ."
 tail -n +${SDK_START_LINE} $0 | sudo tar xpJ -C ${sdk_install_target_dir}
 
-sudo "${sdk_installed_dir}/relocate-sdk.sh" || (echo "Setup SDK environment failed." ; exit 1)
+if [ -f "${repatch_list}" ]; then
+    arg="-l ${repatch_list}"
+else
+    arg=""
+fi
+sudo "${sdk_installed_dir}/relocate-sdk.sh" $arg || (echo "Setup SDK environment failed." ; exit 1)
 
 sudo sed -i "s:@EMLINUX_SDK_INSTALL_DIR@:${sdk_installed_dir}:g" "${sdk_installed_dir}/environment-setup-${MACHINE}-${DISTRO}"
 sudo sed -i "s/@EMLINUX_SDK_TOOLCHAIN_PREFIX@/${EMLINUX_SDK_TARGET_TOOLCHAIN_PREFIX}/g" "${sdk_installed_dir}/environment-setup-${MACHINE}-${DISTRO}"

--- a/recipes-devtools/sdk-files/files/relocate-sdk.sh
+++ b/recipes-devtools/sdk-files/files/relocate-sdk.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# This software is a part of ISAR.
+# Copyright (c) Siemens AG, 2020-2023
+#
+# SPDX-License-Identifier: MIT
+
+sdkroot=$(realpath $(dirname $0))
+arch=$(uname -m)
+
+new_sdkroot=$sdkroot
+
+case "$1" in
+--help|-h)
+	echo "Usage: $0 [--restore-chroot|-r]"
+	exit 0
+	;;
+--restore-chroot|-r)
+	new_sdkroot=/
+	;;
+esac
+
+if [ -z $(which patchelf 2>/dev/null) ]; then
+	echo "Please install 'patchelf' package first."
+	exit 1
+fi
+
+echo -n "Adjusting path of SDK to '${new_sdkroot}'... "
+
+for binary in $(find ${sdkroot}/usr/bin ${sdkroot}/usr/sbin ${sdkroot}/usr/lib/gcc* -executable -type f -exec file {} \; | grep ELF | awk -F ':' '{ print $1 }'); do
+	interpreter=$(patchelf --print-interpreter ${binary} 2>/dev/null)
+	oldpath=${interpreter%/lib*/ld-linux*}
+	interpreter=${interpreter#${oldpath}}
+	if [ -n "${interpreter}" ]; then
+		patchelf --set-interpreter ${new_sdkroot}${interpreter} \
+			--set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
+			--force-rpath \
+			$binary 2>/dev/null
+	fi
+done
+
+sed -i 's|^GCC_SYSROOT=.*|GCC_SYSROOT="'"${new_sdkroot}"'"|' \
+    ${sdkroot}/usr/bin/gcc-sysroot-wrapper.sh
+
+echo "done"

--- a/recipes-devtools/sdk-files/files/relocate-sdk.sh
+++ b/recipes-devtools/sdk-files/files/relocate-sdk.sh
@@ -27,7 +27,7 @@ fi
 
 echo -n "Adjusting path of SDK to '${new_sdkroot}'... "
 
-for binary in $(find ${sdkroot}/usr/bin ${sdkroot}/usr/sbin ${sdkroot}/usr/lib/gcc* -executable -type f -exec file {} \; | grep ELF | awk -F ':' '{ print $1 }'); do
+for binary in $(find ${sdkroot}/usr/bin ${sdkroot}/usr/sbin ${sdkroot}/usr/lib/gcc* -executable -type f,l -exec file -L {} \; | grep ELF | awk -F ':' '{ print $1 }'); do
 	interpreter=$(patchelf --print-interpreter ${binary} 2>/dev/null)
 	oldpath=${interpreter%/lib*/ld-linux*}
 	interpreter=${interpreter#${oldpath}}
@@ -36,6 +36,15 @@ for binary in $(find ${sdkroot}/usr/bin ${sdkroot}/usr/sbin ${sdkroot}/usr/lib/g
 			--set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
 			--force-rpath \
 			$binary 2>/dev/null
+	fi
+done
+
+for library in $(find ${sdkroot}/usr/lib -type f,l -name "lib*.so*" -exec file -L {} \; | grep ELF | awk -F ':' '{ print $1 }'); do
+	rpath=$(patchelf --print-rpath ${library})
+	if [ -n "${library}" ]; then
+		patchelf --set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
+		--force-rpath \
+		$library 2>/dev/null
 	fi
 done
 

--- a/recipes-devtools/sdk-files/files/relocate-sdk.sh
+++ b/recipes-devtools/sdk-files/files/relocate-sdk.sh
@@ -9,16 +9,36 @@ sdkroot=$(realpath $(dirname $0))
 arch=$(uname -m)
 
 new_sdkroot=$sdkroot
+repatch_list=""
 
-case "$1" in
---help|-h)
-	echo "Usage: $0 [--restore-chroot|-r]"
-	exit 0
-	;;
---restore-chroot|-r)
-	new_sdkroot=/
-	;;
-esac
+opt_short="hrl:"
+opt_long="help,resore-chroot,repatch-list:"
+OPTS=$(getopt -o "$opt_short" -l "$opt_long" -- "$@")
+if [ $? -ne 0 ] ; then
+	echo "Wrong input parameter!"; 1>&2
+	exit 1;
+fi
+eval set -- "$OPTS"
+
+while true; do
+	case "$1" in
+	--help|-h)
+		echo "Usage: $0 [--restore-chroot|-r] [--repatch-list|-l <list>]"
+		exit 0
+		;;
+	--restore-chroot|-r)
+		new_sdkroot=/
+		shift
+		;;
+	--repatch-list|-l)
+		repatch_list=${2}
+		shift 2
+		;;
+	--)
+		shift; break
+		;;
+	esac
+done
 
 if [ -z $(which patchelf 2>/dev/null) ]; then
 	echo "Please install 'patchelf' package first."
@@ -45,6 +65,29 @@ for library in $(find ${sdkroot}/usr/lib -type f,l -name "lib*.so*" -exec file -
 		patchelf --set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
 		--force-rpath \
 		$library 2>/dev/null
+	fi
+done
+
+## HACK: Listed binaries require applying patchelf twice to avoid segfaults.
+for binary in $(cat $repatch_list ${new_sdkroot}/repatch.list); do
+	binary=${sdkroot}/${binary}
+	if file -L ${binary} |grep "executable" 2>&1 >/dev/null; then
+		interpreter=$(patchelf --print-interpreter ${binary} 2>/dev/null)
+		oldpath=${interpreter%/lib*/ld-linux*}
+		interpreter=${interpreter#${oldpath}}
+		if [ -n "${interpreter}" ]; then
+			patchelf --set-interpreter ${new_sdkroot}${interpreter} \
+				--set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
+				--force-rpath \
+				$binary 2>/dev/null
+		fi
+	else
+		rpath=$(patchelf --print-rpath ${binary})
+		if [ -n "${binary}" ]; then
+			patchelf --set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
+			--force-rpath \
+			$library 2>/dev/null
+		fi
 	fi
 done
 

--- a/recipes-devtools/sdk-files/files/repatch.list
+++ b/recipes-devtools/sdk-files/files/repatch.list
@@ -1,0 +1,1 @@
+/usr/bin/go

--- a/recipes-devtools/sdk-files/sdk-files.bbappend
+++ b/recipes-devtools/sdk-files/sdk-files.bbappend
@@ -4,6 +4,7 @@ inherit kernel-arch
 
 SRC_URI:append = "\
   file://environment-setup-template.tmpl \
+  file://repatch.list \
 "
 
 TEMPLATE_FILES = "environment-setup-template.tmpl"
@@ -11,4 +12,5 @@ TEMPLATE_VARS = "TARGET_CC_ARCH TARGET_AS_ARCH TARGET_LD_ARCH TARGET_CFLAGS TARG
 
 do_install:append() {
     install -m 644 ${WORKDIR}/environment-setup-template ${D}
+    install -m 644 ${WORKDIR}/repatch.list ${D}
 }


### PR DESCRIPTION
# Purpose

Fixes  issue where Golang and Clang are unavailable when installed in the SDK.

This PR includes the following changes:
 - Added a list that runs patchelf twice.
 - Added the "-r" option to sdk-installer.sh.
 - Fork relocate-sdk.sh from isar.
 - Added processing to run patchelf twice on the binaries listed.

# How to test

Add golang and clang to SDK_PREINSTALL

```
$ cat << EOF >> conf/local.conf
MACHINE ?= "qemu-arm64"
SDK_PREINSTALL += "clang"
SDK_PREINSTALL += "golang"
EOF
```

Build SDK

```
$ bitbake emlinux-image-base -c populate_sdk
```

Install and Enable SDK

```
$ ./tmp/deploy/images/qemu-arm64/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64-sdk-installer.sh
Will you continue to install EMLinux SDK? [y/N]
y
Installing EMLinux SDK to /opt .
Adjusting path of SDK to '/opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64'... done
When you use the SDK in a new shell session, you need to run following command.
  $ source /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/environment-setup-qemu-arm64-emlinux-bookworm
$  source /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/environment-setup-qemu-arm64-emlinux-bookworm
```

List dependencies for Go and Clang
```
$ ldd $(which go)
$ ldd $(which clang)
```

Run go and clang

```
$ go version
$ clang --version
```

# Result

1. Verify that the libraries go and clang depend on are files located under the SDK rootfs directory.

```
$ ldd $(which go)
	linux-vdso.so.1 (0x00007fff41dea000)
	libc.so.6 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libc.so.6 (0x00007914b827e000)
	/opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/lib64/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007914b846e000)
$ ldd $(which clang)
	linux-vdso.so.1 (0x00007ffd471fc000)
	libclang-cpp.so.14 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libclang-cpp.so.14 (0x00007b75dee00000)
	libLLVM-14.so.1 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libLLVM-14.so.1 (0x00007b75d8000000)
	libstdc++.so.6 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007b75d7c00000)
	libm.so.6 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libm.so.6 (0x00007b75d7f1b000)
	libgcc_s.so.1 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007b75e29e8000)
	libc.so.6 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libc.so.6 (0x00007b75d7a12000)
	/opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/lib64/ld-linux-x86-64.so.2 => /lib64/ld-linux-x86-64.so.2 (0x00007b75e2a0e000)
	libffi.so.8 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libffi.so.8 (0x00007b75e29db000)
	libedit.so.2 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libedit.so.2 (0x00007b75e299f000)
	libz3.so.4 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libz3.so.4 (0x00007b75d6200000)
	libz.so.1 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libz.so.1 (0x00007b75e297d000)
	libtinfo.so.6 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libtinfo.so.6 (0x00007b75dedcb000)
	libxml2.so.2 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libxml2.so.2 (0x00007b75d7859000)
	libbsd.so.0 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libbsd.so.0 (0x00007b75e2965000)
	libicuuc.so.72 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libicuuc.so.72 (0x00007b75d5e00000)
	liblzma.so.5 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/liblzma.so.5 (0x00007b75ded9a000)
	libmd.so.0 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libmd.so.0 (0x00007b75ded8c000)
	libicudata.so.72 => /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/lib/x86_64-linux-gnu/libicudata.so.72 (0x00007b75d4000000)

```

2. Verify that go and clang can be executed

```
$ go version
go version go1.19.8 linux/amd64

$ clang --version
Debian clang version 14.0.6
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/usr/bin
```