### PR TITLE
cve-check: Update cve-check_ignore.yml file format

### DIFF
--- a/conf/cve/cve_check_ignore.yml
+++ b/conf/cve/cve_check_ignore.yml
@@ -1,24 +1,54 @@
 # format
 # debian source package name:
+#   version:
 #   - CVE ID
+# 
+# The version key takes following values
+# 1. linux-cip or linux-cip-rt:
+#   It can use version number which is in recipe name.
+#   e.g. 6.12 for linux-cip_6.12.bb, 6.1 for linux-cip_6.1.bb
+# 2. debian package
+#   When installing packages using IMAGE_PREINSTALL or IMAGE_INSTALL 
+#   from the same Debian release as the one specified in the DISTRO 
+#   variable(emlinux-<debian codename>).
+#   It can use debian codename such as bookworm, trixie.
+# 3. other 
+#   If neither of the above conditions 1 and 2 apply, for example,
+#   if you are backporting packages from a newer release of Debian 
+#   regardless of the version, or building from sources other than 
+#   Debian packages, use "all".
+#   
 # example.
 #linux-cip:
-#- CVE-2023-35825
+#  6.1:
+#    - CVE-2023-35825
+#bash:
+#  bookworm:
+#   - CVE-2023-45853
+#vim:
+#  bookworm:
+#    - CVE-2008-4677
+#  trixie:
+#    - CVE-2017-1000382
+#util-linux:
+#  all:
+#   - CVE-2022-0563
 linux-cip:
-  - CVE-2016-3699
-  - CVE-2017-6264
-  - CVE-2019-14899
-  - CVE-2020-26556
-  - CVE-2020-26557
-  - CVE-2020-26559
-  - CVE-2020-26560
-  - CVE-2021-0399
-  - CVE-2021-29256
-  - CVE-2021-3492
-  - CVE-2021-39802
-  - CVE-2022-2327
-  - CVE-2022-36397
-  - CVE-2023-0030
-  - CVE-2023-26242
-  - CVE-2023-3079
-  - CVE-2024-49928
+  6.1:
+    - CVE-2016-3699
+    - CVE-2017-6264
+    - CVE-2019-14899
+    - CVE-2020-26556
+    - CVE-2020-26557
+    - CVE-2020-26559
+    - CVE-2020-26560
+    - CVE-2021-0399
+    - CVE-2021-29256
+    - CVE-2021-3492
+    - CVE-2021-39802
+    - CVE-2022-2327
+    - CVE-2022-36397
+    - CVE-2023-0030
+    - CVE-2023-26242
+    - CVE-2023-3079
+    - CVE-2024-49928

--- a/scripts/cve_check.py
+++ b/scripts/cve_check.py
@@ -7,7 +7,6 @@
 #
 # SPDX-License-Identifier: MIT
 #
-
 import argparse
 import sys
 import os, os.path
@@ -15,6 +14,7 @@ import sqlite3
 import yaml
 import logging
 import debian.debian_support
+import re
 
 logging.basicConfig(level = logging.INFO, format='%(asctime)s:%(levelname)s: %(message)s')
 logger = logging.getLogger("emlinux-cve-check")
@@ -48,26 +48,82 @@ def get_cve_products(extra_cve_product):
 
     return data
 
-def get_cve_ignore(extra_cve_check_ignore):
+def get_cve_ignore(uniq_installed_pkgs, debian_codename, extra_cve_check_ignore):
     name = os.path.join(os.path.dirname(__file__), "../conf/cve/cve_check_ignore.yml")
 
-    data = None
-    with open(name, "r") as f:
-        data = yaml.safe_load(f)
+    def read_ignore_list(filename):
+        if filename is None:
+            return {}
 
-    if extra_cve_check_ignore:
-        with open(extra_cve_check_ignore, "r") as f:
-            tmp = yaml.safe_load(f)
-            if tmp:
-                if data is None:
-                    data = {}
-                for pkg in tmp:
-                    if pkg in data:
-                        data[pkg] = data[pkg] + tmp[pkg]
+        try:
+            with open(filename) as f:
+                return yaml.safe_load(f)
+        except FileNotFoundError:
+            logger.warn(f"File {filename} is not found")
+            return {}
+
+    # 1. Read default ignore data
+    tmp_merge_list = read_ignore_list(name)
+    # 2. Read extra ignore list
+    extra_data = read_ignore_list(extra_cve_check_ignore)
+
+    # backward compatibility
+    def make_backward_compatibility(data):
+        tmp = {}
+        for pkg in data:
+            if type(data[pkg]) is list:
+                tmp[pkg] = { "all": data[pkg] }
+            else:
+                tmp[pkg] = data[pkg]
+        return tmp
+
+    tmp_merge_list = make_backward_compatibility(tmp_merge_list)
+    extra_data = make_backward_compatibility(extra_data)
+
+    # 3. Merge default and extra list
+    if extra_data:
+        for pkg in extra_data:
+            if pkg in tmp_merge_list:
+                for ek in extra_data[pkg].keys():
+                    if ek in tmp_merge_list[pkg]:
+                        tmp_merge_list[pkg][ek] += extra_data[pkg][ek]
                     else:
-                        data[pkg] = tmp[pkg]
+                        tmp_merge_list[pkg][ek] = extra_data[pkg][ek]
+            else:
+                tmp_merge_list[pkg] = extra_data[pkg]
 
-    return data
+    # 4. Create complete ignore list
+    # This step does not collect CVE IDs which are not target distribution/linux version.
+    ignore_list = {}
+    all_used = []
+    for pkg in tmp_merge_list:
+        d = tmp_merge_list[pkg]
+        for version in d.keys():
+            if debian_codename == version:
+                ignore_list[pkg] = d[version]
+            elif version == "all":
+                if not pkg in ignore_list:
+                    ignore_list[pkg] = []
+                all_used.append(pkg)
+            else:
+                if not pkg in uniq_installed_pkgs:
+                    continue
+                pkg_version = str(uniq_installed_pkgs[pkg]["upstream_version"])
+                if str(version) == pkg_version:
+                    ignore_list[pkg] = d[version]
+                    break
+
+                ver_pattern = rf"\b{re.escape(str(version))}(?!\d)"
+                m = re.search(ver_pattern, pkg_version)
+                if m:
+                    if not pkg in ignore_list:
+                        ignore_list[pkg] = d[version]
+                    else:
+                        ignore_list[pkg].extend(d[version])
+
+    for pkg in all_used:
+        ignore_list[pkg].extend(tmp_merge_list[pkg]["all"])
+    return ignore_list
 
 def update_ignored_cves_status(cves, cve_ignore_list):
     if cve_ignore_list is None:
@@ -669,10 +725,10 @@ def main(args):
         exit(1)
 
     installed_pkgs = debian_cve.parse_dpkg_status(bitbakeinfo["dpkg_status"])
-    cve_products = get_cve_products(args.extra_cve_product)
-    cve_ignore_list = get_cve_ignore(args.extra_cve_check_ignore)
-
     uniq_installed_pkgs = create_unique_package(installed_pkgs)
+    cve_products = get_cve_products(args.extra_cve_product)
+    cve_ignore_list = get_cve_ignore(uniq_installed_pkgs, args.debian_codename, args.extra_cve_check_ignore)
+
     linux_kernel_src_dir = os.path.abspath(bitbakeinfo["kernel_srcdir"])
     cves = create_cves_info(db_file, debian_cve_list, uniq_installed_pkgs, installed_pkgs, args.debian_codename, cve_products, linux_kernel_src_dir, cip_kernel_sec_dir, kev_list)
 


### PR DESCRIPTION
# Purpose

Since EMLinux3 support several linux kernel version, debian releases,
and etc.
The ignore list needs to allow specifying which versions should be
subject to the ignore rule.

New format added "version_keyword" key to specify version.

```
source package name:
  version_keyword:
    - CVE ID
    - CVE ID
```

Since allowing free-form input for `version_keyword` would lead to
complexity, only the following three patterns will be considered:

- Settings for each Debian codename:
Specify the codename, such as bookworm or trixie.

- Setting upstream version number
The version number is checked by exact matching and prefix matching.

- For cases where the version is irrelevant, such as backporting packages
from newer Debian releases, or building from sources other than Debian
packages:
Set to "all".

Furthermore, to accommodate users who already have their own ignore
list, the program will automatically convert the old format to the
format that uses "all".

e.g. user defained ignore list has following data.

```
- foo
  - CVE-1111-111111
  - CVE-1111-222222
```

It will be converted to following data.

```
- foo
  all:
    - CVE-1111-111111
    - CVE-1111-222222
```

Examples:

Ignoring by version number.

```
linux-cip:
  6.1:
    - CVE-9999-00000
  6.12:
    - CVE-9999-11111

kmod:
  30:
    - CVE-1111-11111
  34:
    - CVE-2222-22222
```

Ignoring by debian codename.

```
vim:
  bookworm:
    - CVE-2008-4677
  trixie:
    - CVE-2017-1000382
```

Use all.

```
util-linux:
  all:
    - CVE-2022-0563
```

This PR added version to linux-cip 6.1 only.

# Test

# Compare cve check result current emlinux3 branch and this PR

## Prepare

1. Run cve check for emlinux-bookworm and emlinux-trixie both emlinux3 branch and with this PR.
2. Copy cve check result on emlinux3 branch to cve-before.
3. Copy cve check result on emlinux3 branch to cve-after.
4. Save following script to check.sh.

```shell
#!/bin/bash

if [ $# -ne 3 ]; then
  echo "usage $0 <diff file> <ignore list> <text|json>"
  exit 1
fi

filename="$1"
ignore_list="$2"
filetype="$3"

if [ "${filetype}" = "text" ]; then
  cves=$(grep "CVE:" "${filename}" | awk '{print $2}')
elif [ "${filetype}" = "json" ]; then
  cves=$(grep '"CVE":' "${filename}" | awk '{print $2}' | tr -d '"' | tr -d ',')
else
  echo "Unknown type ${filetype}"
  exit 1
fi

for cve in ${cves}; do
  ret=$(grep "${cve}" "${ignore_list}" >/dev/null; echo $?)
  if [ "$ret" = "0" ]; then
    echo "Found ${cve} in ${ignore_list}"
  else
    echo "${cve} is not found in ${ignore_list}"
  fi
done

```

## Check trixie

Default ignore list doesn't contain any CVE ID for linux-cip 6.12 so there are some difference.

Create diff files with following commands for text format.

```
diff -u ./cve-before/emlinux-image-base-emlinux-trixie-qemu-amd64/text/linux-cip ./cve-after/emlinux-image-base-emlinux-trixie-qemu-amd64/text/linux-cip | grep -e "CVE:" -e "CVE STATUS:" > text-linux-cip-diff.txt

diff -u ./cve-before/emlinux-image-base-emlinux-trixie-qemu-amd64/emlinux-image-base-emlinux-trixie-qemu-amd64_cve ./cve-after/emlinux-image-base-emlinux-trixie-qemu-amd64/emlinux-image-base-emlinux-trixie-qemu-amd64_cve | grep -e "CVE:" -e "CVE STATUS:" > text-all-diff.txt
```

Create diff files with following commands for json format.

```
diff -u <(jq --sort-keys . ./cve-before/emlinux-image-base-emlinux-trixie-qemu-amd64/json/linux-cip_cve.json) <(jq --sort-keys . ./cve-after/emlinux-image-base-emlinux-trixie-qemu-amd64/json/linux-cip_cve.json) > json-linux-cip-diff.txt

diff -u <(jq --sort-keys . ./cve-before/emlinux-image-base-emlinux-trixie-qemu-amd64/emlinux-image-base-emlinux-trixie-qemu-amd64_cve.json) <(jq --sort-keys . ./cve-after/emlinux-image-base-emlinux-trixie-qemu-amd64/emlinux-image-base-emlinux-trixie-qemu-amd64_cve.json) > json-all-diff.txt
```

### check linux-cip text file

#### Test emlinux-trixie

Check differences.

```
build@174254923c3a:~/work$ diff -Paur ./cve-before/emlinux-image-base-emlinux-trixie-qemu-amd64 ./cve-after/emlinux-image-base-emlinux-trixie-qemu-amd64 | diffstat
 emlinux-image-base-emlinux-trixie-qemu-amd64_cve      |   34 +++++++++++++++++-----------------
 emlinux-image-base-emlinux-trixie-qemu-amd64_cve.json |   34 +++++++++++++++++-----------------
 json/linux-cip_cve.json                               |   34 +++++++++++++++++-----------------
 text/linux-cip                                        |   34 +++++++++++++++++-----------------
 4 files changed, 68 insertions(+), 68 deletions(-)
```

Check difference in text/linux-cip file.

All CVE IDs that appeared as differences are ignored in version 6.1, but are not ignored in version 6.12, which is why they appeared as differences.

```
build@174254923c3a:~/work$ ./check.sh ./trixie-text-linux-cip-diff.txt ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml text
Found CVE-2016-3699 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2017-6264 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2019-14899 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26556 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26557 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26559 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26560 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-0399 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-29256 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-3492 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-39802 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-2327 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-36397 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-0030 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-26242 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-3079 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2024-49928 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
```

Check difference in emlinux-image-base-emlinux-trixie-qemu-amd64_cve file.

All CVE IDs that appeared as differences are ignored in version 6.1, but are not ignored in version 6.12, which is why they appeared as differences.

```
build@174254923c3a:~/work$ ./check.sh ./trixie-text-all-diff.txt ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml text
Found CVE-2016-3699 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2017-6264 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2019-14899 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26556 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26557 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26559 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26560 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-0399 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-29256 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-3492 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-39802 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-2327 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-36397 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-0030 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-26242 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-3079 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2024-49928 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
```

Check difference in  son/linux-cip_cve.json  file.

All CVE IDs that appeared as differences are ignored in version 6.1, but are not ignored in version 6.12, which is why they appeared as differences.

```
build@174254923c3a:~/work$ ./check.sh ./trixie-json-linux-cip-diff.txt ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml json
Found CVE-2016-3699 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2017-6264 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2019-14899 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26556 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26557 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26559 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26560 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-0399 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-29256 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-3492 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-39802 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-2327 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-36397 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-0030 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-26242 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-3079 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2024-49928 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
```

Check difference in  emlinux-image-base-emlinux-trixie-qemu-amd64_cve.json  file.

All CVE IDs that appeared as differences are ignored in version 6.1, but are not ignored in version 6.12, which is why they appeared as differences.

```
build@174254923c3a:~/work$ ./check.sh ./trixie-json-all-diff.txt ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml json
Found CVE-2016-3699 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2017-6264 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2019-14899 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26556 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26557 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26559 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26560 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-0399 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-29256 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-3492 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-39802 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-2327 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-36397 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-0030 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-26242 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-3079 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2024-49928 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
```

## Check bookworm

The bookworm doesn't have any difference because ignore list contains only CVE ID list for linux-cip 6.1.

```
build@174254923c3a:~/work$ diff -Paur ./cve-before/emlinux-image-base-emlinux-bookworm-qemu-amd64 ./cve-after/emlinux-image-base-emlinux-bookworm-qemu-amd64 | diffstat
 0 files changed
```

## Check bookworm with linux-cip 6.12

Check differences.

```
build@174254923c3a:~/work$ diff -Paur ./cve-before-6.12/emlinux-image-base-emlinux-bookworm-qemu-amd64 ./cve-after-6.12/emlinux-image-base-emlinux-bookworm-qemu-amd64 | diffstat
 emlinux-image-base-emlinux-bookworm-qemu-amd64_cve      |   34 +++++++++++++++++-----------------
 emlinux-image-base-emlinux-bookworm-qemu-amd64_cve.json |   34 +++++++++++++++++-----------------
 json/linux-cip_cve.json                                 |   34 +++++++++++++++++-----------------
 text/linux-cip                                          |   34 +++++++++++++++++-----------------
 4 files changed, 68 insertions(+), 68 deletions(-)
```

Check difference in text/linux-cip file.

All CVE IDs that appeared as differences are ignored in version 6.1, but are not ignored in version 6.12, which is why they appeared as differences.

```
build@174254923c3a:~/work$ ./check.sh bookworm-6.12-text-linux-cip-diff.txt ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml text
Found CVE-2016-3699 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2017-6264 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2019-14899 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26556 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26557 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26559 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26560 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-0399 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-29256 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-3492 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-39802 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-2327 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-36397 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-0030 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-26242 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-3079 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2024-49928 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
```

Check difference in emlinux-image-base-emlinux-trixie-qemu-amd64_cve file.

All CVE IDs that appeared as differences are ignored in version 6.1, but are not ignored in version 6.12, which is why they appeared as differences.

```
build@174254923c3a:~/work$ ./check.sh bookworm-6.12-text-all-diff.txt ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml text
Found CVE-2016-3699 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2017-6264 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2019-14899 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26556 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26557 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26559 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26560 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-0399 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-29256 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-3492 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-39802 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-2327 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-36397 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-0030 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-26242 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-3079 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2024-49928 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
```

Check difference in json/linux-cip_cve.json  file.

All CVE IDs that appeared as differences are ignored in version 6.1, but are not ignored in version 6.12, which is why they appeared as differences.

```
build@174254923c3a:~/work$ ./check.sh bookworm-6.12-json-linux-cip-diff.txt ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml json
Found CVE-2016-3699 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2017-6264 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2019-14899 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26556 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26557 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26559 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26560 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-0399 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-29256 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-3492 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-39802 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-2327 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-36397 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-0030 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-26242 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-3079 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2024-49928 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
```

Check difference in  emlinux-image-base-emlinux-trixie-qemu-amd64_cve.json  file.

All CVE IDs that appeared as differences are ignored in version 6.1, but are not ignored in version 6.12, which is why they appeared as differences.

```
build@174254923c3a:~/work$ ./check.sh bookworm-6.12-json-all-diff.txt ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml json
Found CVE-2016-3699 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2017-6264 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2019-14899 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26556 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26557 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26559 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2020-26560 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-0399 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-29256 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-3492 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2021-39802 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-2327 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2022-36397 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-0030 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-26242 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2023-3079 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
Found CVE-2024-49928 in ./repos/meta-emlinux/conf/cve/cve_check_ignore.yml
```

## Test new format

Before test apply following change to show ignore list data.

```
diff --git a/scripts/cve_check.py b/scripts/cve_check.py
index 9202bdd..e74205b 100755
--- a/scripts/cve_check.py
+++ b/scripts/cve_check.py
@@ -715,7 +715,10 @@ def main(args):
     uniq_installed_pkgs = create_unique_package(installed_pkgs)
     cve_products = get_cve_products(args.extra_cve_product)
     cve_ignore_list = get_cve_ignore(uniq_installed_pkgs, args.debian_codename, args.extra_cve_check_ignore)
-
+    import pprint
+    print("------------------")
+    pprint.pprint(cve_ignore_list)
+    print("------------------")
     linux_kernel_src_dir = os.path.abspath(bitbakeinfo["kernel_srcdir"])
     cves = create_cves_info(db_file, debian_cve_list, uniq_installed_pkgs, installed_pkgs, args.debian_codename, cve_products, linux_kernel_src_dir, cip_kernel_sec_dir, kev_list)
```

### Test version prefix matching

Create ignore_linux_cip.yml then set this file to --cve-ignore option.

```
linux-cip:
  6.1:
    - CVE-1111-11111
  6.12:
    - CVE-2222-22222

```

#### emlinux-bookworm result

CVE-1111-11111 is listed.

```
2025-11-19 00:47:06,069:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-19 00:47:06,069:INFO: Last database update is in 1day so skip NVD database update
2025-11-19 00:47:06,069:INFO: Update debian CVE database
2025-11-19 00:47:06,069:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 00:47:06,069:INFO: Update KEV database
2025-11-19 00:47:06,069:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 00:47:06,069:INFO: Update cip-kernel-sec
------------------
{'linux-cip': ['CVE-2016-3699',
               'CVE-2017-6264',
               'CVE-2019-14899',
               'CVE-2020-26556',
               'CVE-2020-26557',
               'CVE-2020-26559',
               'CVE-2020-26560',
               'CVE-2021-0399',
               'CVE-2021-29256',
               'CVE-2021-3492',
               'CVE-2021-39802',
               'CVE-2022-2327',
               'CVE-2022-36397',
               'CVE-2023-0030',
               'CVE-2023-26242',
               'CVE-2023-3079',
               'CVE-2024-49928',
               'CVE-1111-11111']}
------------------
2025-11-19 00:47:06,808:INFO: Checking CVEs ...
2025-11-19 00:47:46,154:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64
```

#### emlinux-trixie result

CVE-2222-22222 is listed.

```
2025-11-19 01:00:55,983:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-19 01:00:55,983:INFO: Last database update is in 1day so skip NVD database update
2025-11-19 01:00:55,983:INFO: Update debian CVE database
2025-11-19 01:00:55,983:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 01:00:55,983:INFO: Update KEV database
2025-11-19 01:00:55,983:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 01:00:55,983:INFO: Update cip-kernel-sec
------------------
{'linux-cip': ['CVE-2222-22222']}
------------------
2025-11-19 01:00:57,137:INFO: Checking CVEs ...
2025-11-19 01:01:35,296:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-trixie-qemu-amd64
```

### Test version prefix match

This test checks merge different pattern between emlinux's yml and extra yml files.
So, CVE-3333-3333 will be ignored all 6.x kernels.

```
linux-cip:
  6:
    - CVE-3333-33333
  5:
    - CVE-4444-44444
```

#### emlinux-bookworm

Only CVE-3333-33333 is merged.

```
2025-11-20 01:44:23,161:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-20 01:44:23,161:INFO: Last database update is in 1day so skip NVD database update
2025-11-20 01:44:23,161:INFO: Update debian CVE database
2025-11-20 01:44:23,161:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-20 01:44:23,161:INFO: Update KEV database
2025-11-20 01:44:23,161:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-20 01:44:23,161:INFO: Update cip-kernel-sec
------------------
{'linux-cip': ['CVE-2016-3699',
               'CVE-2017-6264',
               'CVE-2019-14899',
               'CVE-2020-26556',
               'CVE-2020-26557',
               'CVE-2020-26559',
               'CVE-2020-26560',
               'CVE-2021-0399',
               'CVE-2021-29256',
               'CVE-2021-3492',
               'CVE-2021-39802',
               'CVE-2022-2327',
               'CVE-2022-36397',
               'CVE-2023-0030',
               'CVE-2023-26242',
               'CVE-2023-3079',
               'CVE-2024-49928',
               'CVE-3333-33333']}
------------------
2025-11-20 01:44:23,940:INFO: Checking CVEs ...
2025-11-20 01:45:03,585:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64
```

#### emlinux-trixie

Only CVE-3333-33333 is meged.

```
2025-11-20 01:46:12,110:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-20 01:46:12,110:INFO: Last database update is in 1day so skip NVD database update
2025-11-20 01:46:12,110:INFO: Update debian CVE database
2025-11-20 01:46:12,110:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-20 01:46:12,110:INFO: Update KEV database
2025-11-20 01:46:12,110:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-20 01:46:12,110:INFO: Update cip-kernel-sec
------------------
{'linux-cip': ['CVE-3333-33333']}
------------------
2025-11-20 01:46:12,816:INFO: Checking CVEs ...
2025-11-20 01:46:50,915:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-trixie-qemu-amd64
```

### Test version exact match

Create ignore_kmod.yml then set this file to --cve-ignore option.
Version 30 is bookworm's version and 34 is trixie's version.

```
kmod:
  30:
    - CVE-1111-11111
  34:
    - CVE-2222-2222
```

#### emlinux-bookworm result

CVE-1111-11111 is listed.

```
2025-11-19 02:18:06,949:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-19 02:18:06,949:INFO: Last database update is in 1day so skip NVD database update
2025-11-19 02:18:06,949:INFO: Update debian CVE database
2025-11-19 02:18:06,949:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 02:18:06,949:INFO: Update KEV database
2025-11-19 02:18:06,949:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 02:18:06,949:INFO: Update cip-kernel-sec
------------------
{'kmod': ['CVE-1111-11111'],
 'linux-cip': ['CVE-2016-3699',
               'CVE-2017-6264',
               'CVE-2019-14899',
               'CVE-2020-26556',
               'CVE-2020-26557',
               'CVE-2020-26559',
               'CVE-2020-26560',
               'CVE-2021-0399',
               'CVE-2021-29256',
               'CVE-2021-3492',
               'CVE-2021-39802',
               'CVE-2022-2327',
               'CVE-2022-36397',
               'CVE-2023-0030',
               'CVE-2023-26242',
               'CVE-2023-3079',
               'CVE-2024-49928']}
------------------
2025-11-19 02:18:07,785:INFO: Checking CVEs ...
2025-11-19 02:18:47,481:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64
```

#### emlinux-trixie result

CVE-2222-22222 is listed.

```
2025-11-19 02:23:44,674:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-19 02:23:44,675:INFO: Last database update is in 1day so skip NVD database update
2025-11-19 02:23:44,675:INFO: Update debian CVE database
2025-11-19 02:23:44,675:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 02:23:44,675:INFO: Update KEV database
2025-11-19 02:23:44,675:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 02:23:44,675:INFO: Update cip-kernel-sec
------------------
{'kmod': ['CVE-2222-2222']}
------------------
2025-11-19 02:23:45,488:INFO: Checking CVEs ...
2025-11-19 02:24:24,215:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-trixie-qemu-amd64
```

### Test debian codename

Create ignore_vim.yml then set this file to --cve-ignore option.

```
vim:
  bookworm:
    - CVE-1111-11111
  trixie:
    - CVE-2222-22222
```

#### emlinux-bookworm result

CVE-1111-11111 is listed.

```
2025-11-19 01:20:19,661:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-19 01:20:19,661:INFO: Last database update is in 1day so skip NVD database update
2025-11-19 01:20:19,661:INFO: Update debian CVE database
2025-11-19 01:20:19,661:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 01:20:19,661:INFO: Update KEV database
2025-11-19 01:20:19,661:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 01:20:19,661:INFO: Update cip-kernel-sec
------------------
{'linux-cip': ['CVE-2016-3699',
               'CVE-2017-6264',
               'CVE-2019-14899',
               'CVE-2020-26556',
               'CVE-2020-26557',
               'CVE-2020-26559',
               'CVE-2020-26560',
               'CVE-2021-0399',
               'CVE-2021-29256',
               'CVE-2021-3492',
               'CVE-2021-39802',
               'CVE-2022-2327',
               'CVE-2022-36397',
               'CVE-2023-0030',
               'CVE-2023-26242',
               'CVE-2023-3079',
               'CVE-2024-49928'],
 'vim': ['CVE-1111-11111']}
------------------
2025-11-19 01:20:20,591:INFO: Checking CVEs ...
2025-11-19 01:21:00,416:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64
```

#### emlinux-trixie result

CVE-2222-22222 is listed.

```
2025-11-19 01:33:03,424:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-19 01:33:03,424:INFO: Last database update is in 1day so skip NVD database update
2025-11-19 01:33:03,424:INFO: Update debian CVE database
2025-11-19 01:33:03,424:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 01:33:03,424:INFO: Update KEV database
2025-11-19 01:33:03,424:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 01:33:03,424:INFO: Update cip-kernel-sec
------------------
{'vim': ['CVE-2222-22222']}
------------------
2025-11-19 01:33:04,191:INFO: Checking CVEs ...
2025-11-19 01:33:42,139:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-trixie-qemu-amd64
```

### Test all version

Create ignore_all.yml then set this file to --cve-ignore option.

```
linux-cip:
  all:
    - CVE-1111-11111
```

#### emlinux-bookworm result

CVE-1111-11111 is listed.

```
2025-11-19 05:18:22,355:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-19 05:18:22,356:INFO: Last database update is in 1day so skip NVD database update
2025-11-19 05:18:22,356:INFO: Update debian CVE database
2025-11-19 05:18:22,356:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 05:18:22,356:INFO: Update KEV database
2025-11-19 05:18:22,356:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 05:18:22,356:INFO: Update cip-kernel-sec
2025-11-19 05:18:23,162:INFO: Checking CVEs ...
------------------
{'linux-cip': ['CVE-2016-3699',
               'CVE-2017-6264',
               'CVE-2019-14899',
               'CVE-2020-26556',
               'CVE-2020-26557',
               'CVE-2020-26559',
               'CVE-2020-26560',
               'CVE-2021-0399',
               'CVE-2021-29256',
               'CVE-2021-3492',
               'CVE-2021-39802',
               'CVE-2022-2327',
               'CVE-2022-36397',
               'CVE-2023-0030',
               'CVE-2023-26242',
               'CVE-2023-3079',
               'CVE-2024-49928',
               'CVE-1111-11111']}
------------------
2025-11-19 05:19:02,571:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64
```

#### emlinux-trixie result

CVE-1111-11111 is listed.

```
2025-11-19 05:19:51,677:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-19 05:19:51,677:INFO: Last database update is in 1day so skip NVD database update
2025-11-19 05:19:51,677:INFO: Update debian CVE database
2025-11-19 05:19:51,677:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 05:19:51,678:INFO: Update KEV database
2025-11-19 05:19:51,678:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 05:19:51,678:INFO: Update cip-kernel-sec
2025-11-19 05:19:52,407:INFO: Checking CVEs ...
------------------
{'linux-cip': ['CVE-1111-11111']}
------------------
2025-11-19 05:20:30,437:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-trixie-qemu-amd64
```

### Test old format

Create ignore_old_format.yml then set this file to --cve-ignore option.

```
linux-cip:
  - CVE-1111-1111
```

#### emlinux-bookworm

CVE-1111-1111 is listed.

```
2025-11-19 04:57:07,812:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-19 04:57:07,812:INFO: Last database update is in 1day so skip NVD database update
2025-11-19 04:57:07,812:INFO: Update debian CVE database
2025-11-19 04:57:07,812:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 04:57:07,812:INFO: Update KEV database
2025-11-19 04:57:07,812:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 04:57:07,812:INFO: Update cip-kernel-sec
------------------
{'linux-cip': ['CVE-2016-3699',
               'CVE-2017-6264',
               'CVE-2019-14899',
               'CVE-2020-26556',
               'CVE-2020-26557',
               'CVE-2020-26559',
               'CVE-2020-26560',
               'CVE-2021-0399',
               'CVE-2021-29256',
               'CVE-2021-3492',
               'CVE-2021-39802',
               'CVE-2022-2327',
               'CVE-2022-36397',
               'CVE-2023-0030',
               'CVE-2023-26242',
               'CVE-2023-3079',
               'CVE-2024-49928',
               'CVE-1111-1111']}
------------------
2025-11-19 04:57:08,578:INFO: Checking CVEs ...
2025-11-19 04:57:48,317:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64
```

#### emliunx-trixie

CVE-1111-1111 is listed.

```
2025-11-19 04:55:45,731:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2025-11-19 04:55:45,731:INFO: Last database update is in 1day so skip NVD database update
2025-11-19 04:55:45,731:INFO: Update debian CVE database
2025-11-19 04:55:45,731:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 04:55:45,731:INFO: Update KEV database
2025-11-19 04:55:45,731:INFO: Last database update is in 1day so skip Debian CVE database update
2025-11-19 04:55:45,731:INFO: Update cip-kernel-sec
------------------
{'linux-cip': ['CVE-1111-1111']}
------------------
2025-11-19 04:55:46,778:INFO: Checking CVEs ...
2025-11-19 04:56:25,269:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-trixie-qemu-amd64
```