### PR TITLE
remove linux-headers from SDK when KERNEL_NAME is blank

### DIFF
--- a/conf/distro/emlinux-common.inc
+++ b/conf/distro/emlinux-common.inc
@@ -43,5 +43,5 @@ SDK_PREINSTALL += " \
   libssl-dev \
   libelf-dev"
 
-SDK_INSTALL += "linux-headers-${KERNEL_NAME}"
+SDK_INSTALL += "${@ "linux-headers-"+d.getVar('KERNEL_NAME') if d.getVar('KERNEL_NAME') else '' }"
 

--- a/recipes-core/images/emlinux-image-base.bb
+++ b/recipes-core/images/emlinux-image-base.bb
@@ -27,6 +27,7 @@ IMAGE_PREINSTALL:append = "\
   iputils-ping \
   procps \
   vim-tiny \
+  udev \
 "
 inherit image
 

--- a/recipes-core/images/emlinux-image-weston.bb
+++ b/recipes-core/images/emlinux-image-weston.bb
@@ -12,7 +12,7 @@ DESCRIPTION = "EMLinux target filesystem to enable Weston"
 
 IMAGE_INSTALL:append = " weston-init"
 
-IMAGE_PREINSTALL:append = " weston libgl1 libpam-systemd kbd udev"
+IMAGE_PREINSTALL:append = " weston libgl1 libpam-systemd kbd"
 IMAGE_PREINSTALL:append:trixie = " seatd"
 
 GROUPS += "weston-launch"

--- a/recipes-core/images/emlinux-image-weston.bb
+++ b/recipes-core/images/emlinux-image-weston.bb
@@ -12,13 +12,11 @@ DESCRIPTION = "EMLinux target filesystem to enable Weston"
 
 IMAGE_INSTALL:append = " weston-init"
 
-IMAGE_PREINSTALL:append = " weston libgl1 libpam-systemd kbd"
+IMAGE_PREINSTALL:append = " weston libgl1 libpam-systemd kbd udev"
 IMAGE_PREINSTALL:append:trixie = " seatd"
 
 GROUPS += "weston-launch"
 GROUP_weston-launch[flags] = "system"
-GROUPS += "render"
-GROUP_render[flags] = "system"
 GROUPS += "wayland"
 GROUP_wayland[flags] = "system"
 


### PR DESCRIPTION
# Purpose

This commit adds an option to create an image without a kernel when `KERNEL_NAME = ""` is defined in local.conf.
This option is mainly intended for providing images for kernel testing.

* This option was only verified to build for the QEMU.

# Test
## How to test
setting local.conf as below.
```sh
MACHINE = "qemu-arm64"
KERNEL_NAME = ""
```

build `emlinux-image-base`.
```sh
$ bitbake emlinux-image-base
```

# Test result

The build was succeed.
```
$ bitbake emlinux-image-base
Loading cache: 100% |######################################################################| Time: 0:00:00
Loaded 1848 entries from dependency cache.
Parsing recipes: 100% |####################################################################| Time: 0:00:01
Parsing of 1260 .bb files complete (1140 cached, 120 parsed). 2208 targets, 12 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 7 Local 0 Mirrors 0 Missed 7 Current 0 (0% match, 0% complete)      | ETA:  0:00:00
Initialising tasks: 100% |#################################################################| Time: 0:00:00
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 52 tasks of which 7 didn't need to be rerun and all succeeded.

$
```

The build artifacts are as below. confirmed without a kernel image.
```sh
$ ls -l tmp/deploy/images/qemu-arm64/
total 184696
-rw-r--r-- 1 build build    123446 Jan  5 18:37 emlinux-image-base-emlinux-bookworm-qemu-arm64.dpkg_status
-rw-r--r-- 1 build build 306900992 Jan  5 18:37 emlinux-image-base-emlinux-bookworm-qemu-arm64.ext4
-rw-r--r-- 1 build build      6391 Jan  5 18:37 emlinux-image-base-emlinux-bookworm-qemu-arm64.manifest
$
```
