### PR TITLE
linux: Abandon printing a private name in dmesg

### DIFF
--- a/recipes-kernel/linux/includes/linux-cip-common.inc
+++ b/recipes-kernel/linux/includes/linux-cip-common.inc
@@ -8,7 +8,7 @@
 
 inherit linux-kernel
 
-MAINTAINER = "Arisu Tachibana <arisu.tachibana@miraclelinux.com>"
+MAINTAINER = "EMLinux development team <emlinux-dev@emlinux-host>"
 
 SRC_URI += " \
     git://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git;branch=${BRANCH};destsuffix=${P};protocol=https \


### PR DESCRIPTION
This sets a dummy string as MAINTAINER instead of a private name to indicate the EMLinux maintained kernel in dmesg.