### PR TITLE
Update kernel to v4.19.325-cip125

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "6ea7b609a0cdeea3232ae4b9f47472140c5beef2"
+LINUX_GIT_SRCREV ?= "d68802a940fe1efb4315cbd06f2fc8d9c861aec3"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip124"
+LINUX_CIP_VERSION ??= "v4.19.325-cip125"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip125

This pull request update the kernel to the following cip versions:
v4.19.325-cip125 with hash tag d68802a940fe1efb4315cbd06f2fc8d9c861aec3
