### PR TITLE
Update kernel to v4.19.325-cip123

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "019ba39c16cf7bf1e244899b97634f11923d4aa7"
+LINUX_GIT_SRCREV ?= "1e9cb006c55b0164de79c50947377a71deca9975"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip122"
+LINUX_CIP_VERSION ??= "v4.19.325-cip123"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip123

This pull request update the kernel to the following cip versions:
v4.19.325-cip123 with hash tag 1e9cb006c55b0164de79c50947377a71deca9975
