### PR TITLE
recipes-bsp/raspberrypi-bootfiles: Update licenses

### DIFF
--- a/recipes-bsp/raspberrypi-bootfiles/raspberrypi-bootfiles/copyright
+++ b/recipes-bsp/raspberrypi-bootfiles/raspberrypi-bootfiles/copyright
@@ -41,7 +41,7 @@ Files:
 Copyright:
  2007-2012 The Kronos Group Inc.
  2006-2012 Broadcom Europe Ltd.
-License: MIT or Apache-2 (FIXME)
+License: MIT and BSD-3-Clause
 
 Files:
  boot/kernel*.img


### PR DESCRIPTION
# Purpose

Files in opt/vc/include directory, license is defined in each files. According to each files, it remains MIT and BSD-3-Clause licenses are used.

# Test

Create an sbom and check licenses in raspberrypi-bootfiles package.

# Test result

Check the licenses field,  Apache-2 (FIXME) is not listed and BSD-3-Clause is listed.

```json
        {
            "bom-ref": "raspberrypi-bootfiles@1.20230405-2a6717f51c09fc1e65a96b40e5719ac1b1a094c265eec4572a810603d68edbb9",
            "description": "Raspberry Pi boot files",
            "group": "raspberrypi-bootfiles",
            "hashes": [
                {
                    "alg": "SHA-256",
                    "content": "3a7b5d11c3ec1e24d70499096c52d61ad6bc0d51c9c56a4f6a627b6c4c653b44"
                }
            ],
            "licenses": [
                {
                    "license": {
                        "name": "BSD-3-Clause"
                    }
                },
                {
                    "license": {
                        "name": "Broadcom"
                    }
                },
                {
                    "license": {
                        "name": "GPL-2"
                    }
                },
                {
                    "license": {
                        "name": "MIT"
                    }
                }
            ],
            "name": "raspberrypi-bootfiles",
            "purl": "pkg:deb/debian/raspberrypi-bootfiles@1.20230405?arch=arm64&distro=bookworm",
            "supplier": {
                "name": "Masami Ichikawa <masami.ichikawa@miraclelinux.com>"
            },
            "type": "application",
            "version": "1.20230405"
        },
```