### PR TITLE
classes/emlinux-compact: Remove vmlinuz-* files when remove files in boot directory

### DIFF
--- a/classes/emlinux-compact.bbclass
+++ b/classes/emlinux-compact.bbclass
@@ -132,7 +132,7 @@ EOL
 
     if [ "${EMLINUX_IMAGE_COMPACT_REMOVE_BOOT_DIR}" = "1" ]; then
       sudo -E chroot "${ROOTFSDIR}" /bin/busybox sh <<EOL
-rm -fr /boot/System.map-* /boot/config-* /boot/vmlinux-* /boot/initrd* || true
+rm -fr /boot/System.map-* /boot/config-* /boot/vmlinux-* /boot/vmlinuz-* /boot/initrd* || true
 rm -fr /initrd.img /initrd.img.old /vmlinuz /vmlinuz.old || true
 EOL
     fi


### PR DESCRIPTION
# Purpose

When EMLINUX_IMAGE_COMPACT_REMOVE_BOOT_DIR variable is set, it removes files in /boot but it forget to remove vmlinuz-*. Therefore, we should remove it.

There is vmlinuz-* left.

```
build@4d3194577adc:~/work/build$ ls /mnt
bin  boot  dev  etc  home  lib  lib64  lost+found  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
build@4d3194577adc:~/work/build$ ls /mnt/boot
vmlinuz-6.1.167-cip53
```

# Test

Use generic-x86-64 machine. However, it default IMAGE_FSTYPES is wic. The wic image with generic-x86-64 machine use grub as boot loader and it requires /boot directory, so we can't use EMLINUX_IMAGE_COMPACT_REMOVE_BOOT_DIR and generic-x86-64 in a same time.
Thereby, we use ext4 image instead of wic.

You need following setting in your local.conf.

```
MACHINE = "generic-x86-64"
IMAGE_FSTYPES = "ext4"
EMLINUX_IMAGE_COMPACT_REMOVE_BOOT_DIR = "1"
```

Then, build emlinux-image-compact for emlinux-bookworm and emlinux-trixie.

Finally, run the image by following script.

```
#!/bin/bash
#

if [ -z "$1" ]; then
    echo "usage: $0 <bookworm | trixie>"
    exit 1
fi
target="$1"

qemu-system-x86_64 \
-drive file=./tmp/deploy/images/generic-x86-64/emlinux-image-compact-emlinux-${target}-generic-x86-64.ext4,discard=unmap,if=none,id=disk,format=raw \
-kernel ./tmp/deploy/images/generic-x86-64/emlinux-image-compact-emlinux-${target}-generic-x86-64-vmlinuz \
-initrd ./tmp/deploy/images/generic-x86-64/emlinux-image-compact-emlinux-${target}-generic-x86-64-initrd.img \
-m 1G \
-serial mon:stdio \
-netdev user,id=net,hostfwd=tcp:127.0.0.1:22222-:22 \
-cpu qemu64 \
-smp 4 \
-machine q35,accel=kvm:tcg \
-global ICH9-LPC.noreboot=off \
-device virtio-net-pci,netdev=net \
-device ide-hd,drive=disk \
-nographic \
-append "root=/dev/sda rw console=ttyS0 ip=dhcp earlyprintk debug"
```

# Test result

## emlinux-trixie

Succeeded to boot and /boot is empty as expected.

```
EMLinux 3.5 EMLinux3 /dev/ttyS0
EMLinux3 login: root
Password: 

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.


BusyBox v1.37.0 (Debian 1:1.37.0-6) built-in shell (ash)
Enter 'help' for a list of built-in commands.

# uname -a
Linux EMLinux3 6.12.80-cip20 #1 SMP PREEMPT_DYNAMIC Thu, 01 Jan 1970 01:00:00 +0000 x86_64 GNU/Linux
# ls -la /boot
total 2
drwxr-xr-x    2 root     root          1024 Mar  4  2024 .
drwxr-xr-x   18 root     root          1024 Mar  4  2024 ..
```

## emlinux-bookworm

Succeeded to boot and /boot is empty as expected.

```
EMLinux 3.5 EMLinux3 /dev/ttyS0
EMLinux3 login: root
Password: 

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.


BusyBox v1.35.0 (Debian 1:1.35.0-4+deb12u1) built-in shell (ash)
Enter 'help' for a list of built-in commands.

# uname -a
Linux EMLinux3 6.1.167-cip53 #1 SMP PREEMPT_DYNAMIC Thu, 01 Jan 1970 01:00:00 +0000 x86_64 GNU/Linux
# ls -la /boot
total 8
drwxr-xr-x    2 root     root          4096 Mar  4  2024 .
drwxr-xr-x   18 root     root          4096 Mar  4  2024 ..
```