### PR TITLE
sdk-files: Fix typo of relocate-sdk.sh

### DIFF
--- a/recipes-devtools/sdk-files/files/relocate-sdk.sh
+++ b/recipes-devtools/sdk-files/files/relocate-sdk.sh
@@ -86,10 +86,10 @@ for binary in $(cat $repatch_list ${new_sdkroot}/repatch.list); do
 		fi
 	else
 		rpath=$(patchelf --print-rpath ${binary})
-		if [ -n "${binary}" ]; then
+		if [ -n "${rpath}" ]; then
 			patchelf --set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
 			--force-rpath \
-			$library 2>/dev/null
+			$binary 2>/dev/null
 		fi
 	fi
 done

--- a/recipes-devtools/sdk-files/files/relocate-sdk.sh
+++ b/recipes-devtools/sdk-files/files/relocate-sdk.sh
@@ -12,7 +12,7 @@ new_sdkroot=$sdkroot
 repatch_list=""
 
 opt_short="hrl:"
-opt_long="help,resore-chroot,repatch-list:"
+opt_long="help,restore-chroot,repatch-list:"
 OPTS=$(getopt -o "$opt_short" -l "$opt_long" -- "$@")
 if [ $? -ne 0 ] ; then
 	echo "Wrong input parameter!"; 1>&2


### PR DESCRIPTION
# Purpose

Fixes the typo of relocate-sdk.sh.

# How to test

1. Modify local.conf and repatch.list for testing purposes.

> [!NOTE]
> `repatch.list` is a file used to list the paths of binaries or libraries that require patchelf to be applied twice to prevent SEGV. 
> Since no such libraries have been identified yet, an arbitrary library has been added to the list for verification purposes.

```
$ cat << EOF >> conf/local.conf
MACHINE ?= "qemu-arm64"
EOF

$: cat << EOF >> ../repos/meta-emlinux/recipes-devtools/sdk-files/files/repatch.list
/usr/aarch64-linux-gnu/lib/libstdc++.so.6
EOF
```

2. Insert debug messages into relocate-sdk.sh.

Apply following patch to meta-emlinux.

```
diff --git a/recipes-devtools/sdk-files/files/relocate-sdk.sh b/recipes-devtools/sdk-files/files/relocate-sdk.sh
index 690b791..282afb2 100755
--- a/recipes-devtools/sdk-files/files/relocate-sdk.sh
+++ b/recipes-devtools/sdk-files/files/relocate-sdk.sh
@@ -87,6 +87,8 @@ for binary in $(cat $repatch_list ${new_sdkroot}/repatch.list); do
        else
                rpath=$(patchelf --print-rpath ${binary})
                if [ -n "${rpath}" ]; then
+                       echo ""
+                       echo "DEBUG: Apply the new rpath to ${binary} twice by patchelf."
                        patchelf --set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
                        --force-rpath \
                        $binary 2>/dev/null
```
 
3. Build SDK

```
$ bitbake emlinux-image-base -c populate_sdk
```

4. Install SDK

```
$ ./tmp/deploy/images/qemu-arm64/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64-sdk-installer.sh
Will you continue to install EMLinux SDK? [y/N]
y
Installing EMLinux SDK to /opt .
Adjusting path of SDK to '/opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64'... done
When you use the SDK in a new shell session, you need to run following command.
  $ source /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64/environment-setup-qemu-arm64-emlinux-bookworm
```


# Result

1. Check the debug messages during SDK installation.

If everything goes as expected, a debug message indicating that patchelf has been applied to libc.so will be displayed.

```
DEBUG: Apply the new rpath to /opt/emlinux-image-base-sdk-emlinux-bookworm-qemu-arm64//usr/aarch64-linux-gnu/lib/libstdc++.so.6 twice by patchelf.
```