### PR TITLE
Support initrd

### DIFF
--- a/recipes-core/images/emlinux-image-base.bb
+++ b/recipes-core/images/emlinux-image-base.bb
@@ -32,3 +32,6 @@ IMAGE_PREINSTALL:append = "\
 inherit image
 
 DEPENDS:class-sdk:append = " ${IMAGE_INSTALL}"
+
+INITRAMFS_RECIPE ?= "emlinux-initramfs-base"
+IMAGE_INITRD = "${INITRAMFS_RECIPE}"

--- a/recipes-initramfs/emlinux-initramfs/emlinux-initramfs-base.bb
+++ b/recipes-initramfs/emlinux-initramfs/emlinux-initramfs-base.bb
@@ -1,0 +1,26 @@
+#
+# EMLinux initramfs base image
+#
+# Copyright Cybertrust Japan Co., Ltd.
+#
+# Authors:
+#  Hirotaka Motai <hirotaka.motai@miraclelinux.com>
+#
+# SPDX-License-Identifier: MIT
+#
+# The image will be deployed to:
+#   build/tmp/deploy/images/${MACHINE}/emlinux-initramfs-base-${DISTRO}-${MACHINE}-initrd.img
+#
+
+inherit initramfs
+
+# Debian packages that should be install into the system for building the
+# initramfs.
+INITRAMFS_PREINSTALL += " \
+	dmsetup \
+	systemd \
+"
+
+# Recipes that should be install into the initramfs build rootfs.
+INITRAMFS_INSTALL += " \
+"


### PR DESCRIPTION
# Purpose

Added INITRD recipe for emlinux-image-base/weston.

# Test

Comfirmed the following:

1. An initrd.img is generated by using the emlinux-initramfs-base recipe.
2. no differences between the file list inside the generated initrd.img and of the original initrd.img.

# Test results

## 1. Confirming initrd.img creation

Add the following line to local.conf.

```sh
TMPDIR .= "-${BB_CURRENT_MC}"
```

Run `bitbake` as follows to build:

```sh
$ bitbake \
      mc:qemu-arm64-bookworm:emlinux-image-base \
      mc:qemu-arm64-trixie:emlinux-image-base \
      mc:qemu-arm64-bookworm:emlinux-image-weston \
      mc:qemu-arm64-trixie:emlinux-image-weston
```

confirmed that the initrd.img was generated and that it uses the name of the INITRD recipe.

* emlinux-initramfs-base-emlinux-bookworm-qemu-arm64-initrd.img\*

* emlinux-initramfs-base-emlinux-trixie-qemu-arm64-initrd.img\*

```sh
$ ls tmp-*/deploy/images/qemu-arm64
tmp-qemu-arm64-bookworm/deploy/images/qemu-arm64:
all-source-info.json
emlinux-image-base-emlinux-bookworm-qemu-arm64.cdx.json
emlinux-image-base-emlinux-bookworm-qemu-arm64.dpkg_status
emlinux-image-base-emlinux-bookworm-qemu-arm64.ext4
emlinux-image-base-emlinux-bookworm-qemu-arm64.manifest
emlinux-image-base-emlinux-bookworm-qemu-arm64.spdx.json
emlinux-image-base-emlinux-bookworm-qemu-arm64-vmlinux
emlinux-image-weston-emlinux-bookworm-qemu-arm64.cdx.json
emlinux-image-weston-emlinux-bookworm-qemu-arm64.dpkg_status
emlinux-image-weston-emlinux-bookworm-qemu-arm64.ext4
emlinux-image-weston-emlinux-bookworm-qemu-arm64.manifest
emlinux-image-weston-emlinux-bookworm-qemu-arm64.spdx.json
emlinux-image-weston-emlinux-bookworm-qemu-arm64-vmlinux
emlinux-initramfs-base-emlinux-bookworm-qemu-arm64.cdx.json
emlinux-initramfs-base-emlinux-bookworm-qemu-arm64-initrd.img*
emlinux-initramfs-base-emlinux-bookworm-qemu-arm64.manifest
emlinux-initramfs-base-emlinux-bookworm-qemu-arm64.spdx.json

tmp-qemu-arm64-trixie/deploy/images/qemu-arm64:
all-source-info.json
emlinux-image-base-emlinux-trixie-qemu-arm64.cdx.json
emlinux-image-base-emlinux-trixie-qemu-arm64.dpkg_status
emlinux-image-base-emlinux-trixie-qemu-arm64.ext4
emlinux-image-base-emlinux-trixie-qemu-arm64.manifest
emlinux-image-base-emlinux-trixie-qemu-arm64.spdx.json
emlinux-image-base-emlinux-trixie-qemu-arm64-vmlinux
emlinux-image-weston-emlinux-trixie-qemu-arm64.cdx.json
emlinux-image-weston-emlinux-trixie-qemu-arm64.dpkg_status
emlinux-image-weston-emlinux-trixie-qemu-arm64.ext4
emlinux-image-weston-emlinux-trixie-qemu-arm64.manifest
emlinux-image-weston-emlinux-trixie-qemu-arm64.spdx.json
emlinux-image-weston-emlinux-trixie-qemu-arm64-vmlinux
emlinux-initramfs-base-emlinux-trixie-qemu-arm64.cdx.json
emlinux-initramfs-base-emlinux-trixie-qemu-arm64-initrd.img*
emlinux-initramfs-base-emlinux-trixie-qemu-arm64.manifest
emlinux-initramfs-base-emlinux-trixie-qemu-arm64.spdx.json
```

## 2. Compare the file list inside initrd.img

The original produces 4 initrd files.

1. emlinux-image-base-emlinux-bookworm-qemu-arm64-initrd.img
2. emlinux-image-weston-emlinux-bookworm-qemu-arm64-initrd.img
3. emlinux-image-base-emlinux-trixie-qemu-arm64-initrd.img
4. emlinux-image-weston-emlinux-trixie-qemu-arm64-initrd.img

Compared them respectively.

### emlinux-bookworm

Ran the following commands for comparison.
No differences found.

```sh
$ diff -u \
  <(cd      mlinux-image-base-emlinux-bookworm-qemu-arm64-initrd; find . | sort)
  <(cd emlinux-initramfs-base-emlinux-bookworm-qemu-arm64-initrd; find . | sort)
$ diff -u \
  <(cd    mlinux-image-weston-emlinux-bookworm-qemu-arm64-initrd; find . | sort)
  <(cd emlinux-initramfs-base-emlinux-bookworm-qemu-arm64-initrd; find . | sort)
$
```

### emlinux-trixie

Ran the following commands for comparison.
No differences found.

```diff
$ diff -u \
  <(cd      mlinux-image-base-emlinux-trixie-qemu-arm64-initrd; find . | sort)
  <(cd emlinux-initramfs-base-emlinux-trixie-qemu-arm64-initrd; find . | sort)
--- /dev/fd/63	2026-04-03 14:13:19.386325617 +0900
+++ /dev/fd/62	2026-04-03 14:13:19.386325617 +0900
@@ -91,6 +91,7 @@
 ./usr/lib/aarch64-linux-gnu/libcrypt.so.1
 ./usr/lib/aarch64-linux-gnu/libcrypt.so.1.1.0
 ./usr/lib/aarch64-linux-gnu/libc.so.6
+./usr/lib/aarch64-linux-gnu/libdevmapper.so.1.02.1
 ./usr/lib/aarch64-linux-gnu/libkmod.so.2
 ./usr/lib/aarch64-linux-gnu/libkmod.so.2.5.1
 ./usr/lib/aarch64-linux-gnu/libmount.so.1
@@ -103,6 +104,8 @@
 ./usr/lib/aarch64-linux-gnu/libseccomp.so.2
 ./usr/lib/aarch64-linux-gnu/libseccomp.so.2.6.0
 ./usr/lib/aarch64-linux-gnu/libselinux.so.1
+./usr/lib/aarch64-linux-gnu/libudev.so.1
+./usr/lib/aarch64-linux-gnu/libudev.so.1.7.10
 ./usr/lib/aarch64-linux-gnu/libz.so.1
 ./usr/lib/aarch64-linux-gnu/libz.so.1.3.1
 ./usr/lib/aarch64-linux-gnu/libzstd.so.1
@@ -232,15 +235,19 @@
 ./usr/lib/udev/rules.d
 ./usr/lib/udev/rules.d/50-firmware.rules
 ./usr/lib/udev/rules.d/50-udev-default.rules
+./usr/lib/udev/rules.d/55-dm.rules
 ./usr/lib/udev/rules.d/60-block.rules
+./usr/lib/udev/rules.d/60-persistent-storage-dm.rules
 ./usr/lib/udev/rules.d/60-persistent-storage.rules
 ./usr/lib/udev/rules.d/71-seat.rules
 ./usr/lib/udev/rules.d/73-special-net-names.rules
 ./usr/lib/udev/rules.d/75-net-description.rules
 ./usr/lib/udev/rules.d/80-drivers.rules
 ./usr/lib/udev/rules.d/80-net-setup-link.rules
+./usr/lib/udev/rules.d/95-dm-notify.rules
 ./usr/lib/udev/scsi_id
 ./usr/sbin
 ./usr/sbin/blkid
+./usr/sbin/dmsetup
 ./usr/sbin/modprobe
 ./usr/sbin/rmmod
$ diff -u \
  <(cd    mlinux-image-weston-emlinux-trixie-qemu-arm64-initrd; find . | sort)
  <(cd emlinux-initramfs-base-emlinux-trixie-qemu-arm64-initrd; find . | sort)

(    Skipped; no changes from above    )
```

Since the differences are identical to those in the two original files as below and no files were missing, I consider this to be acceptable.

1. emlinux-image-base-emlinux-bookworm-qemu-arm64-initrd.img
1. emlinux-image-base-emlinux-trixie-qemu-arm64-initrd.img

