### PR TITLE
sbom: Fix 2 bugs in sbom creation

### DIFF
--- a/scripts/create_sbom.py
+++ b/scripts/create_sbom.py
@@ -181,13 +181,17 @@ def main(args):
     rootfs = bitbakeinfo["rootfs_dir"]
     dpkg_status = bitbakeinfo["dpkg_status"]
 
+    distro = args.distro
+    if not distro:
+        distro = bitbakeinfo["image_distro"].split("-")[1]
+
     installed_pkgs = parse_dpkg_status(dpkg_status)
     
     user_defined_licenses = read_user_defined_license_file(args.user_defined_licenses)
     license_mapping = read_license_mapping_file(args.user_defined_license_mapping)
 
     packages_info = get_package_info_from_control(bitbakeinfo["dl_dir"], bitbakeinfo["repo_isar_dir"],
-            args.distro, bitbakeinfo["image_distro"], bitbakeinfo["distro_arch"])
+            distro, bitbakeinfo["image_distro"], bitbakeinfo["distro_arch"])
 
     installed_pkgs = merge_package_data(installed_pkgs, packages_info)
 
@@ -204,9 +208,9 @@ def main(args):
     logger.info(f"Create {args.sbom_format} format sbom for {args.image}")
 
     if args.sbom_format == "cyclonedx":
-        sbom_data = sbom_cyclonedx.create_cyclonedx_sbom(args.product, args.image, args.distro, installed_pkgs, args.supplier, license_mapping)
+        sbom_data = sbom_cyclonedx.create_cyclonedx_sbom(args.product, args.image, distro, installed_pkgs, args.supplier, license_mapping)
     else:
-        sbom_data = sbom_spdx.create_spdx_sbom(args.product, args.image, args.distro, installed_pkgs, args.supplier, license_mapping)
+        sbom_data = sbom_spdx.create_spdx_sbom(args.product, args.image, distro, installed_pkgs, args.supplier, license_mapping)
 
     if sbom_data:
         write_sbom_json(output_filepath, sbom_data)
@@ -222,7 +226,7 @@ def parse_options():
     parser.add_argument("--sbom-format", dest="sbom_format", help="spdx or cyclonedx",
             metavar="SBOM_FORMAT", required=True)
     parser.add_argument("--distro", dest="distro", help="debian distro name(e.g. bookworm)",
-            default="bookworm", metavar="DISTRO")
+            metavar="DISTRO")
     parser.add_argument("--licenses", dest="user_defined_licenses", help="license yaml file",
             metavar="FILE")
     parser.add_argument("--license-mapping", dest="user_defined_license_mapping", help="license mapping yaml file",

--- a/scripts/lib/python/sbom/licensing.py
+++ b/scripts/lib/python/sbom/licensing.py
@@ -35,6 +35,8 @@ def split_licesense_and_normalize(lic, license_mapping):
 
     if ", and " in lic:
         lics += normalize_licenses(split_licenses(lic, ", and "), license_mapping)
+    elif "," in lic:
+        lics += normalize_licenses(split_licenses(lic, ","), license_mapping)
     elif "/" in lic:
         tmp = normalize_licenses(split_licenses(lic, "/"), license_mapping)
         lics.append("-".join(tmp))


### PR DESCRIPTION
This PR fixes 2 bugs in sbom creation.

## Commit d3a8b6aa44c6e7fb8813b7ab68bdcd2084ce4f9 
Current code set args.distro is set to "bookworm" when user doesn't give the parameter. If DISTO is set to "emlinux-trixie", this behavior causes following bug.
 
```
2026-01-21 00:56:34,793:INFO: Create spdx format sbom for emlinux-image-weston
Traceback (most recent call last):
  File "/home/build/work/repos/meta-emlinux/scripts/create_sbom.py", line 239, in <module>
    main(parse_options())
  File "/home/build/work/repos/meta-emlinux/scripts/create_sbom.py", line 209, in main
    sbom_data = sbom_spdx.create_spdx_sbom(args.product, args.image, args.distro, installed_pkgs, args.supplier, license_mapping)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/lib/python/sbom/sbom_spdx.py", line 156, in create_spdx_sbom
    pkg_spdxid, package = create_package_info(packages[name], distro, license_mapping)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/build/work/repos/meta-emlinux/scripts/lib/python/sbom/sbom_spdx.py", line 129, in create_package_info
    description = pkg["description"],
                  ~~~^^^^^^^^^^^^^^^
KeyError: 'description'
```

This commit unset default value when define command line option and get distro name from DISTRO environment by default.

## 4f28e46fc5dd3e1d0c26dc6e0226c3b72f5cf2fe
This commit removes "," from license text that causes following error when creating an sbom for emlinux-trixie.

```
license_expression.ExpressionError: Invalid license key: the valid characters are: letters and numbers, underscore, dot, colon or hyphen signs and spaces: 'GPL-2.0-or-later-WITH-distribution-exception,-Expat'
```

# Test

We use following command to create an sbom.

```
create_sbom.py --image emlinux-image-weston \
        --supplier "Cybertrust Japan Co., Ltd." \
        --product EMLinux3 \
        --sbom-format spdx 
```

## Test create an sbom for emlinux-trixie

1. Set DISTRO variable to "emlinux-trixie"
2. Build emlinux-image-weston
3. Create sbom

## Test remove comma from license text

Create an sbom without this PR's patch.


1. Set DISTRO to "emlinux-bookworm"
2. Build emlinux-image-weston
3. Copy sbom file into some directory

Create an sbom with this PR's patch.
Create sbom for emlinux-bookworm.

1. Set DISTRO to "emlinux-bookworm"
2. Build emlinux-image-weston
3. Copy sbom file into some directory

Create sbom for emlinux-trixie.
1. Set DISTRO variable to "emlinux-trixie"
2. Build emlinux-image-weston
3. Run following command
Prepare checksbom.py file.
 
```
#!/usr/bin/env python3

import sys
import json
import pprint

def check_license_diff(str1, str2):
    set1 = set(item.strip() for item in str1.split(" AND "))
    set2 = set(item.strip() for item in str2.split(" AND "))
    
    added = set2 - set1
    removed = set1 - set2
    
    return added, removed

def read_file(filename):
    with open(filename) as f:
        return json.load(f)

def read_licenses(data):
    ret = {}
    for pkg in data["packages"]:
        name = pkg["name"]
        ret[name] = {
            "licenseConcluded": pkg["licenseConcluded"],
            "licenseDeclared": pkg["licenseDeclared"],
        }

    return ret

def main(file1, file2):
    data1 = read_file(file1)
    data2 = read_file(file2)

    licenses1 = read_licenses(data1)
    licenses2 = read_licenses(data2)

    if not sorted(licenses1) == sorted(licenses2):
        print(f"data mismatch: {file1} and {file2}")
        exit(0)

    result = True
    for pkg in sorted(licenses1):
        for target in ["licenseConcluded", "licenseDeclared"]:
            old_val = licenses1[pkg][target]
            new_val = licenses2[pkg][target]

            added, removed = check_license_diff(old_val, new_val)
            if added or removed:
                print(f"{pkg}: added: {added}")
                print(f"{pkg}: removed: {removed}")
                result = False

    if result:
        print(f"There are no differences in {file1} and {file2}")
    else:
        print(f"There are some differences in {file1} and {file2}")

if __name__ == "__main__":
    if not len(sys.argv) == 3:
        print(f"usage: $0 file1 file2")
        exit(0)

    main(sys.argv[1], sys.argv[2])
```

# Test results

## Test create an sbom for emlinux-trixie

The sbom was successfully created.

```
build@f7ce7deae250:~/work/build$ create_sbom.py --image emlinux-image-weston \
        --supplier "Cybertrust Japan Co., Ltd." \
        --product EMLinux3 \
        --sbom-format spdx 
2026-01-21 01:12:42,328:INFO: Create spdx format sbom for emlinux-image-weston
2026-01-21 01:12:42,456:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-weston-emlinux-trixie-qemu-amd64/emlinux-image-weston-spdx.json
```

## Test remove comma from license text

Check difference in emlinux-bookworm's sboms.

```
build@f7ce7deae250:~/work/build$ ./checksbom.py old-emlinux-image-weston-spdx.json new-emlinux-image-weston-spdx.json 
There are no differences in old-emlinux-image-weston-spdx.json and new-emlinux-image-weston-spdx.json
```

As shown in "Test create an sbom for emlinux-trixie" section, we successfully created sbom for emlinux-trixie.