### PR TITLE
Update kernel to v4.19.325-cip129

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "6b680c057fd57fa9a38b4a9e76f7196f7159b4c4"
+LINUX_GIT_SRCREV ?= "b09f197499cfd4abeabbb8b072196af192931a60"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip127"
+LINUX_CIP_VERSION ??= "v4.19.325-cip129"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip129

This pull request update the kernel to the following cip versions:
v4.19.325-cip129 with hash tag b09f197499cfd4abeabbb8b072196af192931a60
