### PR TITLE
setup-emlinux: Do not run the script directly

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ $BASH_SOURCE == "$0" ]]; then
+  echo "Please run this script using the source command."
+  exit
+fi
+
 clean_up()
 {
     unset EML_BUILDDIR EML_BUILDDIR_SETUP_DONE REPOS EML_HOOKS


### PR DESCRIPTION
# Purpose of pull request

The setup-emlinux script is not intended to be run directly, so added condition to guard.

# Test

## Case 1
Confirmed that the added message was output.
```
build@a65a408cb733:~/work$ ./setup-emlinux TEST
Please run this script using the source command.
```

## Case 2
Confirmed that it operates normally.
```
build@a65a408cb733:~/work$ . setup-emlinux TEST
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/


### Shell environment set up for builds. ###

You can now run 'bitbake <target>'

Common targets are:
    core-image-minimal
    core-image-sato
    meta-toolchain
    meta-ide-support

You can also run generated qemu images with a command like 'runqemu qemux86'
NOTE: Starting bitbake server...
NOTE: Starting bitbake server...
NOTE: Starting bitbake server...
```