### PR TITLE
Update kernel to v4.19.325-cip124

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "aed025ea2b4be27479946d3fd09245877fa68357"
-LINUX_CVE_VERSION ??= "5.10.240"
-LINUX_CIP_VERSION ?= "v5.10.240-cip63"
+LINUX_GIT_SRCREV ?= "08bc2d3f4ac6226aaaa43aced95da788d3ec4988"
+LINUX_CVE_VERSION ??= "5.10.241"
+LINUX_CIP_VERSION ?= "v5.10.241-cip64"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf

--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "019ba39c16cf7bf1e244899b97634f11923d4aa7"
+LINUX_GIT_SRCREV ?= "6ea7b609a0cdeea3232ae4b9f47472140c5beef2"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip122"
+LINUX_CIP_VERSION ??= "v4.19.325-cip124"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip124

This pull request update the kernel to the following cip versions:
v4.19.325-cip124 with hash tag 6ea7b609a0cdeea3232ae4b9f47472140c5beef2
