### PR TITLE
Update kernel to v4.19.325-cip126

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "d68802a940fe1efb4315cbd06f2fc8d9c861aec3"
+LINUX_GIT_SRCREV ?= "f67c504655343a57dc76388946d47cbb487e7649"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip125"
+LINUX_CIP_VERSION ??= "v4.19.325-cip126"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip126

This pull request update the kernel to the following cip versions:
v4.19.325-cip126 with hash tag f67c504655343a57dc76388946d47cbb487e7649
