### PR TITLE
classes/dl-srcpkg: Fix task order problem

### DIFF
--- a/classes/dl-srcpkg.bbclass
+++ b/classes/dl-srcpkg.bbclass
@@ -90,4 +90,4 @@ do_install_source_package() {
     sudo rm ${ROOTFSDIR}/apt_status.tar.gz
 }
 
-addtask install_source_package before do_rootfs after do_rootfs_postprocess
+addtask install_source_package before do_rootfs_finalize after do_generate_initramfs


### PR DESCRIPTION
# Purpose

Since commit b0913306d94a ("Delay creation of initrd until end of rootfs install") in isar, dl-srpkg and do_generate_initramfs tasks conflict their mount/unmount process.
The result we got following error.

```
| DEBUG: Executing shell function rootfs_do_umounts
| umount: /home/build/work/build/tmp/work/emlinux-bookworm-amd64/emlinux-image-base-qemu-amd64/1.0-r0/rootfs/dev: target is busy.
| WARNING: exit code 32 from a shell command.
| DEBUG: Python function do_generate_initramfs finished
ERROR: Task (/home/build/work/build/../repos/meta-emlinux/recipes-core/images/emlinux-image-base.bb:do_generate_initramfs) failed with exit code '1'
NOTE: Tasks Summary: Attempted 140 tasks of which 0 didn't need to be rerun and 1 failed.
WARNING: /home/build/work/build/tmp/work/emlinux-bookworm-amd64/emlinux-image-base-qemu-amd64/1.0-r0/rootfs/sys/firmware left mounted, unmounting...
WARNING: /home/build/work/build/tmp/work/emlinux-bookworm-amd64/emlinux-image-base-qemu-amd64/1.0-r0/rootfs/sys left mounted, unmounting...
WARNING: /home/build/work/build/tmp/work/emlinux-bookworm-amd64/emlinux-image-base-qemu-amd64/1.0-r0/rootfs/proc left mounted, unmounting...
WARNING: /home/build/work/build/tmp/work/emlinux-bookworm-amd64/emlinux-image-base-qemu-amd64/1.0-r0/rootfs/dev left mounted, unmounting...

Summary: 1 task failed:
  /home/build/work/build/../repos/meta-emlinux/recipes-core/images/emlinux-image-base.bb:do_generate_initramfs
Summary: There were 4 WARNING messages.
Summary: There was 1 ERROR message, returning a non-zero exit code.
```

To fix the issue, we should put dl-srcpkg's task into right place. It looks as if running dl-srcpkg task after do_generate_initramfs and before do_rootfs_finalize is better place.

# Test

1. Add `INHERIT += "dl-srcpkg"` to conf/local.conf
2. Build emlinux-image-base

# Test result

Building an image is succeeded without any warning/error.

```
build@319d0178bd1d:~/work/build$ bitbake emlinux-image-base
Loading cache: 100% |                                                                                                                                                                              | ETA:  --:--:--
Loaded 0 entries from dependency cache.
Parsing recipes: 100% |#############################################################################################################################################################################| Time: 0:00:04
P
Parsing of 1476 .bb files complete (0 cached, 1476 parsed). 2446 targets, 101 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
NOTE: Resolving any missing task queue dependencies
Sstate summary: Wanted 14 Local 0 Mirrors 0 Missed 14 Current 0 (0% match, 0% complete)###########################################################################################                  | ETA:  0:00:00
Initialising tasks: 100% |##########################################################################################################################################################################| Time: 0:00:01
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 147 tasks of which 0 didn't need to be rerun and all succeeded.
build@319d0178bd1d:~/work/build$ 
```

Source packages are stored under the tmp/deploy/sources/qemu-amd64 directory.

```
build@319d0178bd1d:~/work/build$ ls tmp/deploy/sources/qemu-amd64/ 
acl         base-passwd  db5.3                   emlinux-customization  grep                 json-c    libcap-ng               libnumber-compare-perl  libunistring  ncurses  procps          usrmerge
adduser     bash         debconf                 findutils              gzip                 keyutils  libffi                  libseccomp              libxcrypt     netbase  sed             util-linux
apparmor    bzip2        debian-archive-keyring  gcc-12                 hostname             klibc     libfile-find-rule-perl  libselinux              libzstd       nettle   sensible-utils  vim
apt         cdebconf     debianutils             gdbm                   initramfs-tools      kmod      libgcrypt20             libsemanage             linux-base    openssl  shadow          xxhash
argon2      coreutils    diffutils               glibc                  init-system-helpers  krb5      libgpg-error            libsepol                linux-cip     p11-kit  systemd         xz-utils
attr        cpio         dpkg                    gmp                    iproute2             libbpf    libidn2                 libtasn1-6              lvm2          pam      sysvinit        zlib
audit       cryptsetup   e2fsprogs               gnupg2                 iptables             libbsd    libmd                   libtext-glob-perl       lz4           pcre2    tar
base-files  dash         elfutils                gnutls28               iputils              libcap2   libmnl                  libtirpc                mawk          perl     tzdata
build@319d0178bd1d:~/work/build$ 
```
