### PR TITLE
README: Add bubblewrap to satisfy Isar's additional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Run following command to install required packages.
 ```
 $ sudo apt install \
   binfmt-support \
+  bubblewrap \
   debootstrap \
   dosfstools \
   dpkg-dev \


### PR DESCRIPTION
This fixes the `bwrap not found` issue that will happen after introducing the rootless support in the Isar upstream.