### PR TITLE
kernel-cve-check: Fix ignore info issue

### DIFF
--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -17,11 +17,20 @@ inherit cve-check
 
 KERNEL_CVE_CHECK_DIR ?= "${CVE_CHECK_DB_DIR}/KERNEL"
 
-# Consider ignore information.
-# If value is "0", add CVEs that are registered as negligible to whitelist.
+# KERNEL_CVE_CHECK_INCLUDE_IGNORE:
+# - If value is "0":
+#   Consider ignore information, add CVEs that are registered as negligible to
+#   whitelist, then the CVE check result is "Patched".
+# - If value is "1" (default):
+#   Do not consider ignore information when performing CVE check using
+#   cip-kernel-sec tracking information.
 KERNEL_CVE_CHECK_INCLUDE_IGNORE ?= "1"
 
-# Add ignore information to cve manifest.
+# KERNEL_CVE_CHECK_SHOW_IGNORE_INFO:
+# - If value is "0" (default):
+#   Do not output ignore information.
+# - If value is "1":
+#   Add 'IGNORE INFO:' line to cve manifest.
 KERNEL_CVE_CHECK_SHOW_IGNORE_INFO ?= "0"
 
 # Remote branch name. bitbake detects it from kernel-src by default.
@@ -179,7 +188,7 @@ do_cve_check[depends] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), d.ge
 # write_ignore_info
 ###############################################################################
 
-def get_ignore_info(cip_kernel_sec_path, cve_id, d):
+def get_ignore_info(cip_kernel_sec_path, cve_id, target_branch_name, d):
     """
     Get ignore reason for the cve_id.
     """
@@ -195,7 +204,7 @@ def get_ignore_info(cip_kernel_sec_path, cve_id, d):
 
     ignore = issue.get('ignore', {})
     for branch_name in ignore:
-        if branch_name == "all" or branch_name == "cip/4.19":
+        if branch_name == "all" or branch_name == target_branch_name:
             return ignore[branch_name].replace('\n', ' ')
     return None
 
@@ -207,7 +216,13 @@ def insert_ignore_info(file_name, d):
         bb.error("%s is not found." % file_name)
         return
 
-    kernel_cve_check_dir =d.getVar("KERNEL_CVE_CHECK_DIR")
+    # target_branch_name is a string like 'cip/4.19'
+    target_branch_name = ''
+    cip_ver = d.getVar("LINUX_CIP_VERSION")
+    if cip_ver:
+        target_branch_name = 'cip/' + '.'.join(cip_ver.split('.')[0:2]).replace('v', '')
+
+    kernel_cve_check_dir = d.getVar("KERNEL_CVE_CHECK_DIR")
     cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
     issue_list = get_issue_list(cip_kernel_sec_path)
 
@@ -215,15 +230,16 @@ def insert_ignore_info(file_name, d):
         content = f.readlines()
 
     for index,line in enumerate(content):
-        ignore_info = None
         if line.startswith("PACKAGE NAME:"):
+            ignore_info = None
             pkg_name = line.split()[2]
         if line.startswith("CVE:") and pkg_name == d.getVar('KERNEL_PN'):
             cve_id = line.split()[1]
             if cve_id in issue_list:
-                ignore_info = get_ignore_info(cip_kernel_sec_path, cve_id, d)
-                if ignore_info:
-                    content.insert(index+6, "IGNORE INFO: %s\n" % ignore_info)
+                ignore_info = get_ignore_info(cip_kernel_sec_path, cve_id, target_branch_name, d)
+        if line.startswith("MORE INFORMATION:") and ignore_info:
+            content.insert(index, "IGNORE INFO: %s\n" % ignore_info)
+            ignore_info = None
 
     with open(file_name, "w") as f:
         for line in content:


### PR DESCRIPTION
# Purpose of pull request

There were two issues with add 'IGNORE INFO:' line feature when KERNEL_CVE_CHECK_SHOW_IGNORE_INFO value is 1 in kernel-cve-check.bbclass.

- Incorrect 'IGNORE INFO:' position
  When the 'CVE SUMMARY:' line was multi-line, the 'INGORE INFO:' line was added in an incorrect position.
- Use of the fixed string "cip/4.19"

Fix these issues.

# Test
1. Build qemuarm64 image
2. Run cve_check and compare cve report
3. Check to fixed issue

## How to test
### 1. Build qemuarm64 image
Add the following to local.conf and build qemuarm64 image.
```
MACHINE = "qemuarm64"
INHERIT += " cve-check kernel-cve-check"
```
```
$ bitbake core-image-minimal
```

### 2. Run cve_check and compare cve report

Before and after this PR, run cve_check and check that there are no changes in CVE reports each for Kernel version to 4.19 and 5.10.

#### for Kernel 4.19

Set the following to local.conf and run cve_check for linux-base.
```
DISTRO = "emlinux"
MACHINE = "qemuarm64"
INHERIT += " cve-check kernel-cve-check"
```
```
$ bitbake linux-base -c cve_check
```

Copy tmp-glibc/work/qemuarm64-emlinux-linux/linux-base/4.19-r0/temp/cve.log file with the following name:
- before-k419-cve.log
- after-k419-cve.log

Compare before-k419-cve.log and after-k419-cve.log.
```
$ diff -up before-k419-cve.log after-k419-cve.log; echo $?
```

#### for Kernel 5.10

Set the following to local.conf and run cve_check for linux-k510.
```
DISTRO = "emlinux-k510"
MACHINE = "qemuarm64"
INHERIT += " cve-check kernel-cve-check"
```
```
$ bitbake linux-k510 -c cve_check
```

Copy tmp-glibc/work/qemuarm64-emlinux-linux/linux-k510/5.10-r0/temp/cve.log file with the following name:
- before-k510-cve.log
- after-k510-cve.log

Compare before-k510-cve.log and after-k510-cve.log.
```
$ diff -up before-k510-cve.log after-k510-cve.log; echo $?
```

### 3. Check to fixed issue

Before and after this PR, run cve_check to check fixed issues by comparing CVE reports.

Set the following to local.conf and run cve_check for linux-k510.
```
DISTRO = "emlinux-k510"
MACHINE = "qemuarm64"
INHERIT += " cve-check kernel-cve-check"
KERNEL_CVE_CHECK_INCLUDE_IGNORE = "0"
KERNEL_CVE_CHECK_SHOW_IGNORE_INFO = "1"
```
```
$ bitbake linux-k510 -c cve_check
```

Copy tmp-glibc/work/qemuarm64-emlinux-linux/linux-k510/5.10-r0/temp/cve.log file with the following name:
- before-ignore-k510-cve.log
- after-ignore-k510-cve.log

Compare before-ignore-k510-cve.log and after-ignore-k510-cve.log and check CVE report of affected CVE ID on issue.
Check fixed issues:
- Incorrect 'IGNORE INFO:' position
- Use of the fixed string "cip/4.19"


## Test result
### 1. Build qemuarm64 image

Build succeeded.
```
build$ bitbake core-image-minimal
Parsing recipes: 100% |#################################################################################################| Time: 0:00:09
Parsing of 2540 .bb files complete (0 cached, 2540 parsed). 4077 targets, 122 skipped, 6 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.11"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:62172ffdf29d0c155b3d6591fa70425c3b41587f"
meta-debian-extended = "HEAD:ccf89a071ee4452e0c6d4921666005e4d688eed9"
meta-emlinux         = "fix-ignore-info-issue-to-meta-emlinux:7357be284ab485bfaefe5f69ffb68fbd77cce2e4"
meta-emlinux-private = "HEAD:0240322695096c9406f4cd9cd3754f311489bab5"
meta-python          
meta-oe              = "warrior:a24acf94d48d635eca668ea34598c6e5c857e3f8"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 879 Found 0 Missed 879 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: gcc-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /home/build/work/build/tmp-glibc/work/aarch64-emlinux-linux/gcc/8.3.0-r0/temp/cve.log
...<snip 49 lines>...
Image CVE report stored in: /home/build/work/build/tmp-glibc/deploy/images/qemuarm64/core-image-minimal-qemuarm64-20250910095026.rootfs.cve
NOTE: Tasks Summary: Attempted 3366 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 51 WARNING messages shown.
```

### 2. Run cve_check and compare cve report

There was no difference in CVE report before and after this PR, each for Kernel 4.19 and 5.10.

#### for Kernel 4.19
```
$ diff -up before-k419-cve.log after-k419-cve.log; echo $?
0
```

#### for Kernel 5.10
```
build$ diff -up before-k510-cve.log after-k510-cve.log; echo 0
0
```

### 3. Check to fixed issue

Based on test results below, confirmed that issues has been resolved.

Confirmed that there were no differences other than 'IGNORE INFO:' line.
```
$ diff -u before-ignore-k510-cve.log after-ignore-k510-cve.log | grep '^[-+]' -c 
786
$ diff -u before-ignore-k510-cve.log after-ignore-k510-cve.log | grep '^[-+]' | grep -v 'IGNORE INFO'
--- before-ignore-k510-cve.log	2025-09-10 11:42:00.427939119 +0000
+++ after-ignore-k510-cve.log	2025-09-10 11:39:32.756472794 +0000
```


#### For Incorrect 'IGNORE INFO:' position issue

Confirmed that ‘IGNORE INFO:’ line has been added to the correct position.

Visually checked the differences and confirmed CVE-2025-22041, which corresponds to this issue.
```
$ grep -B 3 -A 17 'CVE: CVE-2025-22041' ./before-ignore-k510-cve.log > before-ignore-k510-cve-CVE-2025-22041.log
$ grep -B 3 -A 17 'CVE: CVE-2025-22041' ./after-ignore-k510-cve.log  > after-ignore-k510-cve-CVE-2025-22041.log
```
```diff
$ diff -u -U 10 before-ignore-k510-cve-CVE-2025-22041.log after-ignore-k510-cve-CVE-2025-22041.log 
--- before-ignore-k510-cve-CVE-2025-22041.log	2025-09-10 11:56:47.766755837 +0000
+++ after-ignore-k510-cve-CVE-2025-22041.log	2025-09-10 11:57:07.568984806 +0000
@@ -1,21 +1,21 @@
 
 PACKAGE NAME: linux-k510
 PACKAGE VERSION: 5.10
 CVE: CVE-2025-22041
 CVE STATUS: Patched
 CVE SUMMARY: In the Linux kernel, the following vulnerability has been resolved:
 
 ksmbd: fix use-after-free in ksmbd_sessions_deregister()
 
-IGNORE INFO: ksmbd is not implemented
 In multichannel mode, UAF issue can occur in session_deregister
 when the second channel sets up a session through the connection of
 the first channel. session that is freed through the global session
 table can be accessed again through ->sessions of connection.
 CVSS v2 BASE SCORE: 0.0
 CVSS v3 BASE SCORE: 7.8
 CVSS v4 BASE SCORE: 0.0
 VECTOR: LOCAL
 VECTORSTRING: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+IGNORE INFO: ksmbd is not implemented
 MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2025-22041
 
```

#### For Use of the fixed string "cip/4.19" issue

In Kernel 5.10, confirmed that issue where ‘IGNORE INFO:’ line was incorrectly output has been fixed.

Visually checked the differences and confirmed CVE-2025-38426, which corresponds to this issue.
```
$ grep -B 3 -A 15 'CVE: CVE-2025-38426' ./before-ignore-k510-cve.log > before-ignore-k510-cve-CVE-2025-38426.log
$ grep -B 3 -A 15 'CVE: CVE-2025-38426' ./after-ignore-k510-cve.log  > after-ignore-k510-cve-CVE-2025-38426.log
```
```diff
$ diff -u -U 10 before-ignore-k510-cve-CVE-2025-38426.log after-ignore-k510-cve-CVE-2025-38426.log
--- before-ignore-k510-cve-CVE-2025-38426.log	2025-09-10 12:06:06.063293409 +0000
+++ after-ignore-k510-cve-CVE-2025-38426.log	2025-09-10 12:06:23.000504046 +0000
@@ -1,19 +1,19 @@
 
 PACKAGE NAME: linux-k510
 PACKAGE VERSION: 5.10
 CVE: CVE-2025-38426
 CVE STATUS: Unpatched
 CVE SUMMARY: In the Linux kernel, the following vulnerability has been resolved:
 
 drm/amdgpu: Add basic validation for RAS header
 
-IGNORE INFO: affected file is not present
 If RAS header read from EEPROM is corrupted, it could result in trying
 to allocate huge memory for reading the records. Add some validation to
 header fields.
 CVSS v2 BASE SCORE: 0.0
 CVSS v3 BASE SCORE: 0.0
 CVSS v4 BASE SCORE: 0.0
 VECTOR: UNKNOWN
 VECTORSTRING: UNKNOWN
 MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2025-38426
+
```

Excerpt from ignore info on [CVE-2025-38426.yml](https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec/-/blob/master/issues/CVE-2025-38426.yml) :
```
ignore:
  cip/4.19: affected file is not present
  cip/4.19-rt: affected file is not present
  cip/4.19-st: affected file is not present
  cip/4.4: affected file is not present
  cip/4.4-rt: affected file is not present
  cip/4.4-st: affected file is not present
```
The ignore information exists in “cip/4.19” but not in “cip/5.10”, so it is correct that this PR caused it to no output.