### PR TITLE
Fix invalid licence parse error when creating SPDX format sbom

### DIFF
--- a/scripts/create_sbom.py
+++ b/scripts/create_sbom.py
@@ -175,7 +175,7 @@ def write_sbom_json(output_filepath, sbom_data):
 
 def main(args):
     if args.verbose_output:
-        logging.basicConfig(level = logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
 
     bitbakeinfo = bitbake_runner.get_bitbake_information(args.image)
     rootfs = bitbakeinfo["rootfs_dir"]

--- a/scripts/lib/python/sbom/sbom_spdx.py
+++ b/scripts/lib/python/sbom/sbom_spdx.py
@@ -19,6 +19,7 @@ from spdx_tools.spdx.validation.document_validator import validate_full_spdx_doc
 from spdx_tools.spdx.validation.validation_message import ValidationMessage
 from spdx_tools.spdx.writer.write_anything import write_file
 from spdx_tools.spdx.model.spdx_none import SpdxNone
+from license_expression import ExpressionParseError
 
 import re
 import json
@@ -79,12 +80,21 @@ def split_licenses(lic, sep):
     return arr
 
 def create_license_string(pkg, license_mapping):
-    arr = []
+    licenses = []
     s = ""
 
-    licenses = licensing.normalize_for_spdx(create_uniq_list(pkg["licenses"]), license_mapping)
+    licenses_tmp = licensing.normalize_for_spdx(create_uniq_list(pkg["licenses"]), license_mapping)
+
+    try:
+        for lic in licenses_tmp:
+            spdx_licensing.parse(lic)
+            licenses.append(lic)
+    except ExpressionParseError as e:
+        logger.debug(f"Invalid license name '{lic}'")
+        licenses.append("unknown")
 
     s = " AND ".join(licenses)
+
     return spdx_licensing.parse(s)
 
 def create_package_info(pkg, distro, license_mapping):


### PR DESCRIPTION
# Purpose

This PR contais 2 commits.

8c1935c513704752fe71220f9fe257d3b8a8347d is main purpose. It fixes an error when license string contains  invalid string.
cd0d2ed5e807a890647c6767b00db510f2f191e2 fixes a bug when changing log level from info to debug.

## Commit 8c1935c513704752fe71220f9fe257d3b8a8347d

If license text contains invalid string such as "(",  spdx_licensing.parse() raises ExpressionParseError exception.
This ivalid license is in the [recipes-bsp/raspberrypi-bootfiles/raspberrypi-bootfiles/copyright](https://github.com/miraclelinux/meta-emlinux/blob/emlinux3/recipes-bsp/raspberrypi-bootfiles/raspberrypi-bootfiles/copyright#L44) file. That invalid license will be fixed in another PR.

```
2025-09-18 05:13:35,268:INFO: Create spdx format sbom for emlinux-image-base                                
Traceback (most recent call last):                                                                          
  File "/home/build/.local/lib/python3.11/site-packages/license_expression/__init__.py", line 543, in parse 
    expression = super(Licensing, self).parse(tokens)                                                       
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                       
  File "/home/build/.local/lib/python3.11/site-packages/boolean/boolean.py", line 302, in parse             
    raise ParseError(                                                                                       
boolean.boolean.ParseError: Invalid expression nesting such as (AND xx) for token: "(" at position: 47      
                                                                                                            
The above exception was the direct cause of the following exception:                                        
                                                                                                            
Traceback (most recent call last):                                                                          
  File "/home/build/work/repos/meta-emlinux/scripts/create_sbom.py", line 239, in <module>  
    main(parse_options())
  File "/home/build/work/repos/meta-emlinux/scripts/create_sbom.py", line 209, in main
    sbom_data = sbom_spdx.create_spdx_sbom(args.product, args.image, args.distro, installed_pkgs, args.supplier, license_mapping)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/lib/python/sbom/sbom_spdx.py", line 146, in create_spdx_sbom
    pkg_spdxid, package = create_package_info(packages[name], distro, license_mapping)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/lib/python/sbom/sbom_spdx.py", line 93, in create_package_info
    licenses = create_license_string(pkg, license_mapping)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/lib/python/sbom/sbom_spdx.py", line 88, in create_license_string
    return spdx_licensing.parse(s)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/.local/lib/python3.11/site-packages/license_expression/__init__.py", line 546, in parse
    raise ExpressionParseError(
license_expression.ExpressionParseError: Invalid expression nesting such as (AND xx) for token: "(" at position: 47
```

In the case, we set license as "unknown" instead of using given license text because create_sbom.py doesn't know what is the correct license text. User needs review unknown license.

## Commit cd0d2ed5e807a890647c6767b00db510f2f191e2

This commit fixes a method to change debug log level.
It should use logger instance instead of logging module.

# Test result

The create_sbom.py created  an sbom file successfully.

```
build@f80ef24b4276:~/work/build$ create_sbom.py \
    --image emlinux-image-base \
    --supplier "Cybertrust Japan Co., Ltd." \
    --product EMLinux3 \
    --sbom-format spdx
2025-09-19 03:47:24,720:INFO: Create spdx format sbom for emlinux-image-base
2025-09-19 03:47:24,778:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-raspberrypi3bplus-64/emlinux-image-base-spdx.json
```

License field contains "unknown" license.

```
            "licenseConcluded": "MIT AND Broadcom AND GPL-2.0-only AND unknown",
```