### PR TITLE
Update kernel to v5.10.246-cip66

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "b498ef8f495d37c2c5c2e190140f0c46cfa52f5b"
-LINUX_CVE_VERSION ??= "5.10.245"
-LINUX_CIP_VERSION ?= "v5.10.245-cip65"
+LINUX_GIT_SRCREV ?= "b3874eb8d40fba738c24a65b1d3a4b98c8da7f8f"
+LINUX_CVE_VERSION ??= "5.10.246"
+LINUX_CIP_VERSION ?= "v5.10.246-cip66"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.246-cip66

This pull request update the kernel to the following cip versions:
v5.10.246-cip66 with hash tag b3874eb8d40fba738c24a65b1d3a4b98c8da7f8f
