### PR TITLE
docker/Dockerfile: Install bubblewrap to satisfy Isar's additional dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update --fix-missing && apt-get -y upgrade --fix-missing
 
 RUN apt-get install --fix-missing -y \
   binfmt-support \
+  bubblewrap \
   debootstrap \
   dosfstools \
   dpkg-dev \


### PR DESCRIPTION
This fixes the `bwrap not found` issue that will happen after introducing the rootless support in the Isar upstream.