### PR TITLE
conf/license: Add Vixie-Cron license

### DIFF
--- a/conf/licenses/license-mapping.yml
+++ b/conf/licenses/license-mapping.yml
@@ -25,6 +25,9 @@
 # CC
 "CC0": "CC0-1.0"
 
+# Vixie Cron License
+"Paul-Vixie's-license": "Vixie-Cron"
+
 # FSF
 "FSF-unlimited": "FSFULLRWD"
 "FSF-unlimited-permission": "FSFULLR"


### PR DESCRIPTION
# Purpose

The Debian cron package's Copyright file lists the Paul-Vixie's-license license, but its SPDX identifier is assigned as Vixie-Cron. Since license names cannot contain single quotes, I added a setting to license-mapping.yml to convert Paul-Vixie's-license to Vixie-Cron.

If license string contains single quote, we got following error.

```
license_expression.ExpressionError: Invalid license key: the valid characters are: letters and numbers, underscore, dot, colon or hyphen signs and spaces: "Paul-Vixie's-license"
```

# Test

Add following line in local.conf.

```
IMAGE_PREINSTALL:append = " cron"
```

Then build emlinux-image-base.
Finally, create sbom.

```
create_sbom.py \
    --image emlinux-image-base \
    --supplier "Cybertrust Japan Co., Ltd." \
    --product EMLinux3 \
    --sbom-format spdx
```

# Test result

SBOM file was created without error.

```
build@f02b172344c6:~/work$ create_sbom.py \
    --image emlinux-image-base \
    --supplier "Cybertrust Japan Co., Ltd." \
    --product EMLinux3 \
    --sbom-format spdx
2026-05-18 00:24:23,293:INFO: Create spdx format sbom for emlinux-image-base
2026-05-18 00:24:23,345:INFO: sbom was created to /home/build/work/build/tmp/deploy/sbom/emlinux-image-base-emlinux-bookworm-qemu-amd64/emlinux-image-base-spdx.json
```

The cron package's sbom data contains Vixie-Cron license.

```
        {
            "SPDXID": "SPDXRef-Package-827c312caf8fefc9e0f242299de5241f3d28b28816ed734ea08496389004bba8",
            "attributionTexts": [
                "PkgID: cron-daemon-common@3.0pl1-162"
            ],
            "description": "process scheduling daemon's configuration files\n The cron daemon is a background process that runs particular programs at\n particular times (for example, every minute, day, week, or month), as\n specified in a crontab. By default, users may also create crontabs of\n their own so that processes are run on their behalf.\n .\n This package provides configuration files which must be there to\n define scheduled process sets.",
            "downloadLocation": "NONE",
            "externalRefs": [
                {
                    "referenceCategory": "PACKAGE_MANAGER",
                    "referenceLocator": "pkg:deb/debian/cron-daemon-common@3.0pl1-162?arch=all&distro=bookworm",
                    "referenceType": "purl"
                }
            ],
            "filesAnalyzed": false,
            "licenseConcluded": "GPL-2.0-or-later AND ISC AND Artistic AND Vixie-Cron",
            "licenseDeclared": "GPL-2.0-or-later AND ISC AND Artistic AND Vixie-Cron",
            "name": "cron-daemon-common",
            "primaryPackagePurpose": "APPLICATION",
            "sourceInfo": "build from: cron 3.0pl1-162",
            "supplier": "Organization: Javier Fern\u00e1ndez-Sanguino Pe\u00f1a (jfs@debian.org)",
            "versionInfo": "3.0pl1-162"
        },
```