### PR TITLE
Update kernel to v5.10.249-cip69

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "a8e956a4892cfb1679f0177eb48ef2a2d5576237"
-LINUX_CVE_VERSION ??= "5.10.247"
-LINUX_CIP_VERSION ?= "v5.10.247-cip68"
+LINUX_GIT_SRCREV ?= "cef11f8ad4f7713b1df34ed101be4a0ec1e1a216"
+LINUX_CVE_VERSION ??= "5.10.249"
+LINUX_CIP_VERSION ?= "v5.10.249-cip69"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.249-cip69

This pull request update the kernel to the following cip versions:
v5.10.249-cip69 with hash tag cef11f8ad4f7713b1df34ed101be4a0ec1e1a216
