### PR TITLE
Migrate from recipe helper including to class inheriting

### DIFF
--- a/recipes-bsp/u-boot/u-boot_2023.04.bb
+++ b/recipes-bsp/u-boot/u-boot_2023.04.bb
@@ -6,7 +6,7 @@
 
 FILESPATH:append := ":${FILE_DIRNAME}/files"
 
-require recipes-bsp/u-boot/u-boot-custom.inc
+inherit u-boot
 
 SRC_URI += " \
     https://ftp.denx.de/pub/u-boot/u-boot-${PV}.tar.bz2"

--- a/recipes-kernel/linux/includes/linux-cip-common.inc
+++ b/recipes-kernel/linux/includes/linux-cip-common.inc
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-require recipes-kernel/linux/linux-custom.inc
+inherit linux-kernel
 
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=${BRANCH};destsuffix=${P};protocol=https \


### PR DESCRIPTION
This aligns with the following conversion of recipe helper includes to classes in the Isar upsteam.

https://github.com/ilbers/isar/commit/202c4b7dfe2a156ed9bd523e952379a6fd4e6953