### PR TITLE
sdk-files: Suppress warning of "No such file or directory"

### DIFF
--- a/recipes-devtools/sdk-files/files/relocate-sdk.sh
+++ b/recipes-devtools/sdk-files/files/relocate-sdk.sh
@@ -71,6 +71,9 @@ done
 ## HACK: Listed binaries require applying patchelf twice to avoid segfaults.
 for binary in $(cat $repatch_list ${new_sdkroot}/repatch.list); do
 	binary=${sdkroot}/${binary}
+	if [ ! -f "${binary}" ]; then
+		continue
+	fi
 	if file -L ${binary} |grep "executable" 2>&1 >/dev/null; then
 		interpreter=$(patchelf --print-interpreter ${binary} 2>/dev/null)
 		oldpath=${interpreter%/lib*/ld-linux*}


### PR DESCRIPTION
# Purpose
Suppresses warnings output when files listed in repatch.list do not exist within the SDK.

Fix:
|Adjusting path of SDK to '/opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64'... 
| patchelf: getting info about '/opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64//usr/bin/go': No such file or directory 
|done

# How to test

build sdk and install sdk

```
$ cat << EOF >> conf/local.conf
MACHINE ?= "qemu-arm64"
EOF
$ bitbake emlinux-image-base -c populate_sdk
$ ./tmp/deploy/images/qemu-arm64/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64-sdk-installer.sh
```

# Result

Verify that no warnings are output during SDK installation.

```
$ ./tmp/deploy/images/qemu-arm64/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64-sdk-installer.sh
Will you continue to install EMLinux SDK? [y/N]
y
Installing EMLinux SDK to /opt .
Adjusting path of SDK to '/opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64'... done
When you use the SDK in a new shell session, you need to run following command.
```