### PR TITLE
linux-k510, linux-base: Add patch to fix the RTC driver issue

### DIFF
--- a/recipes-kernel/linux/linux-base/0001-rtc-interface-skip-near-future-check-if-setting-alar.patch
+++ b/recipes-kernel/linux/linux-base/0001-rtc-interface-skip-near-future-check-if-setting-alar.patch
@@ -1,0 +1,43 @@
+From ca5fa008a39693c82c829609344b9b4755c74a4d Mon Sep 17 00:00:00 2001
+From: Akira Shibakawa <akira.shibakawa@miraclelinux.com>
+Date: Tue, 17 Feb 2026 07:36:56 +0000
+Subject: [PATCH] rtc: interface: skip near-future check if setting alarm fails
+
+In __rtc_set_alarm(), a check was previously introduced (see Fixes tag)
+to handle a race condition when an alarm is set to expire in the near
+future.
+
+However, if the attempt to set the alarm fails (e.g., returns -EINVAL
+when set_alarm is not implemented, or -ENODEV when rtc->ops is missing),
+the subsequent near-future check then overwrites this 'err' variable
+with the result of __rtc_read_time() (which is 0 for success).
+
+This causes __rtc_set_alarm() to return 0, falsely indicating that an
+alarm has been scheduled. This misleading return value confuses userspace
+tools like hwclock.
+
+Fix this by only performing the near-future race check if the alarm
+was successfully set (err == 0).
+
+Fixes: 795cda8338ea ("rtc: interface: Fix long-standing race when setting alarm")
+Signed-off-by: Akira Shibakawa <akira.shibakawa@miraclelinux.com>
+---
+ drivers/rtc/interface.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/rtc/interface.c b/drivers/rtc/interface.c
+index d86fcf03624b..b4a54775e09f 100644
+--- a/drivers/rtc/interface.c
++++ b/drivers/rtc/interface.c
+@@ -467,7 +467,7 @@ static int __rtc_set_alarm(struct rtc_device *rtc, struct rtc_wkalrm *alarm)
+ 	 * are in, we can return -ETIME to signal that the timer has already
+ 	 * expired, which is true in both cases.
+ 	 */
+-	if ((scheduled - now) <= 1) {
++	if (err == 0 && (scheduled - now) <= 1) {
+ 		err = __rtc_read_time(rtc, &tm);
+ 		if (err)
+ 			return err;
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-base_git.bbappend
+++ b/recipes-kernel/linux/linux-base_git.bbappend
@@ -2,7 +2,11 @@ require linux-common.inc
 
 PV = "4.19"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:${THISDIR}/linux-base:"
+
+SRC_URI_append = "\
+    file://0001-rtc-interface-skip-near-future-check-if-setting-alar.patch \
+"
 
 CVE_VERSION = "${LINUX_CVE_VERSION}"
 

--- a/recipes-kernel/linux/linux-k510/0001-rtc-interface-skip-near-future-check-if-setting-alar.patch
+++ b/recipes-kernel/linux/linux-k510/0001-rtc-interface-skip-near-future-check-if-setting-alar.patch
@@ -1,0 +1,43 @@
+From ee1e608f4e5f5887f0421a8ba229e321c87edfc7 Mon Sep 17 00:00:00 2001
+From: Akira Shibakawa <akira.shibakawa@miraclelinux.com>
+Date: Fri, 13 Feb 2026 09:27:46 +0000
+Subject: [PATCH] rtc: interface: skip near-future check if setting alarm fails
+
+In __rtc_set_alarm(), a check was previously introduced (see Fixes tag)
+to handle a race condition when an alarm is set to expire in the near
+future.
+
+However, if the attempt to set the alarm fails (e.g., returns -EINVAL
+when set_alarm is not implemented, or -ENODEV when rtc->ops is missing),
+the subsequent near-future check then overwrites this 'err' variable
+with the result of __rtc_read_time() (which is 0 for success).
+
+This causes __rtc_set_alarm() to return 0, falsely indicating that an
+alarm has been scheduled. This misleading return value confuses userspace
+tools like hwclock.
+
+Fix this by only performing the near-future race check if the alarm
+was successfully set (err == 0).
+
+Fixes: 795cda8338ea ("rtc: interface: Fix long-standing race when setting alarm")
+Signed-off-by: Akira Shibakawa <akira.shibakawa@miraclelinux.com>
+---
+ drivers/rtc/interface.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/rtc/interface.c b/drivers/rtc/interface.c
+index 9d2a2637246e..f3f8b7c215c8 100644
+--- a/drivers/rtc/interface.c
++++ b/drivers/rtc/interface.c
+@@ -456,7 +456,7 @@ static int __rtc_set_alarm(struct rtc_device *rtc, struct rtc_wkalrm *alarm)
+ 	 * are in, we can return -ETIME to signal that the timer has already
+ 	 * expired, which is true in both cases.
+ 	 */
+-	if ((scheduled - now) <= 1) {
++	if (err == 0 && (scheduled - now) <= 1) {
+ 		err = __rtc_read_time(rtc, &tm);
+ 		if (err)
+ 			return err;
+-- 
+2.25.1
+

--- a/recipes-kernel/linux/linux-k510_git.bb
+++ b/recipes-kernel/linux/linux-k510_git.bb
@@ -6,10 +6,13 @@ PV = "5.10"
 PROVIDES += " linux-k510"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:${THISDIR}/linux-k510:"
 
 FILESEXTRAPATHS_append := ":${LAYERDIR_DEBIAN_debian}/recipes-kernel/linux/files/"
 
+SRC_URI_append = "\
+    file://0001-rtc-interface-skip-near-future-check-if-setting-alar.patch \
+"
 KERNEL_CONFIG_COMMAND = "oe_runmake_call O=${B} -C ${S} olddefconfig"
 
 CVE_VERSION = "${LINUX_CVE_VERSION}"


### PR DESCRIPTION
# Purpose of pull request

Due to the following upstream patch, in environments where the RTC driver does not support alarm setting (such as ek874), the return value of `__rtc_set_alarm()` can be overwritten with 0 (success) under certain conditions, instead of the error code that should originally be returned. [https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master\&id=795cda8338eab036013314dbc0b04aae728880ab](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=master&id=795cda8338eab036013314dbc0b04aae728880ab)

This causes user-space commands like `hwclock` to misinterpret that the timer has been set successfully, leading to unintended behavior such as timeouts.

Below is an example using the `hwclock` command included in the util-linux package:

```
root@ek874:~# hwclock -r
hwclock: select() to /dev/rtc0 to wait for clock tick timed out
```

I have added a patch to fix this issue.  
Please refer to the comments within the patch for further details.

# Test

I built images for the following combinations of MACHINE, DISTRO and images. Then, confirmed that the `hwclock` command from the util-linux package executes correctly.   
Note that for ls1046ardb and qemuarm64, the RTC drivers support alarm setting; therefore, the aforementioned issue does not occur regardless of this fix.

* ek874 / k419 / core-image-weston  
* ek874 / k510 / core-image-weston  
* ls1046ardb / k510 / core-image-minimal  
* qemuarm64 / k419 / core-image-minimal  
* qemuarm64 / k510 / core-image-minimal


## ek874 / k419 / core-image-weston  

```
$ ln -sf ../repos/meta-emlinux-ext-rzg2/scripts/add-layer-emlinux-ext-rzg2 setup-hooks/30-add-layer-emlinux-ext-rzg2
$ source setup-emlinux build
```

Add the following to local.conf:

```
MACHINE = "ek874"
IMAGE_INSTALL_append = " util-linux-hwclock"
```

Build image:

```
$ bitbake core-image-weston
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "ek874"
DISTRO               = "emlinux"
DISTRO_VERSION       = "2.12"
TUNE_FEATURES        = "aarch64 cortexa53 crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:614ce13688c547c874244e6c6da000d91bc389a3"
meta-debian-extended = "HEAD:48e16dffb5380981c9db75c0fb124a2e4a2e3df5"
meta-emlinux         = "fix-rtc-issue:c5328898ecd0de4fbc99c9b369705ff055a166a6"
meta-emlinux-private = "HEAD:23617b571efaca4c4fd9b4669da7b33480d36cc3"
meta-emlinux-ext-rzg2 = "HEAD:e7ba60a9464c33c65c8510ec139a3e93222ac549"
...
NOTE: Tasks Summary: Attempted 5339 tasks of which 5 didn't need to be rerun and all succeeded.
```

Confirmed that hwclock command from util-linux package works:

```
root@ek874:~# uname -a
Linux ek874 4.19.325-cip128-st12 #1 SMP PREEMPT Mon Mar 2 10:02:01 UTC 2026 aarch64 GNU/Linux

root@ek874:~# ls -l /sbin/hwclock*
lrwxrwxrwx    1 root     root            24 Mar  2 10:03 /sbin/hwclock -> /sbin/hwclock.util-linux
-rwxr-xr-x    1 root     root         80848 Mar  2 08:53 /sbin/hwclock.util-linux

root@ek874:~# /sbin/hwclock -r
2026-03-02 10:05:21.809562+00:00
```

## ek874 / k510 / core-image-weston  

```
$ ln -sf ../repos/meta-emlinux-ext-rzg2/scripts/add-layer-emlinux-ext-rzg2 setup-hooks/30-add-layer-emlinux-ext-rzg2
$ source setup-emlinux build
```

Add the following to local.conf:

```
MACHINE = "ek874"
DISTRO = "emlinux-k510"
DISTRO_FEATURES_remove = "x11"
IMAGE_INSTALL_append = " util-linux-hwclock"
```

Build image:

```
$ bitbake core-image-weston
...
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "ek874"
DISTRO               = "emlinux-k510"
DISTRO_VERSION       = "2.12"
TUNE_FEATURES        = "aarch64 cortexa53 crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:614ce13688c547c874244e6c6da000d91bc389a3"
meta-debian-extended = "HEAD:48e16dffb5380981c9db75c0fb124a2e4a2e3df5"
meta-emlinux         = "fix-rtc-issue:c5328898ecd0de4fbc99c9b369705ff055a166a6"
meta-emlinux-private = "HEAD:23617b571efaca4c4fd9b4669da7b33480d36cc3"
meta-emlinux-ext-rzg2 = "HEAD:e7ba60a9464c33c65c8510ec139a3e93222ac549"
...
NOTE: Tasks Summary: Attempted 4689 tasks of which 5 didn't need to be rerun and all succeeded.
```

Confirmed that hwclock command from util-linux package works:

```
root@ek874:~# uname -a
Linux ek874 5.10.249-cip69 #1 SMP PREEMPT Mon Mar 2 10:04:06 UTC 2026 aarch64 GNU/Linux

root@ek874:~# ls -l /sbin/hwclock*
lrwxrwxrwx    1 root     root            24 Mar  2 10:05 /sbin/hwclock -> /sbin/hwclock.util-linux
-rwxr-xr-x    1 root     root         80848 Mar  2 09:12 /sbin/hwclock.util-linux

root@ek874:~# /sbin/hwclock -r
2026-03-02 10:17:30.934734+00:00
```

## ls1046ardb / k510 / core-image-minimal

```
$ ln -sf ../repos/meta-emlinux-ext-qoriq/scripts/add-layer-emlinux-ext-qoriq setup-hooks/30-add-layer-emlinux-ext-qoriq
$ source setup-emlinux build
```

Add the following to local.conf:

```
MACHINE = "ls1046ardb"
IMAGE_INSTALL_append = " util-linux-hwclock"
DISTRO = "emlinux-k510"
```

Build image:

```
$ bitbake core-image-minimal
...
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "ls1046ardb"
DISTRO               = "emlinux-k510"
DISTRO_VERSION       = "2.12"
TUNE_FEATURES        = "aarch64"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:614ce13688c547c874244e6c6da000d91bc389a3"
meta-debian-extended = "HEAD:48e16dffb5380981c9db75c0fb124a2e4a2e3df5"
meta-emlinux         = "fix-rtc-issue:c5328898ecd0de4fbc99c9b369705ff055a166a6"
meta-emlinux-private = "HEAD:23617b571efaca4c4fd9b4669da7b33480d36cc3"
meta-emlinux-ext-qoriq = "HEAD:a0265d345c18455286e738956840453b5a15f005"
...
```

Confirmed that hwclock command from util-linux package works:

```
root@ls1046ardb:~# uname -a
Linux ls1046ardb 5.10.249-cip69 #1 SMP PREEMPT Mon Mar 2 10:20:39 UTC 2026 aarch64 GNU/Linux

root@ls1046ardb:~# ls -l /sbin/hwclock*
lrwxrwxrwx    1 root     root            24 Mar  2 10:29 /sbin/hwclock -> /sbin/hwclock.util-linux
-rwxr-xr-x    1 root     root         80848 Mar  2 10:28 /sbin/hwclock.util-linux

root@ls1046ardb:~#  /sbin/hwclock -r
2026-03-02 10:33:54.814550+00:00
```

## qemuarm64 / k419 / core-image-minimal

```
$ source setup-emlinux build
```

Add the following to local.conf:

```
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " util-linux-hwclock"
```

Build image:

```
$ bitbake core-image-minimal
...
Build Configuration:                                                                                                                             
BB_VERSION           = "1.42.0"                                                                                                                  
BUILD_SYS            = "x86_64-linux"                                                                                                            
NATIVELSBSTRING      = "ubuntu-20.04"                                                                                                            
TARGET_SYS           = "aarch64-emlinux-linux"                                                                                                   
MACHINE              = "qemuarm64"                                                                                                               
DISTRO               = "emlinux"                                                                                                                 
DISTRO_VERSION       = "2.12"                                                                                                                    
TUNE_FEATURES        = "aarch64 armv8a crc"                                                                                                      
TARGET_FPU           = ""                                                                                                                        
meta                                                                                                                                             
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"                                                                           
meta-debian          = "HEAD:a824f6ebceee2c143be1f91ec22deb6815238b88"                                                                           
meta-debian-extended = "HEAD:2eb3299e373afd36fde0a658d3ffc724e373d3f4"                                                                           
meta-emlinux         = "fix-rtc-issue:c5328898ecd0de4fbc99c9b369705ff055a166a6"                                                                  
meta-emlinux-private = "HEAD:23617b571efaca4c4fd9b4669da7b33480d36cc3" 
...
NOTE: Tasks Summary: Attempted 3249 tasks of which 5 didn't need to be rerun and all succeeded.
```

Run the image:

```
$ runqemu qemuarm64 nographic
```

Confirmed that hwclock command from util-linux package works:

```
root@qemuarm64:~# uname -a
Linux qemuarm64 4.19.325-cip128-st12 #1 SMP PREEMPT Tue Mar 3 01:27:03 UTC 2026 aarch64 GNU/Linux

root@qemuarm64:~# ls -l /sbin/hwclock*
lrwxrwxrwx    1 root     root            24 Mar  3 01:47 /sbin/hwclock -> /sbin/hwclock.util-linux
-rwxr-xr-x    1 root     root         80848 Mar  3 01:45 /sbin/hwclock.util-linux

root@qemuarm64:~# /sbin/hwclock -r
2026-03-03 02:45:18.991371+00:00
```

## qemuarm64 / k510 / core-image-minimal

```
$ source setup-emlinux build
```

Add the following to local.conf:

```
MACHINE = "qemuarm64"
IMAGE_INSTALL_append = " util-linux-hwclock"
DISTRO = "emlinux-k510"
```

Build image:

```
$ bitbake core-image-minimal
...
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-20.04"
TARGET_SYS           = "aarch64-emlinux-linux"
MACHINE              = "qemuarm64"
DISTRO               = "emlinux-k510"
DISTRO_VERSION       = "2.12"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-yocto-bsp       = "HEAD:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "HEAD:a824f6ebceee2c143be1f91ec22deb6815238b88"
meta-debian-extended = "HEAD:2eb3299e373afd36fde0a658d3ffc724e373d3f4"
meta-emlinux         = "fix-rtc-issue:c5328898ecd0de4fbc99c9b369705ff055a166a6"
meta-emlinux-private = "HEAD:23617b571efaca4c4fd9b4669da7b33480d36cc3"
...
NOTE: Tasks Summary: Attempted 3272 tasks of which 5 didn't need to be rerun and all succeeded.
```

Run the image:

```
$ runqemu qemuarm64 nographic
```

Confirmed that hwclock command from util-linux package works:

```
root@qemuarm64:~# uname -a
Linux qemuarm64 5.10.249-cip69 #1 SMP PREEMPT Tue Mar 3 01:38:40 UTC 2026 aarch64 GNU/Linux

root@qemuarm64:~# ls -l /sbin/hwclock*
lrwxrwxrwx    1 root     root            24 Mar  3 01:57 /sbin/hwclock -> /sbin/hwclock.util-linux
-rwxr-xr-x    1 root     root         80848 Mar  3 01:56 /sbin/hwclock.util-linux

root@qemuarm64:~# /sbin/hwclock -r
2026-03-03 02:44:12.991070+00:00
```
