### PR TITLE
bitbake_runner: find_layers: Check paths really exist

### DIFF
--- a/scripts/lib/python/bitbake_runner.py
+++ b/scripts/lib/python/bitbake_runner.py
@@ -8,6 +8,7 @@
 
 import re
 import subprocess
+import pathlib
 
 def find_layers():
     cmd = ["bitbake-layers", "show-layers"]
@@ -20,7 +21,7 @@ def find_layers():
     for line in lines:
         tmp = [col for col in line.split(" ") if not col == ""]
         if len(tmp) >= 2:
-            if "/repos/" in tmp[1]:
+            if pathlib.Path(tmp[1]).exists():
                 layers.append(tmp[1])
 
     return layers


### PR DESCRIPTION
fix the issue that find_layers() is not able to find a valid layer whose path does not contain string `/repos/`.

## Test

I confirmed that `repos-tmp/meta-tmp` (outside of `repos`) was recognized by `find_layers()` as `bitbake-layers show-layers` did.
```
# `bitbake-layers show-layers` for reference
build@6da0efbc5119:~/work/repos/meta-emlinux/scripts$ bitbake-layers show-layers
NOTE: Starting bitbake server...
layer                 path                                                                    priority
========================================================================================================
core                  /home/build/work/build/../repos/isar/meta                               5
emlinux               /home/build/work/build/../repos/meta-emlinux                            12
cip-core              /home/build/work/build/../repos/isar-cip-core                           6
meta-tmp              /home/build/work/build/../repos-tmp/meta-tmp                            6

# Test find_layers()
build@6da0efbc5119:~/work/repos/meta-emlinux/scripts$ python3 -c 'from lib.python.bitbake_runner import find_layers; print(find_layers())'
['/home/build/work/build/../repos/isar/meta', '/home/build/work/build/../repos/meta-emlinux', '/home/build/work/build/../repos/isar-cip-core', '/home/build/work/build/../repos-tmp/meta-tmp']
```

`repos-tmp/meta-tmp` has a minimal `conf/layrer.conf`:
```
BBFILE_COLLECTIONS += "meta-tmp"
BBFILE_PATTERN_meta-tmp = "^${LAYERDIR}/"
LAYERSERIES_COMPAT_meta-tmp = "next"
```