### PR TITLE
conf/licenses: Add licenses for trixie packages

### DIFF
--- a/conf/licenses/licenses.yml
+++ b/conf/licenses/licenses.yml
@@ -12,6 +12,10 @@ busybox:
   licenses: [
     GPL-2,
   ]
+busybox-static:
+  licenses: [
+    GPL-2,
+  ]
 debian-archive-keyring:
   licenses: [
     GPL-3,
@@ -28,6 +32,24 @@ gcc-12-base:
     GPL-2,
     GPL-3,
     LGPL
+  ]
+gcc-14-base:
+  licenses: [
+    Artistic,
+    GPL-3.0-only,
+    GPL-3.0-or-later,
+    GPL-3.0-with-GCC-exception,
+    BSD-3-Clause,
+    MIT,
+    GFDL-1.2,
+    GPL-2.0-or-later,
+    LGPL-2.1-only,
+    LGPL-2.1-or-later,
+    LGPL-3.0,
+    public-domain,
+    Zlib,
+    BSL-1.0,
+    Unicode-DFS-2015
   ]
 initramfs-tools:
   licenses: [
@@ -50,6 +72,24 @@ libasound2-data:
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1061276
   licenses: [
     LGPL-2.1+,
+  ]
+libatomic1:
+  licenses: [
+    Artistic,
+    GPL-3.0-only,
+    GPL-3.0-or-later,
+    GPL-3.0-with-GCC-exception,
+    BSD-3-Clause,
+    MIT,
+    GFDL-1.2,
+    GPL-2.0-or-later,
+    LGPL-2.1-only,
+    LGPL-2.1-or-later,
+    LGPL-3.0,
+    public-domain,
+    Zlib,
+    BSL-1.0,
+    Unicode-DFS-2015
   ]
 libc-bin:
   licenses: [
@@ -103,6 +143,15 @@ libgcrypt20:
     LGPL
   ]
 libgnutls30:
+  licenses: [
+    Apache-2.0,
+    GFDL-1.3,
+    GPL,
+    GPL-3,
+    LGPL,
+    LGPL-3
+  ]
+libgnutls30t64:
   licenses: [
     Apache-2.0,
     GFDL-1.3,
@@ -168,6 +217,22 @@ libpython3.11-minimal:
 libpython3.11-stdlib:
   licenses: [
     PSF-2.0,
+  ]
+libpython3.13:
+  licenses: [
+    PSF-2.0
+  ]
+libpython3.13-minimal:
+  licenses: [
+    PSF-2.0
+  ]
+libpython3.13-minimal:
+  licenses: [
+    PSF-2.0
+  ]
+libpython3.13-stdlib:
+  licenses: [
+    PSF-2.0
   ]
 librtmp1:
   licenses: [


### PR DESCRIPTION
# Purpose

This PR adds some licenses for Debian trixie packages.

# Test

1. Set following lines in local.conf

```
DISTRO = "emlinux-trixie"
IMAGE_PREINSTALL:append = " busybox-static"
IMAGE_PREINSTALL:append = " gcc-14-base libatomic1"
IMAGE_PREINSTALL:append = " libgnutls30t64"
IMAGE_PREINSTALL:append = " libpython3.13 libpython3.13-minimal libpython3.13-stdlib"
```

2. Build emlinux-image-base.
3. Create an sbom by following command line. 

```
create_sbom.py \
    --image emlinux-image-base \
    --supplier "Cybertrust Japan Co., Ltd." \
    --product EMLinux3 \
    --sbom-format spdx 
```

4. Check licenses by following command line.

```
jq '.packages[] | select(.name == "busybox-static" or .name == "gcc-14-base" or .name == "libatomic1" or .name == "libgnutls30t64" or .name == "libpython3.13" or .name == "libpython3.13-minimal" or .name == "libpython3.13-stdlib") | {pkg: .name, license: .licenseConcluded}'  build/tmp/deploy/sbom/emlinux-image-base-emlinux-trixie-qemu-amd64/emlinux-image-base-spdx.json 
```

# Test result

Without this PR, licenses are reported as unknown.

```
build@b1cbbe66fd85:~/work$ jq '.packages[] | select(.name == "busybox-static" or .name == "gcc-14-base" or .name == "libatomic1" or .name == "libgnutls30t64" or .name == "libpython3.13" or .name == "libpython3.13-minimal" or .name == "libpython3.13-stdlib") | {pkg: .name, license: .licenseConcluded}'  build/tmp/deploy/sbom/emlinux-image-base-emlinux-trixie-qemu-amd64/emlinux-image-base-spdx.json 
{
  "pkg": "busybox-static",
  "license": "unknown"
}
{
  "pkg": "gcc-14-base",
  "license": "unknown"
}
{
  "pkg": "libatomic1",
  "license": "unknown"
}
{
  "pkg": "libgnutls30t64",
  "license": "unknown"
}
{
  "pkg": "libpython3.13",
  "license": "unknown"
}
{
  "pkg": "libpython3.13-minimal",
  "license": "unknown"
}
{
  "pkg": "libpython3.13-stdlib",
  "license": "unknown"
}
```

Applying this PR,  licenses are reported without unknown data.

```
build@b1cbbe66fd85:~/work$ jq '.packages[] | select(.name == "busybox-static" or .name == "gcc-14-base" or .name == "libatomic1" or .name == "libgnutls30t64" or .name == "libpython3.13" or .name == "libpython3.13-minimal" or .name == "libpython3.13-stdlib") | {pkg: .name, license: .licenseConcluded}'  build/tmp/deploy/sbom/emlinux-image-base-emlinux-trixie-qemu-amd64/emlinux-image-base-spdx.json 
{
  "pkg": "busybox-static",
  "license": "GPL-2.0-only"
}
{
  "pkg": "gcc-14-base",
  "license": "Zlib AND LicenseRef-scancode-public-domain AND LGPL-3.0-only AND GPL-3.0-only AND MIT AND BSL-1.0 AND GPL-3.0-or-later AND GPL-3.0-with-GCC-exception AND LGPL-2.1-only AND LGPL-2.1-or-later AND GPL-2.0-or-later AND Unicode-DFS-2015 AND GFDL-1.2-only AND Artistic AND BSD-3-Clause"
}
{
  "pkg": "libatomic1",
  "license": "Zlib AND LicenseRef-scancode-public-domain AND LGPL-3.0-only AND GPL-3.0-only AND MIT AND BSL-1.0 AND GPL-3.0-or-later AND GPL-3.0-with-GCC-exception AND LGPL-2.1-only AND LGPL-2.1-or-later AND GPL-2.0-or-later AND Unicode-DFS-2015 AND GFDL-1.2-only AND Artistic AND BSD-3-Clause"
}
{
  "pkg": "libgnutls30t64",
  "license": "LGPL-3.0-only AND GFDL-1.3-only AND GPL-3.0-only AND Apache-2.0 AND LGPL AND GPL-1.0-or-later"
}
{
  "pkg": "libpython3.13",
  "license": "PSF-2.0"
}
{
  "pkg": "libpython3.13-minimal",
  "license": "PSF-2.0"
}
{
  "pkg": "libpython3.13-stdlib",
  "license": "PSF-2.0"
}
```