### PR TITLE
Update kernel to v5.10.247-cip67

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "b3874eb8d40fba738c24a65b1d3a4b98c8da7f8f"
-LINUX_CVE_VERSION ??= "5.10.246"
-LINUX_CIP_VERSION ?= "v5.10.246-cip66"
+LINUX_GIT_SRCREV ?= "a39d4c75952517f473d99710cc33aeb781524fc4"
+LINUX_CVE_VERSION ??= "5.10.247"
+LINUX_CIP_VERSION ?= "v5.10.247-cip67"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.247-cip67

This pull request update the kernel to the following cip versions:
v5.10.247-cip67 with hash tag a39d4c75952517f473d99710cc33aeb781524fc4
