### PR TITLE
Update kernel to v5.10.252-cip71

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "99e8b9912822c35e388d236d0aadca61195f75e6"
-LINUX_CVE_VERSION ??= "5.10.251"
-LINUX_CIP_VERSION ?= "v5.10.251-cip70"
+LINUX_GIT_SRCREV ?= "6aaa48ed39383d53b0ed2dc209ed941b3cd7a7e3"
+LINUX_CVE_VERSION ??= "5.10.252"
+LINUX_CIP_VERSION ?= "v5.10.252-cip71"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.252-cip71

This pull request update the kernel to the following cip versions:
v5.10.252-cip71 with hash tag 6aaa48ed39383d53b0ed2dc209ed941b3cd7a7e3
