### PR TITLE
Update kernel to v5.10.256-cip73

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "6aaa48ed39383d53b0ed2dc209ed941b3cd7a7e3"
-LINUX_CVE_VERSION ??= "5.10.252"
-LINUX_CIP_VERSION ?= "v5.10.252-cip71"
+LINUX_GIT_SRCREV ?= "b1d0cf5ac0d2f6deb7687dd190100cb8423d71ff"
+LINUX_CVE_VERSION ??= "5.10.256"
+LINUX_CIP_VERSION ?= "v5.10.256-cip73"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.256-cip73

This pull request update the kernel to the following cip versions:
v5.10.256-cip73 with hash tag b1d0cf5ac0d2f6deb7687dd190100cb8423d71ff
