### PR TITLE
Update kernel to v5.10.245-cip65

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "08bc2d3f4ac6226aaaa43aced95da788d3ec4988"
-LINUX_CVE_VERSION ??= "5.10.241"
-LINUX_CIP_VERSION ?= "v5.10.241-cip64"
+LINUX_GIT_SRCREV ?= "b498ef8f495d37c2c5c2e190140f0c46cfa52f5b"
+LINUX_CVE_VERSION ??= "5.10.245"
+LINUX_CIP_VERSION ?= "v5.10.245-cip65"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.245-cip65

This pull request update the kernel to the following cip versions:
v5.10.245-cip65 with hash tag b498ef8f495d37c2c5c2e190140f0c46cfa52f5b
