### PR TITLE
recipes-sample: openssl-apt: Set a fixed version to fetch the apt package

### DIFF
--- a/doc/samples/recipes-sample/openssl-apt/openssl_3.0.16.bb.sample
+++ b/doc/samples/recipes-sample/openssl-apt/openssl_3.0.16.bb.sample
@@ -19,7 +19,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=c75985e733726beaba57bc5253e96d04"
 inherit dpkg
 
 SRC_URI = " \
-    apt://${PN}/bookworm \
+    apt://${PN}=3.0.16-1~deb12u1/bookworm \
     file://custom-debian \
 "
 


### PR DESCRIPTION
This fetches the same package version as the recipe name.