### PR TITLE
Revert "conf: Update kernel version to v4.19.325-cip123"

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "1e9cb006c55b0164de79c50947377a71deca9975"
+LINUX_GIT_SRCREV ?= "019ba39c16cf7bf1e244899b97634f11923d4aa7"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip123"
+LINUX_CIP_VERSION ??= "v4.19.325-cip122"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
This reverts commit 7037b704201be195de020525a2e672fd48177363.

This is because the version update results in the following compilation errors.

| /buildbot/build_daily_emlinux_am335xevmsk_latest_dev/build/build_am335x-evmsk_emlinux_core-image-weston/tmp-glibc/work-shared/am335x-evmsk/kernel-source/drivers/media/platform/omap3isp/ispccdc.c: In function 'ccdc_lsc_config': | /buildbot/build_daily_emlinux_am335xevmsk_latest_dev/build/build_am335x-evmsk_emlinux_core-image-weston/tmp-glibc/work-shared/am335x-evmsk/kernel-source/drivers/media/platform/omap3isp/ispccdc.c:452:3: error: implicit declaration of function 'dma_sync_sgtable_for_cpu'; did you mean 'dma_sync_single_for_cpu'? [-Werror=implicit-function-declaration]
|    dma_sync_sgtable_for_cpu(isp->dev, &req->table.sgt,
|    ^~~~~~~~~~~~~~~~~~~~~~~~
|    dma_sync_single_for_cpu
|   CC [M]  drivers/media/rc/keymaps/rc-avermedia-a16d.o
| /buildbot/build_daily_emlinux_am335xevmsk_latest_dev/build/build_am335x-evmsk_emlinux_core-image-weston/tmp-glibc/work-shared/am335x-evmsk/kernel-source/drivers/media/platform/omap3isp/ispccdc.c:461:3: error: implicit declaration of function 'dma_sync_sgtable_for_device'; did you mean 'dma_sync_single_for_device'? [-Werror=implicit-function-declaration]
|    dma_sync_sgtable_for_device(isp->dev, &req->table.sgt,
|    ^~~~~~~~~~~~~~~~~~~~~~~~~~~
|    dma_sync_single_for_device