### PR TITLE
conf/licenses: Add more licenses

### DIFF
--- a/conf/licenses/licenses.yml
+++ b/conf/licenses/licenses.yml
@@ -4,6 +4,17 @@
 #     "LICENSE A",
 #     "LICENSE B"
 #   ]
+adwaita-icon-theme:
+  licenses: [
+    CC-BY-SA-3.0,
+    LGPL-3.0-only,
+    CC-BY-SA-3.0-US,
+    CC-BY-SA-4.0,
+    GFDL-1.2+,
+    CC-BY-SA-3.0-Unported,
+    CC-BY-SA-2.0-IT,
+    CC-BY-3.0-US,
+  ]
 base-files:
   licenses: [
     GPL-3,
@@ -23,6 +34,14 @@ debian-archive-keyring:
 emlinux-customization:
   licenses: [
     MIT,
+  ]
+fontconfig:
+  licenses: [
+    MIT
+  ]
+fontconfig-config:
+  licenses: [
+    MIT
   ]
 gcc-12-base:
   licenses: [
@@ -51,6 +70,133 @@ gcc-14-base:
     BSL-1.0,
     Unicode-DFS-2015
   ]
+gstreamer1.0-alsa:
+  licenses: [
+    LGPL-2.0-or-later,
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    MIT
+  ]
+gstreamer1.0-gl:
+  licenses: [
+    LGPL-2.0-or-later,
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    MIT
+  ]
+gstreamer1.0-gtk3:
+  licenses: [
+    BSD-2-Clause,
+    BSD-3-Clause,
+    LGPL-2.0-or-later,
+    LGPL-2.0-only,
+    LGPL-2.1-or-later,
+    MIT
+  ]
+gstreamer1.0-opencv:
+  licenses: [
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    GPL-3.0-or-later,
+    LGPL-2.0-or-later,
+    LGPL-2.1-or-later,
+    LGPL-2.1-only,
+    LGPL-2.1-only,
+    MPL-1.1,
+    MIT,
+    Proprietary
+  ]
+gstreamer1.0-plugins-bad:
+  licenses: [
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    GPL-3.0-or-later,
+    LGPL-2.0-or-later,
+    LGPL-2.1-or-later,
+    LGPL-2.1-only,
+    LGPL-2.1-only,
+    MPL-1.1,
+    MIT,
+    Proprietary
+  ]
+gstreamer1.0-plugins-bad-apps:
+  licenses: [
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    GPL-3.0-or-later,
+    LGPL-2.0-or-later,
+    LGPL-2.1-or-later,
+    LGPL-2.1-only,
+    LGPL-2.1-only,
+    MPL-1.1,
+    MIT,
+    Proprietary
+  ]
+gstreamer1.0-plugins-base:
+  licenses: [
+    LGPL-2.0-or-later,
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    MIT
+  ]
+gstreamer1.0-plugins-base-apps:
+  licenses: [
+    LGPL-2.0-or-later,
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    MIT
+  ]
+gstreamer1.0-plugins-good:
+  licenses: [
+    BSD-2-Clause,
+    BSD-3-Clause,
+    LGPL-2.0-or-later,
+    LGPL-2.0-only,
+    LGPL-2.1-or-later,
+    MIT
+  ]
+gstreamer1.0-pulseaudio:
+  licenses: [
+    BSD-2-Clause,
+    BSD-3-Clause,
+    LGPL-2.0-or-later,
+    LGPL-2.0-only,
+    LGPL-2.1-or-later,
+    MIT
+  ]
+gstreamer1.0-tools:
+  licenses: [
+    GPL-2.0-or-later,
+    GPL-3.0-or-later,
+    LGPL-2.0-or-later,
+    LGPL-2.1-or-later
+  ]
+gstreamer1.0-x:
+  licenses: [
+    LGPL-2.0-or-later,
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    MIT
+  ]
+i2c-tools:
+  licenses: [
+    LGPL-2.1-or-later,
+    GPL-2.0-only,
+    GPL-2.0-or-later
+  ]
+initramfs-tee-supplicant-hook:
+  licenses: [
+    GPL-2.0-only,
+    MIT
+  ]
 initramfs-tools:
   licenses: [
     GPL-2
@@ -62,6 +208,10 @@ initramfs-tools-core:
 klibc-utils:
   licenses: [
     GPL-2
+  ]
+libaec0:
+  licenses: [
+    BSD-2-Clause
   ]
 libasound2:
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1061276
@@ -91,6 +241,32 @@ libatomic1:
     BSL-1.0,
     Unicode-DFS-2015
   ]
+libavahi-client3:
+  licenses: [
+    LGPL-2.1-or-later,
+    GPL-2.0-only,
+    GPL-3.0-with-autoconf-exception,
+    GPL-2.0-only,
+    BSD-2-Clause,
+    BSD-3-Clause
+  ]
+libavahi-common-data:
+  licenses: [
+    LGPL-2.1-or-later,
+    GPL-2.0-only,
+    GPL-3.0-with-autoconf-exception,
+    GPL-2.0-only,
+    BSD-2-Clause,
+    BSD-3-Claus
+  ]
+libavahi-common3:
+  licenses: [
+    LGPL-2.1-or-later,
+    GPL-2.0-only,
+    GPL-3.0-with-autoconf-exception,
+    BSD-2-Clause,
+    BSD-3-Clause
+  ]
 libc-bin:
   licenses: [
     GPL-2,
@@ -116,17 +292,87 @@ libcairo2:
     MPL-1.1,
     LGPL-2.1-only,
   ]
+libcfitsio10:
+  licenses: [
+    NASA-1.3,
+    MIT,
+    LGPL-2.0-only,
+    GPL-2.0-only
+  ]
 libcrypt1:
   licenses: [
     public-domain
+  ]
+libdc1394-25:
+  licenses: [
+    LGPL-2.0-or-later
+  ]
+libdrm-amdgpu1:
+  licenses: [
+    MIT
   ]
 libdrm-common:
   licenses: [
     MIT,
   ]
+libdrm-nouveau2:
+  licenses: [
+    MIT
+  ]
+libdrm-radeon1:
+  licenses: [
+    MIT
+  ]
 libdrm2:
   licenses: [
     MIT,
+  ]
+libdw1:
+  licenses: [
+    BSD-2-Clause,
+    GFDL-NIV-1.3,
+    GPL-3.0-or-later,
+    GPL-3.0-or-later WITH Bison-exception-2.2,
+    GPL-2.0-or-later,
+    LGPL-2.1-or-later,
+    LGPL-3.0-or-later
+  ]
+libegl1:
+  licenses: [
+    MIT,
+    BSD-1-Clause,
+    BSD-3-Clause,
+    GPL-3.0-with-autoconf-exception
+  ]
+libelf1:
+  licenses: [
+    BSD-2-Clause,
+    GFDL-NIV-1.3,
+    GPL-3.0-or-later,
+    GPL-3.0-or-later WITH Bison-exception-2.2,
+    GPL-2.0-or-later,
+    LGPL-2.1-or-later,
+    LGPL-3.0-or-later
+  ]
+libflite1:
+  licenses: [
+    BSD-3-Clause,
+    GPL-2.0-only
+  ]
+libfontconfig1:
+  licenses: [
+    MIT,
+  ]
+libgbm1:
+  licenses: [
+    Apache-2.0,
+    BSD-2-clause,
+    BSD-3-google,
+    BSL,
+    GPL-3.0-or-later,
+    Khronos,
+    MIT,
+    SGI-B-2.0
   ]
 libgcc-s1:
   licenses: [
@@ -141,6 +387,22 @@ libgcrypt20:
   licenses: [
     GPL-2,
     LGPL
+  ]
+libgfortran5:
+  licenses: [
+    Artistic,
+    GFDL-1.2,
+    GPL,
+    GPL-2,
+    GPL-3,
+    LGPL
+  ]
+libgles2:
+  licenses: [
+    MIT,
+    BSD-1-Clause,
+    BSD-3-Clause,
+    GPL-3.0-with-autoconf-exception
   ]
 libgnutls30:
   licenses: [
@@ -169,6 +431,80 @@ libgssapi-krb5-2:
   licenses: [
     GPL-2
   ]
+libgstreamer-gl1.0-0:
+  licenses: [
+    LGPL-2.0-or-later,
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    MIT
+  ]
+libgstreamer-opencv1.0-0:
+  licenses: [
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    GPL-3.0-or-later,
+    LGPL-2.0-or-later,
+    LGPL-2.1-or-later,
+    LGPL-2.1-only,
+    LGPL-2.1-only,
+    MPL-1.1,
+    MIT,
+    Proprietary
+  ]
+libgstreamer-plugins-bad1.0-0:
+  licenses: [
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    GPL-3.0-or-later,
+    LGPL-2.0-or-later,
+    LGPL-2.1-or-later,
+    LGPL-2.1-only,
+    LGPL-2.1-only,
+    MPL-1.1,
+    MIT,
+    Proprietary
+  ]
+libgstreamer-plugins-base1.0-0:
+  licenses: [
+    LGPL-2.0-or-later,
+    BSD-2-Clause,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+    MIT
+  ]
+libgstreamer1.0-0:
+  licenses: [
+    GPL-2.0-or-later,
+    GPL-3.0-or-later,
+    LGPL-2.0-or-later,
+    LGPL-2.1-or-later
+  ]
+libgupnp-igd-1.0-4:
+  licenses: [
+    LGPL-2.0-or-later,
+    GPL-3.0-only
+  ]
+libhwloc15:
+  licenses: [
+    BSD-3-Clause
+  ]
+libi2c0:
+  licenses: [
+    LGPL-2.1-or-later,
+    GPL-2.0-only,
+    GPL-2.0-or-later
+  ]
+libice6:
+  licenses: [
+    MIT-open-group
+  ]
+libiec61883-0:
+  licenses: [
+    LGPL-2.1-or-later
+  ]
 libjudydebian1:
   licenses: [
     LGPL-2+,
@@ -193,18 +529,79 @@ libksba8:
   licenses: [
     GPL-3
   ]
+liblept5:
+  licenses: [
+    BSD-2-Clause
+  ]
+libllvm15:
+  licenses: [
+    Apache-2.0-with-LLVM-exception,
+    MIT,
+    BSD-3-clause,
+    Python-2.0
+  ]
+libmjpegutils-2.1-0:
+  licenses: [
+    GPL-2.0-or-later,
+    GPL-2.0-only,
+    GPL-1.0-or-later
+  ]
+libmodplug1:
+  licenses: [
+    PD
+  ]
+libmpcdec6:
+  licenses: [
+    LGPL-2.1-or-later,
+    BSD-3-Clause,
+    GPL-2.0-or-later,
+  ]
+libmpeg2encpp-2.1-0:
+  licenses: [
+    GPL-2.0-or-later,
+    GPL-2.0-only,
+    GPL-1.0-or-later
+  ]
 libmpfr6:
   licenses: [
     LGPL-3+,
-    GFDL-1.2,
+    GFDL-1.2
   ]
-linux-image-cip:
+libmplex2-2.1-0:
   licenses: [
-    GPL-2
+    GPL-2.0-or-later,
+    GPL-2.0-only,
+    GPL-1.0-or-later
   ]
-linux-image-cip-rt:
+libnice10:
   licenses: [
-    GPL-2
+    LGPL-2.1-or-later,
+    MPL-1.1,
+    GPL-2.0-only,
+    GPL-3.0-or-later,
+  ]
+libnuma1:
+  licenses: [
+    LGPL-2.1-or-later,
+  ]
+liborc-0.4-0:
+  licenses: [
+    BSD-2-Clause,
+    BSD-3-Clause
+  ]
+libpangocairo-1.0-0:
+  licenses: [
+    MPL-1.1,
+    LGPL-2.1-only
+  ]
+libpixman-1-0:
+  licenses: [
+    MIT
+  ]
+libproxy1v5:
+  licenses: [
+    LGPL-2.1-or-later,
+    GPL-2.0-or-later
   ]
 libpython3.11:
   licenses: [
@@ -226,13 +623,15 @@ libpython3.13-minimal:
   licenses: [
     PSF-2.0
   ]
-libpython3.13-minimal:
-  licenses: [
-    PSF-2.0
-  ]
 libpython3.13-stdlib:
   licenses: [
     PSF-2.0
+  ]
+libraw1394-11:
+  licenses: [
+    LGPL-2.1-or-later,
+    GPL-2.0-or-later,
+    MIT
   ]
 librtmp1:
   licenses: [
@@ -253,6 +652,25 @@ libsemanage2:
     GPL,
     LGPL
   ]
+libsensors-config:
+  licenses: [
+    LGPL-2.1-or-later,
+    GPL-2.0-or-later
+  ]
+libsensors5:
+  licenses: [
+    LGPL-2.1-or-later,
+    GPL-2.0-or-later
+  ]
+libsm6:
+  licenses: [
+    MIT-open-group
+  ]
+libspandsp2:
+  licenses: [
+    GPL-2.0-only,
+    LGPL-2.0-only
+  ]
 libstdc++6:
   licenses: [
     Artistic,
@@ -262,24 +680,52 @@ libstdc++6:
     GPL-3,
     LGPL
   ]
+libsz2:
+  licenses: [
+    BSD-2-Clause
+  ]
 libtasn1-6:
   licenses: [
     LGPL-2.1,
     GPL-3,
     GFDL-1.3
   ]
-libpangocairo-1.0-0:
+libteec1:
   licenses: [
-    MPL-1.1,
-    LGPL-2.1-only,
+    BSD-2-Clause
+  ]
+libusb-1.0-0:
+  licenses: [
+    GPL-2.0-only,
+    LGPL-2.0-only
   ]
 libwayland-client0:
   licenses: [
     X11,
   ]
+libwayland-cursor0:
+  licenses: [
+    GPL-2.0-only,
+    LGPL-2.1-or-later
+  ]
+libwayland-egl1:
+  licenses: [
+    GPL-2.0-only,
+    LGPL-2.1-or-later
+  ]
 libwayland-server0:
   licenses: [
     X11,
+  ]
+libwebp7:
+  licenses: [
+    BSD-3-Clause,
+    Apache-2.0
+  ]
+libwebpmux3:
+  licenses: [
+    BSD-3-Clause,
+    Apache-2.0
   ]
 libx11-6:
   licenses: [
@@ -309,6 +755,10 @@ libxau6:
   licenses: [
     MIT,
   ]
+libxcb-composite0:
+  licenses: [
+    MIT
+  ]
 libxcb-dri2-0:
   licenses: [
     MIT,
@@ -317,13 +767,29 @@ libxcb-dri3-0:
   licenses: [
     MIT,
   ]
+libxcb-glx0:
+  licenses: [
+    MIT
+  ]
 libxcb-present0:
   licenses: [
     MIT,
   ]
 libxcb-randr0:
   licenses: [
+    MIT
+  ]
+libxcb-render0:
+  licenses: [
     MIT,
+  ]
+libxcb-shape0:
+  licenses: [
+    MIT
+  ]
+libxcb-shm0:
+  licenses: [
+    MIT
   ]
 libxcb-sync1:
   licenses: [
@@ -333,29 +799,163 @@ libxcb-xfixes0:
   licenses: [
     MIT,
   ]
+libxcb-xinerama0:
+  licenses: [
+    MIT
+  ]
+libxcb-xinput0:
+  licenses: [
+    MIT
+  ]
+libxcb-xkb1:
+  licenses: [
+    MIT
+  ]
 libxcb1:
   licenses: [
     MIT,
+  ]
+libxcomposite1:
+  licenses: [
+    MIT
+  ]
+libxcursor1:
+  licenses: [
+    MIT
+  ]
+libxdamage1:
+  licenses: [
+    MIT
   ]
 libxdmcp6:
   licenses: [
     MIT,
   ]
+libxext6:
+  licenses: [
+    MIT-open-group,
+    MIT,
+    HPND,
+  ]
+libxfixes3:
+  licenses: [
+    MIT,
+    HPND
+  ]
+libxi6:
+  licenses: [
+    MIT-open-group,
+    HPND,
+    MIT
+  ]
+libxinerama1:
+  licenses: [
+    MIT-open-group,
+    MIT
+  ]
+libxkbcommon-x11-0:
+  licenses: [
+    MIT,
+    MIT-open-group,
+    HPND,
+    HPND-sell-variant,
+    X11
+  ]
+libxkbcommon0:
+  licenses: [
+    MIT,
+    MIT-open-group,
+    HPND,
+    HPND-sell-variant,
+    X11
+  ]
+libxkbfile1:
+  licenses: [
+    HPND,
+    MIT-open-group
+  ]
+libxrandr2:
+  licenses: [
+    MIT
+  ]
+libxrender1:
+  licenses: [
+    MIT
+  ]
 libxshmfence1:
   licenses: [
     HPND,
   ]
-lrzsz:
+libxslt1.1:
+  licenses: [
+    MIT
+  ]
+libxss1:
+  licenses: [
+    MIT
+  ]
+libxtst6:
+  licenses: [
+    MIT,
+    X11,
+    HPND
+  ]
+libxv1:
+  licenses: [
+    MIT
+  ]
+libxxf86vm1:
+  licenses: [
+    X11
+  ]
+libzbar0:
+  licenses: [
+    LGPL-2.0-or-later
+  ]
+linux-image-cip:
+  licenses: [
+    GPL-2,
+  ]
+linux-image-cip-rt:
   licenses: [
     GPL-2,
   ]
 locales:
   licenses: [
     LGPL-2.1,
+    GPL-2,
+  ]
+lrzsz:
+  licenses: [
     GPL-2
+  ]
+shared-mime-info:
+  licenses: [
+    GPL-2.0-or-later
+  ]
+sshd-regen-keys:
+  licenses: [
+    MIT,
+    GPL-2.0-only
+  ]
+tee-supplicant:
+  licenses: [
+    BSD-2-Clause
   ]
 weston-init:
   licenses: [
     MIT,
   ]
-
+x11-common:
+  licenses: [
+    MIT,
+    GPL-2.0-or-later
+  ]
+xkb-data:
+  licenses: [
+    MIT,
+    X11,
+    HPND,
+    MIT-open-group,
+    xkeyboard-config-Zinovie
+  ]


### PR DESCRIPTION
Added licenses for following packages.

- adwaita-icon-theme
- fontconfig
- fontconfig-config
- gstreamer1.0-alsa
- gstreamer1.0-gl
- gstreamer1.0-gtk3
- gstreamer1.0-opencv
- gstreamer1.0-plugins-bad
- gstreamer1.0-plugins-bad-apps
- gstreamer1.0-plugins-base
- gstreamer1.0-plugins-base-apps
- gstreamer1.0-plugins-good
- gstreamer1.0-pulseaudio
- gstreamer1.0-tools
- gstreamer1.0-x
- i2c-tools
- initramfs-tee-supplicant-hook
- libaec0
- libavahi-client3
- libavahi-common-data
- libavahi-common3
- libcfitsio10
- libdc1394-25
- libdrm-amdgpu1
- libdrm-nouveau2
- libdrm-radeon1
- libdw1
- libegl1
- libelf1
- libflite1
- libfontconfig1
- libgbm1
- libgfortran5
- libgles2
- libgstreamer-gl1.0-0
- libgstreamer-opencv1.0-0
- libgstreamer-plugins-bad1.0-0
- libgstreamer-plugins-base1.0-0
- libgstreamer1.0-0
- libgupnp-igd-1.0-4
- libhwloc15
- libi2c0
- libice6
- libiec61883-0
- liblept5
- libllvm15
- libmjpegutils-2.1-0
- libmodplug1
- libmpcdec6
- libmpeg2encpp-2.1-0
- libmplex2-2.1-0
- libnice10
- libnuma1
- liborc-0.4-0
- libpangocairo-1.0-0
- libpixman-1-0
- libproxy1v5
- libpython3.13-stdlib
- libraw1394-11
- libsensors-config
- libsensors5
- libsm6
- libspandsp2
- libsz2
- libteec1
- libusb-1.0-0
- libwayland-cursor0
- libwayland-egl1
- libwebp7
- libwebpmux3
- libxcb-composite0
- libxcb-glx0
- libxcb-render0
- libxcb-shape0
- libxcb-shm0
- libxcb-xinerama0
- libxcb-xinput0
- libxcb-xkb1
- libxcomposite1
- libxcursor1
- libxdamage1
- libxext6
- libxfixes3
- libxi6
- libxinerama1
- libxkbcommon-x11-0
- libxkbcommon0
- libxkbfile1
- libxrandr2
- libxrender1
- libxslt1.1
- libxss1
- libxtst6
- libxv1
- libxxf86vm1
- libzbar0
- linux-image-cip
- linux-image-cip-rt
- lrzsz
- shared-mime-info
- sshd-regen-keys
- tee-supplicant
- x11-common
- xkb-data

# Test

Following steps run with/without this PR.

Add following setting to conf/local.conf.

```
MACHINE = "qemu-arm64"
DISTRO = "emlinux-bookworm"

IMAGE_PREINSTALL:append = " adwaita-icon-theme"
IMAGE_PREINSTALL:append = " fontconfig"
IMAGE_PREINSTALL:append = " fontconfig-config"
IMAGE_PREINSTALL:append = " gstreamer1.0-alsa"
IMAGE_PREINSTALL:append = " gstreamer1.0-gl"
IMAGE_PREINSTALL:append = " gstreamer1.0-gtk3"
IMAGE_PREINSTALL:append = " gstreamer1.0-opencv"
IMAGE_PREINSTALL:append = " gstreamer1.0-plugins-bad"
IMAGE_PREINSTALL:append = " gstreamer1.0-plugins-bad-apps"
IMAGE_PREINSTALL:append = " gstreamer1.0-plugins-base"
IMAGE_PREINSTALL:append = " gstreamer1.0-plugins-base-apps"
IMAGE_PREINSTALL:append = " gstreamer1.0-plugins-good"
IMAGE_PREINSTALL:append = " gstreamer1.0-pulseaudio"
IMAGE_PREINSTALL:append = " gstreamer1.0-tools"
IMAGE_PREINSTALL:append = " gstreamer1.0-x"
IMAGE_PREINSTALL:append = " i2c-tools"
IMAGE_PREINSTALL:append = " libaec0"
IMAGE_PREINSTALL:append = " libavahi-client3"
IMAGE_PREINSTALL:append = " libavahi-common-data"
IMAGE_PREINSTALL:append = " libavahi-common3"
IMAGE_PREINSTALL:append = " libcfitsio10"
IMAGE_PREINSTALL:append = " libdc1394-25"
IMAGE_PREINSTALL:append = " libdrm-amdgpu1"
IMAGE_PREINSTALL:append = " libdrm-nouveau2"
IMAGE_PREINSTALL:append = " libdrm-radeon1"
IMAGE_PREINSTALL:append = " libdw1"
IMAGE_PREINSTALL:append = " libegl1"
IMAGE_PREINSTALL:append = " libelf1"
IMAGE_PREINSTALL:append = " libflite1"
IMAGE_PREINSTALL:append = " libfontconfig1"
IMAGE_PREINSTALL:append = " libgbm1"
IMAGE_PREINSTALL:append = " libgfortran5"
IMAGE_PREINSTALL:append = " libgles2"
IMAGE_PREINSTALL:append = " libgstreamer-gl1.0-0"
IMAGE_PREINSTALL:append = " libgstreamer-opencv1.0-0"
IMAGE_PREINSTALL:append = " libgstreamer-plugins-bad1.0-0"
IMAGE_PREINSTALL:append = " libgstreamer-plugins-base1.0-0"
IMAGE_PREINSTALL:append = " libgstreamer1.0-0"
IMAGE_PREINSTALL:append = " libhwloc15"
IMAGE_PREINSTALL:append = " libi2c0"
IMAGE_PREINSTALL:append = " libice6"
IMAGE_PREINSTALL:append = " libiec61883-0"
IMAGE_PREINSTALL:append = " liblept5"
IMAGE_PREINSTALL:append = " libllvm15"
IMAGE_PREINSTALL:append = " libmjpegutils-2.1-0"
IMAGE_PREINSTALL:append = " libmodplug1"
IMAGE_PREINSTALL:append = " libmpcdec6"
IMAGE_PREINSTALL:append = " libmpeg2encpp-2.1-0"
IMAGE_PREINSTALL:append = " libmplex2-2.1-0"
IMAGE_PREINSTALL:append = " libnuma1"
IMAGE_PREINSTALL:append = " liborc-0.4-0"
IMAGE_PREINSTALL:append = " libpixman-1-0"
IMAGE_PREINSTALL:append = " libproxy1v5"
IMAGE_PREINSTALL:append = " libraw1394-11"
IMAGE_PREINSTALL:append = " libsensors-config"
IMAGE_PREINSTALL:append = " libsensors5"
IMAGE_PREINSTALL:append = " libsm6"
IMAGE_PREINSTALL:append = " libspandsp2"
IMAGE_PREINSTALL:append = " libsz2"
IMAGE_PREINSTALL:append = " libteec1"
IMAGE_PREINSTALL:append = " libusb-1.0-0"
IMAGE_PREINSTALL:append = " libwayland-cursor0"
IMAGE_PREINSTALL:append = " libwayland-egl1"
IMAGE_PREINSTALL:append = " libwebp7"
IMAGE_PREINSTALL:append = " libwebpmux3"
IMAGE_PREINSTALL:append = " libxcb-composite0"
IMAGE_PREINSTALL:append = " libxcb-glx0"
IMAGE_PREINSTALL:append = " libxcb-render0"
IMAGE_PREINSTALL:append = " libxcb-shape0"
IMAGE_PREINSTALL:append = " libxcb-shm0"
IMAGE_PREINSTALL:append = " libxcb-xinerama0"
IMAGE_PREINSTALL:append = " libxcb-xinput0"
IMAGE_PREINSTALL:append = " libxcb-xkb1"
IMAGE_PREINSTALL:append = " libxcomposite1"
IMAGE_PREINSTALL:append = " libxcursor1"
IMAGE_PREINSTALL:append = " libxdamage1"
IMAGE_PREINSTALL:append = " libxext6"
IMAGE_PREINSTALL:append = " libxfixes3"
IMAGE_PREINSTALL:append = " libxi6"
IMAGE_PREINSTALL:append = " libxinerama1"
IMAGE_PREINSTALL:append = " libxkbcommon-x11-0"
IMAGE_PREINSTALL:append = " libxkbcommon0"
IMAGE_PREINSTALL:append = " libxkbfile1"
IMAGE_PREINSTALL:append = " libxrandr2"
IMAGE_PREINSTALL:append = " libxrender1"
IMAGE_PREINSTALL:append = " libxslt1.1"
IMAGE_PREINSTALL:append = " libxss1"
IMAGE_PREINSTALL:append = " libxtst6"
IMAGE_PREINSTALL:append = " libxv1"
IMAGE_PREINSTALL:append = " libxxf86vm1"
IMAGE_PREINSTALL:append = " shared-mime-info"
IMAGE_PREINSTALL:append = " tee-supplicant"
IMAGE_PREINSTALL:append = " x11-common"
IMAGE_PREINSTALL:append = " xkb-data"
IMAGE_INSTALL:append = " initramfs-tee-supplicant-hook"
```

1. Build emlinux-image-base
2. Create spdx sbom
3. Check license

# Test result

Current version has 90 unknown licenses.

```
build@658653b0d539:~/work/build$ create_sbom.py \
    --image emlinux-image-base \
    --supplier "Cybertrust Japan Co., Ltd." \
    --product EMLinux3 \
    --sbom-format spdx
2026-03-26 04:42:09,629:INFO: Create spdx format sbom for emlinux-image-base
2026-03-26 04:42:09,857:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-spdx.json
build@658653b0d539:~/work/build$ cat tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-spdx.json | jq '.packages[] | select(.licenseConcluded == "unknown") | .name' > old-licenses.txt
build@658653b0d539:~/work/build$ wc -l old-licenses.txt 
90 old-licenses.txt
```

With this PR's patch, there are no unknown license.

```
build@658653b0d539:~/work/build$ create_sbom.py \
    --image emlinux-image-base \
    --supplier "Cybertrust Japan Co., Ltd." \
    --product EMLinux3 \
    --sbom-format spdx
2026-03-26 04:43:08,872:INFO: Create spdx format sbom for emlinux-image-base
2026-03-26 04:43:09,094:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-spdx.json
build@658653b0d539:~/work/build$ cat tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-spdx.json | jq '.packages[] | select(.licenseConcluded == "unknown") | .name' > new-licenses.txt
build@658653b0d539:~/work/build$ wc -l new-licenses.txt 
0 new-licenses.txt
```