### PR TITLE
cve-update-nvd2-native: Fix predownload file name

### DIFF
--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -36,7 +36,7 @@ CVE_SOCKET_TIMEOUT ?= "60"
 CVE_CHECK_DB_DLDIR_FILE ?= "${DL_DIR}/CVE_CHECK/${CVE_CHECK_DB_FILENAME}"
 CVE_CHECK_DB_TEMP_FILE ?= "${CVE_CHECK_DB_FILE}.tmp"
 
-CVE_DB_PREDOWNLOAD_TEMP_FILE = "downlaod_temp_nvdcve_2.db"
+CVE_DB_PREDOWNLOAD_TEMP_FILE = "downlaod_temp_${CVE_CHECK_DB_FILENAME}"
 
 python () {
     if not bb.data.inherits_class("cve-check", d):


### PR DESCRIPTION
# Purpose of pull request

In the future, the CVE database filename may change, so fix to use CVE database file name as part of pre-download file name.

# Test

## How to test
1. local.conf setting
   Add the following to local.conf.
   ```
   MACHINE = "qemuarm64"
   INHERIT += " cve-check debian-cve-check kernel-cve-check"
   CVE_DB_PREDOWNLOAD="1"
   ```

2. Update CVE database 
   ```
   $ bitbake cve-update-nvd2-native 
   ```

3. Check CVE_DB_PREDOWNLOAD_TEMP_FILE variable
   ```
   $ bitbake cve-update-nvd2-native -e | grep 'CVE_DB_PREDOWNLOAD_TEMP_FILE='
   ```

## Test result
As expected, the pre-download file name is “download_temp_nvdcve_2-2.db”.
```
build$ bitbake cve-update-nvd2-native 
Parsing recipes: 100% |#################################################################################################| Time: 0:00:09
Parsing of 2540 .bb files complete (0 cached, 2540 parsed). 4077 targets, 122 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "HEAD:ccf89a071ee4452e0c6d4921666005e4d688eed9"
meta-emlinux         = "fix-predownload-file-name:01579ef517696255626ebca5da64fd9ad2a07578"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"
meta-python          
meta-oe              = "warrior:a24acf94d48d635eca668ea34598c6e5c857e3f8"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 1 Found 0 Missed 1 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
Fetching prepared NVD database file from ... http://emlinux-pkgs.miraclelinux.com/CVE/emlinux2/nvdcve_2-2.db;downloadfilename=downlaod_temp_nvdcve_2-2.db
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Missing md5 SRC_URI checksum for /home/build/work/build/../downloads/downlaod_temp_nvdcve_2-2.db, consider adding to the recipe:
SRC_URI[md5sum] = "9d78742129ad3b1f5192acf2a989eca0"
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Missing sha256 SRC_URI checksum for /home/build/work/build/../downloads/downlaod_temp_nvdcve_2-2.db, consider adding to the recipe:
SRC_URI[sha256sum] = "ff716dc98496af670fa293a82e02058a50fed1acec9003d846662d9a85fb74f6"
NOTE: Tasks Summary: Attempted 4 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```
```
build$ bitbake cve-update-nvd2-native -e | grep 'CVE_DB_PREDOWNLOAD_TEMP_FILE='
CVE_DB_PREDOWNLOAD_TEMP_FILE="downlaod_temp_nvdcve_2-2.db"
```

**For reference, before this PR**
```
build$ bitbake cve-update-nvd2-native -e | grep 'CVE_DB_PREDOWNLOAD_TEMP_FILE='
CVE_DB_PREDOWNLOAD_TEMP_FILE="downlaod_temp_nvdcve_2.db"
```