### PR TITLE
docker: Fix gitproxy not working issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,13 +64,12 @@ ENV LANGUAGE en_US.UTF-8
 
 ADD gitproxy /usr/bin
 RUN chmod +x /usr/bin/gitproxy
-RUN bash -c 'if test -n "$http_proxy"; then sed -i -e "s#\(http_proxy=\"\).*#\1$http_proxy\"#" /usr/bin/gitproxy; fi'
 
 USER build
 WORKDIR /home/build
 
 RUN bash -c 'if test -n "$http_proxy"; then git config --global http.proxy "$http_proxy"; \
-                                            git config --global core.gitproxy gitproxy; fi'
+                                            git config --global core.gitproxy "/usr/bin/gitproxy"; fi'
 RUN bash -c 'if test -n "$https_proxy"; then git config --global https.proxy "$https_proxy"; fi'
 RUN bash -c 'if test -n "$no_proxy"; then git config --global core.noproxy "$no_proxy"; fi'
 

--- a/docker/gitproxy
+++ b/docker/gitproxy
@@ -1,2 +1,45 @@
-#!/bin/sh
-exec socat STDIO PROXY:$http_proxy:$1:$2
+#!/bin/bash
+#
+# Script for using proxy with git protocol
+#
+# The http_proxy environment variable is expected to have the following format:
+# - http_proxy="http://proxy.example.com"
+#   socat command HTTP proxy port default value: 8080
+# - http_proxy="http://proxy.example.com:1234"
+# - http_proxy="http://username:password@proxy.example.com:1234"
+#
+# Also can specify an IPv4/IPv6 address.
+# For IPv6 address use '[]'.
+# e.g.:
+# - http_proxy="127.0.0.1:8080"
+# - http_proxy="[::1]:8080"
+#
+
+_proxy_string=`echo ${http_proxy##http*:\/\/}`
+if [[ ${_proxy_string} == *@* ]]; then
+    _proxy_serverport=`echo ${_proxy_string##*@}`
+    _proxy_userpass=`echo ${_proxy_string%%@*}`
+    _proxyuser=`echo ${_proxy_userpass%:*}`
+    _proxypass=`echo ${_proxy_userpass#*:}`
+    if [ -n "${_proxyuser}" ] && [ -n "${_proxypass}" ]; then
+        proxyauth=",proxyauth=${_proxyuser}:${_proxypass}"
+    fi
+else
+    _proxy_serverport="${_proxy_string}"
+fi
+
+if [[ ${_proxy_serverport} == *\[*\]* ]]; then
+    _tmp_port=`echo ${_proxy_serverport/\[*\]/}`
+    _proxyserver=`echo ${_proxy_serverport/${_tmp_port}/}`
+    _proxyport=`echo ${_tmp_port##*:}`
+elif [[ ${_proxy_serverport} == *:* ]]; then
+    _proxyserver=`echo ${_proxy_serverport%:*}`
+    _proxyport=`echo ${_proxy_serverport##*:}`
+else
+    _proxyserver="${_proxy_serverport}"
+fi
+if [ -n "${_proxyport}" ]; then
+    proxyport=",proxyport=${_proxyport}"
+fi
+
+exec socat STDIO PROXY:${_proxyserver}:$1:$2${proxyport}${proxyauth}


### PR DESCRIPTION
# Purpose of pull request

Within Docker container build environment, do_fetch fails when SRC_URI uses the git protocol and goes through a proxy.

So, fixed it as follows:
- Fix Dockerfile file
  - gitproxy script specification to full path
  - Remove unnecessary line Do not edit the `gitproxy` file within the Dockerfile.
- Fix gitproxy script The gitproxy file was backported from meta-debian:
  - 740c80da docker: Add support proxy for git protocol And some additional modifications:
  - Change '/bin/sh' to '/bin/bash'
  - Supports 'https://' protocol
  - Supports no port specification
  - Supports IPv4/IPv6 address specification

# Test
## How to test

1. Run script to rebuild docker container
   ```
   repos/meta-emlinux$ docker/run.sh clean
   repos/meta-emlinux$ docker/run.sh build
   ```

2. Run script to enter docker container
   ```
   repos/meta-emlinux$ docker/run.sh
   ```

3. Check to `gitproxy` is full path

   ```
   $ git config core.gitproxy
   ```

4. Check `gitproxy` file

   ```
   $ ls -la /usr/bin/gitproxy
   $ cat /usr/bin/gitproxy
   ```

5. Unit testing for `gitproxy`

   Copy it to `gitproxy_unittest` and change the last line to echo output.
   ``` diff
   $ sudo cp /usr/bin/gitproxy /usr/bin/gitproxy_unittest
   $ sudo vi /usr/bin/gitproxy_unittest
   $ diff -up /usr/bin/gitproxy /usr/bin/gitproxy_unittest
   --- /usr/bin/gitproxy	2025-12-09 03:53:40.000000000 +0000
   +++ /usr/bin/gitproxy_unittest	2025-12-09 04:11:03.081771895 +0000
   @@ -42,4 +42,4 @@ if [ -n "${_proxyport}" ]; then
        proxyport=",proxyport=${_proxyport}"
    fi
    
   -exec socat STDIO PROXY:${_proxyserver}:$1:$2${proxyport}${proxyauth}
   +echo "exec socat STDIO PROXY:${_proxyserver}:$1:$2${proxyport}${proxyauth}"
   ```

   Check the result output by combinating:
   - Specify domain, IPv4 address and IPv6 address
   - Proxy port with and without
   - "username:password" with and without
   - http or https

   That is, run the following command:
   ```
   http_proxy="http://proxy.example.com" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://127.0.0.1" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://[::1]" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://proxy.example.com:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://127.0.0.1:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://[::1]:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://username:password@proxy.example.com" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://username:password@127.0.0.1" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://username:password@[::1]" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://username:password@proxy.example.com:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://username:password@127.0.0.1:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="http://username:password@[::1]:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://proxy.example.com" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://127.0.0.1" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://[::1]" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://proxy.example.com:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://127.0.0.1:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://[::1]:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://username:password@proxy.example.com" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://username:password@127.0.0.1" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://username:password@[::1]" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://username:password@proxy.example.com:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://username:password@127.0.0.1:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   http_proxy="https://username:password@[::1]:1234" /usr/bin/gitproxy_unittest '$1' '$2'
   ```

## Test result

### 2. Run script to enter docker container

```
repos/meta-emlinux$ ./docker/run.sh 
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
Creating docker_emlinux3-build_run ... done
build@749d175cc37f:~/work$ 
```

### 3. Check to `gitproxy` is full path

Checked that `gitproxy` specification is a full path.

```
build@749d175cc37f:~/work$ git config core.gitproxy
/usr/bin/gitproxy
```

### 4. Check `gitproxy` file

The `gitproxy` file is correctly placed.

```
build@749d175cc37f:~/work$ ls -la /usr/bin/gitproxy
-rwxrwxr-x 1 root root 1468 Dec  9 03:53 /usr/bin/gitproxy
build@749d175cc37f:~/work$ cat /usr/bin/gitproxy
#!/bin/bash
#
# Script for using proxy with git protocol
#
# The http_proxy environment variable is expected to have the following format:
# - http_proxy="http://proxy.example.com"
#   socat command HTTP proxy port default value: 8080
# - http_proxy="http://proxy.example.com:1234"
# - http_proxy="http://username:password@proxy.example.com:1234"
#
# Also can specify an IPv4/IPv6 address.
# For IPv6 address use '[]'.
# e.g.:
# - http_proxy="127.0.0.1:8080"
# - http_proxy="[::1]:8080"
#

_proxy_string=`echo ${http_proxy##http*:\/\/}`
if [[ ${_proxy_string} == *@* ]]; then
    _proxy_serverport=`echo ${_proxy_string##*@}`
    _proxy_userpass=`echo ${_proxy_string%%@*}`
    _proxyuser=`echo ${_proxy_userpass%:*}`
    _proxypass=`echo ${_proxy_userpass#*:}`
    if [ -n "${_proxyuser}" ] && [ -n "${_proxypass}" ]; then
        proxyauth=",proxyauth=${_proxyuser}:${_proxypass}"
    fi
else
    _proxy_serverport="${_proxy_string}"
fi

if [[ ${_proxy_serverport} == *\[*\]* ]]; then
    _tmp_port=`echo ${_proxy_serverport/\[*\]/}`
    _proxyserver=`echo ${_proxy_serverport/${_tmp_port}/}`
    _proxyport=`echo ${_tmp_port##*:}`
elif [[ ${_proxy_serverport} == *:* ]]; then
    _proxyserver=`echo ${_proxy_serverport%:*}`
    _proxyport=`echo ${_proxy_serverport##*:}`
else
    _proxyserver="${_proxy_serverport}"
fi
if [ -n "${_proxyport}" ]; then
    proxyport=",proxyport=${_proxyport}"
fi

exec socat STDIO PROXY:${_proxyserver}:$1:$2${proxyport}${proxyauth}
```

### 5. Unit testing for `gitproxy`

Checked that it is appropriately converted according to the input parameters.

```
build@749d175cc37f:~/work$ http_proxy="http://proxy.example.com" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:proxy.example.com:$1:$2
build@749d175cc37f:~/work$ http_proxy="http://127.0.0.1" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:127.0.0.1:$1:$2
build@749d175cc37f:~/work$ http_proxy="http://[::1]" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:[::1]:$1:$2
build@749d175cc37f:~/work$ http_proxy="http://proxy.example.com:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:proxy.example.com:$1:$2,proxyport=1234
build@749d175cc37f:~/work$ http_proxy="http://127.0.0.1:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:127.0.0.1:$1:$2,proxyport=1234
build@749d175cc37f:~/work$ http_proxy="http://[::1]:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:[::1]:$1:$2,proxyport=1234
build@749d175cc37f:~/work$ http_proxy="http://username:password@proxy.example.com" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:proxy.example.com:$1:$2,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="http://username:password@127.0.0.1" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:127.0.0.1:$1:$2,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="http://username:password@[::1]" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:[::1]:$1:$2,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="http://username:password@proxy.example.com:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:proxy.example.com:$1:$2,proxyport=1234,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="http://username:password@127.0.0.1:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:127.0.0.1:$1:$2,proxyport=1234,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="http://username:password@[::1]:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:[::1]:$1:$2,proxyport=1234,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="https://proxy.example.com" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:proxy.example.com:$1:$2
build@749d175cc37f:~/work$ http_proxy="https://127.0.0.1" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:127.0.0.1:$1:$2
build@749d175cc37f:~/work$ http_proxy="https://[::1]" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:[::1]:$1:$2
build@749d175cc37f:~/work$ http_proxy="https://proxy.example.com:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:proxy.example.com:$1:$2,proxyport=1234
build@749d175cc37f:~/work$ http_proxy="https://127.0.0.1:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:127.0.0.1:$1:$2,proxyport=1234
build@749d175cc37f:~/work$ http_proxy="https://[::1]:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:[::1]:$1:$2,proxyport=1234
build@749d175cc37f:~/work$ http_proxy="https://username:password@proxy.example.com" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:proxy.example.com:$1:$2,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="https://username:password@127.0.0.1" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:127.0.0.1:$1:$2,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="https://username:password@[::1]" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:[::1]:$1:$2,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="https://username:password@proxy.example.com:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:proxy.example.com:$1:$2,proxyport=1234,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="https://username:password@127.0.0.1:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:127.0.0.1:$1:$2,proxyport=1234,proxyauth=username:password
build@749d175cc37f:~/work$ http_proxy="https://username:password@[::1]:1234" /usr/bin/gitproxy_unittest '$1' '$2'
exec socat STDIO PROXY:[::1]:$1:$2,proxyport=1234,proxyauth=username:password
```