### PR TITLE
initramfs: add initial emlinux-initramfs-base recipe

### DIFF
--- a/recipes-initramfs/emlinux-initramfs/emlinux-initramfs-base.bb
+++ b/recipes-initramfs/emlinux-initramfs/emlinux-initramfs-base.bb
@@ -1,0 +1,26 @@
+#
+# EMLinux initramfs base image
+#
+# Copyright Cybertrust Japan Co., Ltd.
+#
+# Authors:
+#  Hirotaka Motai <hirotaka.motai@miraclelinux.com>
+#
+# SPDX-License-Identifier: MIT
+#
+# The image will be deployed to:
+#   build/tmp/deploy/images/${MACHINE}/emlinux-initramfs-base-${DISTRO}-${MACHINE}-initrd.img
+#
+
+inherit initramfs
+
+# Debian packages that should be install into the system for building the
+# initramfs.
+INITRAMFS_PREINSTALL += " \
+	dmsetup \
+	systemd \
+"
+
+# Recipes that should be install into the initramfs build rootfs.
+INITRAMFS_INSTALL += " \
+"


### PR DESCRIPTION
# Purpose

Added a new INITRD recipe.

# Test

Comfirmed the following:

1. An initrd.img is generated by using the emlinux-initramfs-base recipe when `IMAGE_INITRD` is defined in local.conf.
2. no differences between the file list inside the generated initrd.img and of the original initrd.img.

# Test results

## 1. Confirming initrd.img creation

Add the following line to local.conf.

```sh
MACHINE = "qemu-arm64"
TMPDIR .= "-${DISTRO}"
IMAGE_INITRD = "emlinux-initramfs-base"
```

Run `bitbake emlinux-image-base` twice:

1. `DISTRO = "emlinux-bookworm"` in conf/local.conf
2. `DISTRO = "emlinux-trixie"` in conf/local.conf

confirmed that the initrd.img was generated and that it uses the name of the INITRD recipe.

* `${INITRD_RECIPE_NAME}`-`${DISTRO}`-`${MACHINE}`-initrd.img

```sh
$ (cd tmp-emlinux-bookworm/deploy/images/qemu-amd64; ls *.img)
emlinux-initramfs-base-emlinux-bookworm-qemu-amd64-initrd.img
$ (cd tmp-emlinux-trixie/deploy/images/qemu-amd64; ls *.img)
emlinux-initramfs-base-emlinux-trixie-qemu-amd64-initrd.img
```

## 2. Compare the file list inside initrd.img

The original produces 2 initrd files.

1. emlinux-image-base-emlinux-bookworm-qemu-arm64-initrd.img
2. emlinux-image-base-emlinux-trixie-qemu-arm64-initrd.img

Compared them respectively.

### emlinux-bookworm

Ran the following commands for comparison.
No differences found.

```sh
$ diff -u \
  <(cd     emlinux-image-base-emlinux-bookworm-qemu-arm64-initrd; find . | sort)
  <(cd emlinux-initramfs-base-emlinux-bookworm-qemu-arm64-initrd; find . | sort)
$ 
```

### emlinux-trixie

Ran the following commands for comparison.
No differences found.

```diff
$ diff -u \
  <(cd     emlinux-image-base-emlinux-trixie-qemu-arm64-initrd; find . | sort)
  <(cd emlinux-initramfs-base-emlinux-trixie-qemu-arm64-initrd; find . | sort)
--- /dev/fd/63	2026-04-10 20:21:04.691966357 +0900
+++ /dev/fd/62	2026-04-10 20:21:04.691966357 +0900
@@ -91,6 +91,7 @@
 ./usr/lib/aarch64-linux-gnu/libcrypt.so.1
 ./usr/lib/aarch64-linux-gnu/libcrypt.so.1.1.0
 ./usr/lib/aarch64-linux-gnu/libc.so.6
+./usr/lib/aarch64-linux-gnu/libdevmapper.so.1.02.1
 ./usr/lib/aarch64-linux-gnu/libkmod.so.2
 ./usr/lib/aarch64-linux-gnu/libkmod.so.2.5.1
 ./usr/lib/aarch64-linux-gnu/libmount.so.1
@@ -103,6 +104,8 @@
 ./usr/lib/aarch64-linux-gnu/libseccomp.so.2
 ./usr/lib/aarch64-linux-gnu/libseccomp.so.2.6.0
 ./usr/lib/aarch64-linux-gnu/libselinux.so.1
+./usr/lib/aarch64-linux-gnu/libudev.so.1
+./usr/lib/aarch64-linux-gnu/libudev.so.1.7.10
 ./usr/lib/aarch64-linux-gnu/libz.so.1
 ./usr/lib/aarch64-linux-gnu/libz.so.1.3.1
 ./usr/lib/aarch64-linux-gnu/libzstd.so.1
@@ -232,15 +235,19 @@
 ./usr/lib/udev/rules.d
 ./usr/lib/udev/rules.d/50-firmware.rules
 ./usr/lib/udev/rules.d/50-udev-default.rules
+./usr/lib/udev/rules.d/55-dm.rules
 ./usr/lib/udev/rules.d/60-block.rules
+./usr/lib/udev/rules.d/60-persistent-storage-dm.rules
 ./usr/lib/udev/rules.d/60-persistent-storage.rules
 ./usr/lib/udev/rules.d/71-seat.rules
 ./usr/lib/udev/rules.d/73-special-net-names.rules
 ./usr/lib/udev/rules.d/75-net-description.rules
 ./usr/lib/udev/rules.d/80-drivers.rules
 ./usr/lib/udev/rules.d/80-net-setup-link.rules
+./usr/lib/udev/rules.d/95-dm-notify.rules
 ./usr/lib/udev/scsi_id
 ./usr/sbin
 ./usr/sbin/blkid
+./usr/sbin/dmsetup
 ./usr/sbin/modprobe
 ./usr/sbin/rmmod
$ 
```

Since the differences are identical to those in the two original files as below and no files were missing, I consider this to be acceptable.

1. emlinux-image-base-emlinux-bookworm-qemu-arm64-initrd.img
2. emlinux-image-base-emlinux-trixie-qemu-arm64-initrd.img

