### PR TITLE
linux: linux-k510: Add CVE to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -119,6 +119,8 @@ do_shared_workdir_prepend () {
 # CVE-2024-50286: Vulnerable code not present.
 # CVE-2019-14899: This is not a kernel issue.
 # CVE-2023-32256: Vulnerable code not present.
+# CVE-2024-42147: Vulnerable code not present.
+# CVE-2024-56609: Vulnerable code not present.
 CVE_CHECK_WHITELIST = "\
     CVE-2021-43057 CVE-2015-8955 CVE-2020-8834 \
     CVE-2017-6264 CVE-2017-1000377 CVE-2007-2764 \
@@ -150,4 +152,5 @@ CVE_CHECK_WHITELIST = "\
     CVE-2024-27297 CVE-2024-49932 CVE-2025-37805 \
     CVE-2024-50086 CVE-2024-50112 CVE-2024-50217 \
     CVE-2024-50286 CVE-2019-14899 CVE-2023-32256 \
+    CVE-2024-42147 CVE-2024-56609 \
 "


### PR DESCRIPTION
# Purpose of pull request

Add CVEs to CVE\_CHECK\_WHITELIST which there is no vulnerable code in kernel 5.10.y.

- CVE-2024-42147  
- CVE-2024-56609

# Test

## How to test

Add the following to local.conf.

```
MACHINE = "qemuarm64"
DISTRO = "emlinux-k510"
INHERIT += " cve-check debian-cve-check kernel-cve-check"
```

Run cve-check command

```
$ bitbake linux-k510 -c cve_check
```

Then, compare the log (tmp-glibc/work/qemuarm64-emlinux-linux/linux-k510/5.10-r0/temp/cve.log)  between before and after this fix.

## Test result

Before this fix:

```
$ grep -A 1 -e CVE-2024-42147 -e CVE-2024-56609 cve_before.log 
CVE: CVE-2024-42147
CVE STATUS: Unpatched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2024-42147

--
CVE: CVE-2024-56609
CVE STATUS: Unpatched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2024-56609
```

After this fix:

```
$ grep -A 1 -e CVE-2024-42147 -e CVE-2024-56609 cve_after.log 
CVE: CVE-2024-42147
CVE STATUS: Patched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2024-42147

--
CVE: CVE-2024-56609
CVE STATUS: Patched
--
MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2024-56609
```
