### PR TITLE
Update kernel to v4.19.325-cip130

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "8665174e4bc9923fa55a22e1b4b3717e7b335404"
+LINUX_GIT_SRCREV ?= "ef917a8bed27ab284a27aa2e8e242bab707d7aa3"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip128"
+LINUX_CIP_VERSION ??= "v4.19.325-cip130"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip130

This pull request update the kernel to the following cip versions:
v4.19.325-cip130 with hash tag ef917a8bed27ab284a27aa2e8e242bab707d7aa3
