### PR TITLE
Update kernel to v4.19.325-cip132

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "7aeff6c7984c582f96916d12bd33eefbd746459c"
+LINUX_GIT_SRCREV ?= "a0cf0e1623b28b1d20f9626f32809952b7a40f15"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip131"
+LINUX_CIP_VERSION ??= "v4.19.325-cip132"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip132

This pull request update the kernel to the following cip versions:
v4.19.325-cip132 with hash tag a0cf0e1623b28b1d20f9626f32809952b7a40f15
