### PR TITLE
setup-emlinux: Add generetad version comment to local.conf

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -8,6 +8,20 @@ fi
 clean_up()
 {
     unset EML_BUILDDIR EML_BUILDDIR_SETUP_DONE REPOS EML_HOOKS
+    unset get_emlinux_version
+}
+
+get_emlinux_version()
+{
+    tagname="2.x"
+    if [ -f "${REPOS}/meta-emlinux/conf/distro/include/emlinux.inc" ]; then
+        tmpver=$(grep '^DISTRO_VERSION *= *' ${REPOS}/meta-emlinux/conf/distro/include/emlinux.inc)
+        tmpver=$(echo ${tmpver//\'/\"} | cut -d'"' -f2)
+        if [ -n "${tmpver}" ]; then
+            tagname="${tmpver}"
+        fi
+    fi
+    echo "${tagname} "
 }
 
 # save error during 'source setup-emlinux'
@@ -73,6 +87,7 @@ if [ -z "$TEMPLATECONF" ] && [ "${EML_BUILDDIR_SETUP_DONE}" = "false" ]; then
 	    source ${EML_HOOKS}/$hook
 	done
     fi
+    echo "# The above settings were generated in EMLinux $(get_emlinux_version)on $(date '+%Y-%m-%d')" >> conf/local.conf
 fi
 
 clean_up


### PR DESCRIPTION
# Purpose of pull request
Add EMLinux version and date it was created as comment to local.conf generated by setup-emlinux script.

With this change, it becomes easier to find configuration errors caused by EMLinux updates when reusing an old local.conf.

Example comment added to local.conf:
  ```
  # The above settings were generated in EMLinux 2.13 on 2026-03-27
  ```

# Test
Confirmed that comment was added to local.conf with EMLinux version and date.
```
build@c41625905514:~/work$ . setup-emlinux TEST
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/


### Shell environment set up for builds. ###

You can now run 'bitbake <target>'

Common targets are:
    core-image-minimal
    core-image-sato
    meta-toolchain
    meta-ide-support

You can also run generated qemu images with a command like 'runqemu qemux86'
NOTE: Starting bitbake server...
NOTE: Starting bitbake server...
NOTE: Starting bitbake server...
build@c41625905514:~/work/TEST$ tail -n 1 conf/local.conf
# The above settings were generated in EMLinux 2.13 on 2026-03-27
```