### PR TITLE
Update kernel to v5.10.247-cip68

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "a39d4c75952517f473d99710cc33aeb781524fc4"
+LINUX_GIT_SRCREV ?= "a8e956a4892cfb1679f0177eb48ef2a2d5576237"
 LINUX_CVE_VERSION ??= "5.10.247"
-LINUX_CIP_VERSION ?= "v5.10.247-cip67"
+LINUX_CIP_VERSION ?= "v5.10.247-cip68"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.247-cip68

This pull request update the kernel to the following cip versions:
v5.10.247-cip68 with hash tag a8e956a4892cfb1679f0177eb48ef2a2d5576237
