### PR TITLE
Update kernel to v4.19.325-cip131

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "ef917a8bed27ab284a27aa2e8e242bab707d7aa3"
+LINUX_GIT_SRCREV ?= "7aeff6c7984c582f96916d12bd33eefbd746459c"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip130"
+LINUX_CIP_VERSION ??= "v4.19.325-cip131"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip131

This pull request update the kernel to the following cip versions:
v4.19.325-cip131 with hash tag 7aeff6c7984c582f96916d12bd33eefbd746459c
