### PR TITLE
sdk-files: use patchelf "--no-sort" option on Debian 13

### DIFF
--- a/recipes-devtools/sdk-files/files/relocate-sdk.sh
+++ b/recipes-devtools/sdk-files/files/relocate-sdk.sh
@@ -45,6 +45,14 @@ if [ -z $(which patchelf 2>/dev/null) ]; then
 	exit 1
 fi
 
+# Use patchelf "--no-sort" option to avoid segfaults for long install directory
+# if the version is newer than 0.14.3 (eg. Debian 13).
+patchelf_opts=""
+patchelf_ver=$(patchelf --version | awk '{print $2}')
+if dpkg --compare-versions "${patchelf_ver}" "gt" "0.14.3"; then
+	patchelf_opts="--no-sort"
+fi
+
 echo -n "Adjusting path of SDK to '${new_sdkroot}'... "
 
 for binary in $(find ${sdkroot}/usr/bin ${sdkroot}/usr/sbin ${sdkroot}/usr/lib/gcc* -executable -type f,l -exec file -L {} \; | grep ELF | awk -F ':' '{ print $1 }'); do
@@ -52,7 +60,7 @@ for binary in $(find ${sdkroot}/usr/bin ${sdkroot}/usr/sbin ${sdkroot}/usr/lib/g
 	oldpath=${interpreter%/lib*/ld-linux*}
 	interpreter=${interpreter#${oldpath}}
 	if [ -n "${interpreter}" ]; then
-		patchelf --set-interpreter ${new_sdkroot}${interpreter} \
+		patchelf ${patchelf_opts} --set-interpreter ${new_sdkroot}${interpreter} \
 			--set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
 			--force-rpath \
 			$binary 2>/dev/null
@@ -62,7 +70,7 @@ done
 for library in $(find ${sdkroot}/usr/lib -type f,l -name "lib*.so*" -exec file -L {} \; | grep ELF | awk -F ':' '{ print $1 }'); do
 	rpath=$(patchelf --print-rpath ${library})
 	if [ -n "${library}" ]; then
-		patchelf --set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
+		patchelf ${patchelf_opts} --set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
 		--force-rpath \
 		$library 2>/dev/null
 	fi
@@ -79,7 +87,7 @@ for binary in $(cat $repatch_list ${new_sdkroot}/repatch.list); do
 		oldpath=${interpreter%/lib*/ld-linux*}
 		interpreter=${interpreter#${oldpath}}
 		if [ -n "${interpreter}" ]; then
-			patchelf --set-interpreter ${new_sdkroot}${interpreter} \
+			patchelf ${patchelf_opts} --set-interpreter ${new_sdkroot}${interpreter} \
 				--set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
 				--force-rpath \
 				$binary 2>/dev/null
@@ -87,7 +95,7 @@ for binary in $(cat $repatch_list ${new_sdkroot}/repatch.list); do
 	else
 		rpath=$(patchelf --print-rpath ${binary})
 		if [ -n "${rpath}" ]; then
-			patchelf --set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
+			patchelf ${patchelf_opts} --set-rpath ${new_sdkroot}/usr/lib:${new_sdkroot}/usr/lib/${arch}-linux-gnu \
 			--force-rpath \
 			$binary 2>/dev/null
 		fi


### PR DESCRIPTION
# Purpose

Fixes SDK binaries segfault problem when installed into long directory name on Debian 13.

# How to test
1. Modify docker/Dockerfile as the following for preparing Debian 13 docker build environment

```diff
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:trixie
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NOWARNINGS yes

@@ -32,7 +32,7 @@ RUN apt-get install --fix-missing -y \
   sbuild \
   schroot \
   zstd \
-  python3-distutils \
+  python3-setuptools \
   python3-yaml \
   python3-html5lib \
   python3-pip \
```

2. Rebuild docker image

```
$ ./docker/run.sh clean
$ ./docker/run.sh build
```

3. Run docker

```
$ ./docker/run.sh
```

4. Build SDK

```
$ source setup-emlinux
$ cat << EOF >> conf/local.conf
MACHINE = "qemu-arm64"
DISTRO = "emlinux-trixie"
$ bitbake emlinux-image-base -c populate_sdk
```

5. Install SDK

```
$ ./tmp/deploy/images/qemu-arm64/emlinux-image-base-sdk-emlinux-trixie-qemu-arm64-sdk-installer.sh -d ./longdir/12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
Will you continue to install EMLinux SDK? [y/N]
y
Installing EMLinux SDK to /home/build/work/build/longdir/12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 .
Adjusting path of SDK to '/home/build/work/build/longdir/12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890/emlinux-image-base-sdk-emlinux-trixie-qemu-arm64'... done
When you use the SDK in a new shell session, you need to run following command.
  $ source /home/build/work/build/longdir/12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890/emlinux-image-base-sdk-emlinux-trixie-qemu-arm64/environment-setup-qemu-arm64-emlinux-trixie
```

6. Using SDK

```
$ source /home/build/work/build/longdir/12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890/emlinux-image-base-sdk-emlinux-trixie-qemu-arm64/environment-setup-qemu-arm64-emlinux-trixie
$ echo -e '#include<stdio.h>\nint main(void){printf("Hello world\\n");return 0;}' | ${CC} -Wall -x c - && /usr/bin/file a.out
```

# Result

1. Before this fix

```
$ echo -e '#include<stdio.h>\nint main(void){printf("Hello world\\n");return 0;}' | ${CC} -Wall -x c - && /usr/bin/file a.out
Segmentation fault (core dumped)
```

2. After this fix

```
$ echo -e '#include<stdio.h>\nint main(void){printf("Hello world\\n");return 0;}' | ${CC} -Wall -x c - && /usr/bin/file a.out
a.out: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=3569a0a26cc99ab19dac1b990be371ed6a67dc84, for GNU/Linux 3.7.0, not stripped
```