### PR TITLE
cve-check-ng: Add Kernel CVE check plugin

### DIFF
--- a/scripts/lib/python/cve/cve_info.py
+++ b/scripts/lib/python/cve/cve_info.py
@@ -15,6 +15,7 @@ class CveStatus:
     CVE_STATUS_PATCHED = "Patched"
     CVE_STATUS_UNPATCHED = "Unpatched"
     CVE_STATUS_REJECTED = "Rejected"
+    CVE_STATUS_IGNORED = "Ignored"
 
 
 class CveCheckResult:

--- a/scripts/lib/python/cve/nvd_lib.py
+++ b/scripts/lib/python/cve/nvd_lib.py
@@ -150,7 +150,7 @@ class CveCheckMergedList:
                     if cveid in self.merged[src_pkg_name]:
                         self.merged[src_pkg_name][cveid][
                             "cve_info"
-                        ].status = CveStatus.CVE_STATUS_PATCHED
+                        ].status = CveStatus.CVE_STATUS_IGNORED
 
     def get_cve_status(self, src_pkg_name: str, cveid: str) -> str:
         return self.merged[src_pkg_name][cveid]["cve_info"].status

--- a/scripts/lib/python/cve/plugin/eml_cve_cip_kernel_plugin.py
+++ b/scripts/lib/python/cve/plugin/eml_cve_cip_kernel_plugin.py
@@ -1,0 +1,238 @@
+from typing import Any
+from lib.python.cve.cve_product import CveProductList
+from lib.python.cve.plugin.eml_cve_plugin_base import EmlCvePlugin
+from lib.python.cve.cve_info import CveStatus, CveCheckResult, CveCheckResultList
+from lib.python.package_info import PackageList
+
+import yaml
+import subprocess
+from datetime import datetime, timezone
+import os
+import errno
+import re
+import tempfile
+import shutil
+
+import logging
+logger = logging.getLogger("emlinux-cve-check")
+
+CIP_KERNEK_SEC_UPDATE_INTERVAL = 86400
+CIP_KERNEL_SEC_GIT_REPO_URL = (
+    "https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec.git"
+)
+
+
+class EmlCIPKernelPlugin(EmlCvePlugin):
+    def __init__(
+        self,
+        cve_data_dir: str,
+        args: Any,
+        bitbakeinfo: Any,
+        installed_packages: PackageList,
+        cve_products: CveProductList,
+    ):
+        super().__init__(
+            "EmlCIPKernelPlugin",
+            2,
+            cve_data_dir,
+            args,
+            bitbakeinfo,
+            installed_packages,
+            cve_products,
+        )
+
+        self.cip_kernel_sec_dir = f"{self.cve_data_dir}/cip-kernel-sec"
+        self.kernel_src_pkg_name = None
+
+    def update_database(self) -> bool:
+        return self._fetch_cve_data()
+
+    def run_check(self) -> CveCheckResultList:
+        logger.debug(f"{self.plugin_name}: run-check start")
+        if not os.path.exists(self.cip_kernel_sec_dir):
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), self.cip_kernel_sec_dir
+            )
+
+        if "linux-cip" in self.installed_packages:
+            self.kernel_src_pkg_name = "linux-cip"
+        elif "linux-cip-rt" in self.installed_packages:
+            self.kernel_src_pkg_name = "linux-cip"
+        else:
+            logger.info("No linux kernel package in the image")
+            return self.cve_check_result_list
+
+        logger.debug(f"Linux kernel package is {self.kernel_src_pkg_name}")
+
+        pkg_ver = self.installed_packages.get_version(self.kernel_src_pkg_name)
+        pattern = r"^([^+]+)"
+        m = re.search(pattern, pkg_ver)
+        kver = m.group(1)
+
+        cves = self._run_report_affected(kver)
+
+        self._create_cve_check_result(cves)
+        return self.cve_check_result_list
+
+    def _is_update_need(self) -> bool:
+        if not os.path.exists(self.cip_kernel_sec_dir):
+            return True
+
+        logger.info("check update")
+        cmd = ["git", "reflog", "--date=iso"]
+
+        with subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.cip_kernel_sec_dir,
+            text=True,
+        ) as proc:
+            proc.wait()
+            retcode = int(proc.returncode)
+            if not retcode == 0:
+                logger.warning("Failed to get last updated date in cip-kernel-sec")
+                return False
+
+            stdout, stderr = proc.communicate()
+            last_log = stdout.split("\n")[0]
+            m = re.search(r"HEAD@\{(.*?)\}", last_log)
+            if not m:
+                return True
+
+            timestamp = m.group(1)
+            last_date = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S %z")
+            now = datetime.now(timezone.utc)
+            diff = now - last_date
+
+            logger.debug(f"time diff: {diff}")
+            if diff.total_seconds() <= CIP_KERNEK_SEC_UPDATE_INTERVAL:
+                logger.info(
+                    f"cip-kernel-sec has been updated in {CIP_KERNEK_SEC_UPDATE_INTERVAL} second. skip update."
+                )
+                return False
+
+        return True
+
+    def _fetch_cve_data(self) -> bool:
+        if not self._is_update_need():
+            return True
+
+        logger.info("Update cip-kernel-sec CVE database")
+
+        is_cloned = os.path.exists(self.cip_kernel_sec_dir)
+
+        ret = self._clone_or_updatecip_kernel_sec(is_cloned)
+
+        if not ret:
+            # Remove old cip-kernel-sec directory then clone all data next time.
+            shutil.rmtree(self.cip_kernel_sec_dir)
+            return False
+
+        return True
+
+    def _clone_or_updatecip_kernel_sec(self, is_cloned: bool) -> bool:
+        logger.info("clone/update cip-kernel-sec")
+
+        if is_cloned:
+            cmd = ["git", "pull"]
+            workdir = self.cip_kernel_sec_dir
+        else:
+            cmd = ["git", "clone", CIP_KERNEL_SEC_GIT_REPO_URL]
+            workdir = self.cve_data_dir
+
+        with subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=workdir
+        ) as proc:
+            proc.wait()
+            retcode = int(proc.returncode)
+
+            if not retcode == 0:
+                logger.warning("Failed to clone/update cip-kernel-sec")
+                return False
+
+        if not is_cloned:
+            remotes_path = f"{self.cip_kernel_sec_dir}/conf/remotes.yml"
+            self._update_remote(remotes_path)
+
+        return True
+
+    def _update_remote(self, remotes_path: str):
+        with open(remotes_path) as f:
+            content = yaml.safe_load(f)
+
+        with open(remotes_path, "w") as f:
+            yaml.dump({"cip": content["cip"]}, f, default_flow_style=False)
+            return True
+
+        return False
+
+    def _run_report_affected(self, kver: str) -> list:
+        cves = {
+            "Patched": [],
+            "Unpatched": [],
+        }
+
+        if not kver.startswith("v"):
+            kver = f"v{kver}"
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            output_filename = f.name
+
+        kernel_dir = os.path.abspath(self.bitbakeinfo["kernel_srcdir"])
+
+        retcode = -1
+        cmd = [
+            "./scripts/report_affected.py",
+            "--include-fixed",
+            "--output-format=yaml",
+            f"--output-filename={output_filename}",
+            "--git-repo",
+            kernel_dir,
+            "--remote-name",
+            "cip:origin",
+            "--include-ignored",
+            kver,
+        ]
+
+        with subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.cip_kernel_sec_dir,
+        ) as proc:
+            proc.wait()
+            retcode = int(proc.returncode)
+
+            if not retcode == 0:
+                logger.warning("Failed to run cip-kernel-sec")
+                for s in proc.stderr:
+                    logger.warning(s.decode())
+
+        with open(output_filename) as f:
+            yaml_data = yaml.safe_load(f.read())
+            k = list(yaml_data)[0]
+
+            if len(yaml_data[k]["fixed"]) > 0:
+                cves["Patched"] = yaml_data[k]["fixed"]
+            if len(yaml_data[k]["affected"]) > 0:
+                cves["Unpatched"] = yaml_data[k]["affected"]
+
+        if os.path.exists(output_filename):
+            os.unlink(output_filename)
+
+        return cves
+
+    def _create_cve_check_result(self, cves: dict):
+        for cveid in cves["Patched"]:
+            ci = CveCheckResult(
+                cveid, self.kernel_src_pkg_name, CveStatus.CVE_STATUS_PATCHED
+            )
+            self.cve_check_result_list.add_cve_info(self.kernel_src_pkg_name, ci)
+
+        for cveid in cves["Unpatched"]:
+            ci = CveCheckResult(
+                cveid, self.kernel_src_pkg_name, CveStatus.CVE_STATUS_UNPATCHED
+            )
+            self.cve_check_result_list.add_cve_info(self.kernel_src_pkg_name, ci)
+


### PR DESCRIPTION
# Purpose 

This PR added a plugin for checking CIP kernel CVEs by cip-kernel-sec. Commit  https://github.com/miraclelinux/meta-emlinux/pull/612/changes/10d8b2f54e1ed3437f3fc4784898d571d5035724 added the plugin.
Commit https://github.com/miraclelinux/meta-emlinux/pull/612/changes/10d8b2f54e1ed3437f3fc4784898d571d5035724 added Ignored status that we need it to mark the CVE is ignoerd.

# Test

We use following command to run cve check scripts. Note: nvd-api-key and cve-db-predownload options are optional.

```
cve_check.py \
--debian-codename trixie \
--image emlinux-image-weston \
--output-format text,json \
--nvd-api-key <your api key> \
--cve-db-predownload \
--verbose

cve_check_ng.py \
--debian-codename trixie \
--image emlinux-image-weston \
--output-format text,json \
--nvd-api-key <your api key> \
--cve-db-predownload \
--verbose

cve_check.py \
--debian-codename bookworm \
--image emlinux-image-weston \
--output-format text,json \
--nvd-api-key <your api key> \
--cve-db-predownload \
--verbose

cve_check_ng.py \
--debian-codename bookworm \
--image emlinux-image-weston \
--output-format text,json \
--nvd-api-key <your api key> \
--cve-db-predownload \
--verbose
```
1. Build emlinux-image-weston for emlinux-boowkworm and emlinux-trixie without this PR's commits
2. Run cve_check.py to both emlinux-boowkworm and emlinux-trixie
3. Build emlinux-image-weston for emlinux-boowkworm and emlinux-trixie with this PR's commits
4. Run cve_check.py to both emlinux-boowkworm and emlinux-trixie
5.  Run following script to check differences

```
#!/usr/bin/env python3

import sys
import json

import pprint

def collect_cves(jsondata):
    ret = {}

    for data in jsondata["package"]:
        pkg = data["name"]
        ret[pkg] = {}
        
        for issue in data["issue"]:
            cveid = issue["CVE"]
            status = issue["CVE STATUS"]
            ret[pkg][cveid] = status
    return ret
        
def read_json(filename):
    with open(filename) as f:
        return json.load(f)

def main(json1, json2):
    j1 = read_json(json1)
    j2 = read_json(json2)

    j1_cves = collect_cves(j1)
    j2_cves = collect_cves(j2)

    j1_pkgs = sorted(list(j1_cves.keys()))
    j2_pkgs = sorted(list(j2_cves.keys()))

    a = set(j1_pkgs) - set(j2_pkgs)
    if len(a) > 0:
        print(f"There are package differences between {json1} and {json2}")
        print(a)

    found_diff = False

    for pkg in j1_pkgs:
        j1 = j1_cves[pkg]
        j2 = j2_cves[pkg]

        if not j1 == j2:
            print(f"{pkg} has difference")
            j1_cveids = list(j1.keys())
            j2_cveids = list(j2.keys())
            j1_only = set(j1_cveids) - set(j2_cveids)
            j2_only = set(j2_cveids) - set(j1_cveids)

            if len(j1_only) > 0:
                foudn_diff = True
                print(f"Fllowing CVEs are only in {json1}")
                for cveid in j1_only:
                    print(f"- {cveid}")

            if len(j2_only) > 0:
                foudn_diff = True
                print(f"Fllowing CVEs are only in {json2}")
                for cveid in j2_only:
                    print(f"- {cveid}")

            if len(j1_only) == 0 and len(j2_only) == 0:
                for pkg in j1_cves:
                    j1_cve_list = j1_cves[pkg]
                    j2_cve_list = j2_cves[pkg]
                    if not j1_cve_list == j2_cve_list:
                        foudn_diff = True
                        for cveid in j1_cve_list:
                            if not j1_cve_list[cveid] == j2_cve_list[cveid]:
                                print(f"{pkg}: CVE: {cveid} status {j1_cve_list[cveid]} : {j2_cve_list[cveid]}")

    if not found_diff:
        print("There are not difference")

if __name__ == "__main__":
    if not len(sys.argv) == 3:
        print(f"usage: {sys.argv[0]} json1 json2")
        exit(1)

    main(sys.argv[1], sys.argv[2])
```

# Test result

cve_check_ng.py result for emlinux-bookworm

```
build@6e60066fa017:~/work$ cve_check_ng.py \
--debian-codename bookworm \
--image emlinux-image-weston \
--output-format text,json \
--nvd-api-key <your api key>\
--cve-db-predownload \
--verbose
2026-03-13 08:15:49,277:INFO: |------------------------------|
2026-03-13 08:15:49,277:INFO: | This is experimental version |
2026-03-13 08:15:49,277:INFO: |------------------------------|
2026-03-13 08:15:56,646:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_debian_plugin.py
2026-03-13 08:15:56,647:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_cip_kernel_plugin.py
2026-03-13 08:15:56,648:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_nvd_plugin.py
2026-03-13 08:15:56,649:DEBUG: run EmlDebianPlugin
2026-03-13 08:15:56,649:INFO: Update debian CVE database
2026-03-13 08:15:56,649:INFO: Last database update is in 1day so skip Debian CVE database update
2026-03-13 08:15:56,649:DEBUG: EmlDebianPlugin: run-check start
2026-03-13 08:15:57,245:DEBUG: run EmlCIPKernelPlugin
2026-03-13 08:15:57,245:INFO: check update
2026-03-13 08:15:57,247:DEBUG: time diff: 0:02:18.247796
2026-03-13 08:15:57,247:INFO: cip-kernel-sec has been updated in 86400 second. skip update.
2026-03-13 08:15:57,247:DEBUG: EmlCIPKernelPlugin: run-check start
2026-03-13 08:15:57,247:DEBUG: Linux kernel package is linux-cip
2026-03-13 08:16:26,957:DEBUG: run EmlNVDPlugin
2026-03-13 08:16:26,957:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2026-03-13 08:16:26,957:INFO: Last database update is in 1 day skip NVD database update
2026-03-13 08:16:26,957:DEBUG: EmlNVDPlugin: run-check start
2026-03-13 08:17:05,169:DEBUG: EmlNVDPlugin: run-check finish
2026-03-13 08:17:05,543:INFO: Update KEV database
2026-03-13 08:17:05,543:INFO: Last database update is in 1day so skip Debian CVE database update
2026-03-13 08:17:05,838:INFO: Text report were written to /home/build/work/build/tmp/deploy/cve/emlinux-image-weston-emlinux-bookworm-qemu-amd64/cve_check_ng/text
2026-03-13 08:17:05,889:INFO: All in one text report was written to /home/build/work/build/tmp/deploy/cve/emlinux-image-weston-emlinux-bookworm-qemu-amd64/cve_check_ng/emlinux-image-weston-emlinux-bookworm-qemu-amd64_cve
2026-03-13 08:17:06,070:INFO: Json report were written to /home/build/work/build/tmp/deploy/cve/emlinux-image-weston-emlinux-bookworm-qemu-amd64/cve_check_ng/json
2026-03-13 08:17:06,304:INFO: All in one json report was written to /home/build/work/build/tmp/deploy/cve/emlinux-image-weston-emlinux-bookworm-qemu-amd64/cve_check_ng/emlinux-image-weston-emlinux-bookworm-qemu-amd64_cve.json
```

cve_check_ng.py result for emlinux-trixie

```
build@6e60066fa017:~/work$ cve_check_ng.py \
--debian-codename trixie \
--image emlinux-image-weston \
--output-format text,json \
--nvd-api-key <your api key>\
--cve-db-predownload \
--verbose
2026-03-13 08:26:55,857:INFO: |------------------------------|
2026-03-13 08:26:55,857:INFO: | This is experimental version |
2026-03-13 08:26:55,857:INFO: |------------------------------|
2026-03-13 08:27:03,687:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_debian_plugin.py
2026-03-13 08:27:03,688:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_cip_kernel_plugin.py
2026-03-13 08:27:03,689:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_nvd_plugin.py
2026-03-13 08:27:03,690:DEBUG: run EmlDebianPlugin
2026-03-13 08:27:03,690:INFO: Update debian CVE database
2026-03-13 08:27:03,690:INFO: Last database update is in 1day so skip Debian CVE database update
2026-03-13 08:27:03,690:DEBUG: EmlDebianPlugin: run-check start
2026-03-13 08:27:04,296:DEBUG: run EmlCIPKernelPlugin
2026-03-13 08:27:04,296:INFO: check update
2026-03-13 08:27:04,299:DEBUG: time diff: 0:13:25.299133
2026-03-13 08:27:04,299:INFO: cip-kernel-sec has been updated in 86400 second. skip update.
2026-03-13 08:27:04,299:DEBUG: EmlCIPKernelPlugin: run-check start
2026-03-13 08:27:04,299:DEBUG: Linux kernel package is linux-cip
2026-03-13 08:27:35,963:DEBUG: run EmlNVDPlugin
2026-03-13 08:27:35,963:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db.db
2026-03-13 08:27:35,963:INFO: Last database update is in 1 day skip NVD database update
2026-03-13 08:27:35,963:DEBUG: EmlNVDPlugin: run-check start
2026-03-13 08:28:21,833:DEBUG: EmlNVDPlugin: run-check finish
2026-03-13 08:28:22,244:INFO: Update KEV database
2026-03-13 08:28:22,244:INFO: Last database update is in 1day so skip Debian CVE database update
2026-03-13 08:28:22,541:INFO: Text report were written to /home/build/work/build/tmp/deploy/cve/emlinux-image-weston-emlinux-trixie-qemu-amd64/cve_check_ng/text
2026-03-13 08:28:22,592:INFO: All in one text report was written to /home/build/work/build/tmp/deploy/cve/emlinux-image-weston-emlinux-trixie-qemu-amd64/cve_check_ng/emlinux-image-weston-emlinux-trixie-qemu-amd64_cve
2026-03-13 08:28:22,779:INFO: Json report were written to /home/build/work/build/tmp/deploy/cve/emlinux-image-weston-emlinux-trixie-qemu-amd64/cve_check_ng/json
2026-03-13 08:28:23,039:INFO: All in one json report was written to /home/build/work/build/tmp/deploy/cve/emlinux-image-weston-emlinux-trixie-qemu-amd64/cve_check_ng/emlinux-image-weston-emlinux-trixie-qemu-amd64_cve.json
```

Check differences for bookworm.

```
build@6e60066fa017:~/work$ ./get_cve_check_differences.py ./build/tmp/deploy/cve/emlinux-image-weston-emlinux-bookworm-qemu-amd64/json/linux-cip_cve.json ./build/tmp/deploy/cve/emlinux-image-weston-emlinux-bookworm-qemu-amd64/cve_check_ng/json/linux-cip_cve.json 
There are not difference
```

Check differences for trixie.

```
build@6e60066fa017:~/work$ ./get_cve_check_differences.py ./build/tmp/deploy/cve/emlinux-image-weston-emlinux-trixie-qemu-amd64/json/linux-cip_cve.json ./build/tmp/deploy/cve/emlinux-image-weston-emlinux-trixie-qemu-amd64/cve_check_ng/json/linux-cip_cve.json 
There are not difference
```

Both bookworm and trixie results do not have any difference from current cve_check.py result.
