### PR TITLE
generic:x86-64: Update kernel cmdline parameter when bootlower with grub

### DIFF
--- a/scripts/lib/wic/canned-wks/generic-x86-64.wks.in
+++ b/scripts/lib/wic/canned-wks/generic-x86-64.wks.in
@@ -12,5 +12,5 @@ part /boot --source bootimg-efi-isar --sourceparams "loader=grub-efi" --label ef
 
 part / --source rootfs --fstype ext4 --mkfs-extraopts "-T default" --label platform --size=${ROOTFS_EXTRA} --align 1024 --use-uuid
 
-bootloader --ptable gpt --timeout 2 --append "rw console=ttyS0,115200 console=tty0"
+bootloader --ptable gpt --timeout 2 --append "rw console=ttyS0,115200 console=tty0 ${ADDITIONAL_KERNEL_CMDLINE}"
 

--- a/scripts/lib/wic/canned-wks/generic-x86-64.wks.in
+++ b/scripts/lib/wic/canned-wks/generic-x86-64.wks.in
@@ -12,5 +12,5 @@ part /boot --source bootimg-efi-isar --sourceparams "loader=grub-efi" --label ef
 
 part / --source rootfs --fstype ext4 --mkfs-extraopts "-T default" --label platform --size=${ROOTFS_EXTRA} --align 1024 --use-uuid
 
-bootloader --ptable gpt --timeout 2 --append "console=ttyS0,115200 console=tty0"
+bootloader --ptable gpt --timeout 2 --append "rw console=ttyS0,115200 console=tty0"
 


### PR DESCRIPTION
This PR contains two commits.

# commit: fc5cd6f92b5ecb72030d0d7c0a51ad8d7cbc84d7

This commit added ADDITIONAL_KERNEL_CMDLINE variable to customize kernel cmdline.

Use ADDITIONAL_KERNEL_CMDLINE variable to append kernel cmdline. This variable is used in meta-isar/scripts/lib/wic/canned-wks/installer-efi.wks.in and meta-isar/recipes-core/images/isar-image-installer.bb so we use same variable.


# commit: bf7050c20e0e1ad1923983f40e0bfe5009b79f32

This commit added "rw" option in the kernel cmdline to solve following issue.

Without rw option, rootfs will be mounted read only first, the re-mount with read/write option.
In this case, firstboot which is run at fisrt time,  will run on ro rootfs. In the result, some firstboot process fails because it cannot create symbolic link onto the rootfs.

# Current problem

In the kernel cmdline, rw option is not set.

```
root@EMLinux3:~# cat /proc/cmdline 
BOOT_IMAGE=/vmlinuz-6.1.159-cip49 root=PARTUUID=3d221ac1-96fe-47f8-b46b-eecc81f8c092 rootwait console=ttyS0,115200 console=tty0
```

The firstboot process couldn't create symbolic link file so that systemd-networkd is not running even though preset is enabeld.

```
root@EMLinux3:~# systemctl status systemd-networkd
○ systemd-networkd.service - Network Configuration
     Loaded: loaded (/lib/systemd/system/systemd-networkd.service; disabled; preset: enabled)
     Active: inactive (dead)
TriggeredBy: ○ systemd-networkd.socket
       Docs: man:systemd-networkd.service(8)
             man:org.freedesktop.network1(5)
```

# Test

qemu command line is here.

```
sudo qemu-system-x86_64 \                                                                                                                                                    
  -drive file=./tmp/deploy/images/generic-x86-64/emlinux-image-base-emlinux-bookworm-generic-x86-64.wic,discard=unmap,if=none,id=disk,format=raw \                           
  -m 1G \                                                                                                                                                                    
  -serial mon:stdio \                                                                                                                                                        
  -cpu qemu64 \                                                                                                                                                              
  -smp 4 \                                                                                                                                                                   
  -machine q35,accel=kvm:tcg \                                                                                                                                               
  -global ICH9-LPC.noreboot=off \                                                                                                                                            
  -device ide-hd,drive=disk \                                                                                                                                                
  -nographic \                                                                                                                                                               
  -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd \                                                                                                
  -drive if=pflash,format=raw,file=/usr/share/OVMF/OVMF_VARS.fd  
```

## Checking rw option 

1. Bulid emlinux-image-base
2. Run qemu to boot emlinux-image-base
3. Check /proc/cmdline
4. Check status of systemd-networkd

## Checking additional kernel cmdline options

1. Add  'ADDITIONAL_KERNEL_CMDLINE:append = " earlyprintk"' in local.conf
2. Run qemu to boot emlinux-image-base
3. Check /proc/cmdline

# Test Result

## Test result of Checking rw option 

rw option is set.

```
root@EMLinux3:~# cat /proc/cmdline 
BOOT_IMAGE=/vmlinuz-6.1.159-cip49 root=PARTUUID=f5da7416-d04b-4616-8e7f-8075bc21eec0 rootwait rw console=ttyS0,115200 console=tty0
```

systemd-networkd is running.

```
root@EMLinux3:~# systemctl status systemd-networkd
● systemd-networkd.service - Network Configuration
     Loaded: loaded (/lib/systemd/system/systemd-networkd.service; enabled; preset: enabled)
     Active: active (running) since Wed 2026-01-07 04:22:38 UTC; 52s ago
TriggeredBy: ● systemd-networkd.socket
       Docs: man:systemd-networkd.service(8)
             man:org.freedesktop.network1(5)
   Main PID: 302 (systemd-network)
     Status: "Processing requests..."
      Tasks: 1 (limit: 1087)
     Memory: 3.0M
        CPU: 13ms
     CGroup: /system.slice/systemd-networkd.service
             └─302 /lib/systemd/systemd-networkd

Jan 07 04:22:38 EMLinux3 systemd[1]: Starting systemd-networkd.service - Network Configuration...
Jan 07 04:22:38 EMLinux3 systemd-networkd[302]: lo: Link UP
Jan 07 04:22:38 EMLinux3 systemd-networkd[302]: lo: Gained carrier
Jan 07 04:22:38 EMLinux3 systemd-networkd[302]: Enumeration completed
Jan 07 04:22:38 EMLinux3 systemd[1]: Started systemd-networkd.service - Network Configuration.
```

## Test result of Checking additional kernel cmdline options

ealryprintk option is set.

```
root@EMLinux3:~# cat /proc/cmdline 
BOOT_IMAGE=/vmlinuz-6.1.159-cip49 root=PARTUUID=5efc325c-ceb8-42c0-b88e-56425fa49ef8 rootwait rw console=ttyS0,115200 console=tty0 earlyprintk
```

