### PR TITLE
setup-emlinux: Add generetad version comment to local.conf

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -10,6 +10,26 @@ clean_up()
     unset EML_BUILDDIR EML_BUILDDIR_SETUP_DONE REPOS EML_HOOKS
 }
 
+get_generated_comment()
+{
+    tagname="2.x"
+    if [ -d "../.repo/manifests/" ]; then
+        cd ../.repo/manifests
+        submodule="$(git submodule status | grep 'emlinux-manifests')"
+        if [ -n "${submodule}" ]; then
+            tmptag="${submodule}"
+            tmptag="${tmptag#*(}"
+            tmptag="${tmptag%)}"
+        else
+            tmptag="$(git describe --tags --abbrev=0)"
+        fi
+        if [ -n "${tmptag}" ]; then
+            tagname="${tmptag}"
+        fi
+    fi
+    echo "# The above settings were generated in EMLinux ${tagname} on $(date '+%Y-%m-%d')"
+}
+
 # save error during 'source setup-emlinux'
 _ERROR=0
 trap '_ERROR=$?' ERR
@@ -73,6 +93,7 @@ if [ -z "$TEMPLATECONF" ] && [ "${EML_BUILDDIR_SETUP_DONE}" = "false" ]; then
 	    source ${EML_HOOKS}/$hook
 	done
     fi
+    echo "$(get_generated_comment)" >> conf/local.conf
 fi
 
 clean_up


### PR DESCRIPTION
# Purpose of pull request

Add EMLinux version and date it was created as comment to local.conf generated by setup-emlinux script.

Example comment added to local.conf:
  ```
  # The above settings were generated in EMLinux 2.x-202601 on 2026-01-27
  ```

# Test
## Case 1
Confirmed that comment was added to local.conf with EMLinux version and date.
```
build@6b260b863556:~/work$ . setup-emlinux TEST1
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/


### Shell environment set up for builds. ###

You can now run 'bitbake <target>'

Common targets are:
    core-image-minimal
    core-image-sato
    meta-toolchain
    meta-ide-support

You can also run generated qemu images with a command like 'runqemu qemux86'
NOTE: Starting bitbake server...
NOTE: Starting bitbake server...
NOTE: Starting bitbake server...
build@6b260b863556:~/work/TEST1$ tail -n 1 conf/local.conf 
# The above settings were generated in EMLinux 2.x-202602 on 2026-01-27
```

## Case 2: In other project, reference emlinux-manifests in git-submodule
Confirmed that expected comment in git-submodule case.
```
build@642d1c4b19b3:~/work$ echo "$(cd .repo/manifests && git submodule status)"
 aef92b1f123febc094a92cdbe84921c3e23b7f4e emlinux-manifests (2.x-202512)
build@642d1c4b19b3:~/work$ . setup-emlinux TEST2
...<snip>...
build@642d1c4b19b3:~/work/TEST2$ tail -n 1 conf/local.conf 
# The above settings were generated in EMLinux 2.x-202512 on 2026-01-27
```

## Case 3: If emlinux-manifests does not exist

Confirmed that ouputed "EMLinux 2.x" (without version) in the local.conf comment as expected.
```
build@6b260b863556:~/work$ rm -fr .repo/
build@6b260b863556:~/work$ . setup-emlinux TEST3
...<snip>...
build@6b260b863556:~/work/TEST3$ tail -n 1 conf/local.conf 
# The above settings were generated in EMLinux 2.x on 2026-01-27
```