### PR TITLE
cve-check: Update loop condition

### DIFF
--- a/scripts/lib/python/cve/nvd_cve.py
+++ b/scripts/lib/python/cve/nvd_cve.py
@@ -209,6 +209,10 @@ def fetch_all_cves(db_file, conn, last_modified, api_key):
             for cve in data["vulnerabilities"]:
                update_db(conn, cve)
 
+            if per_page == 0:
+                # no more data
+                break
+
             index += per_page
             if index >= total:
                break

--- a/scripts/lib/python/cve/plugin/eml_cve_nvd_plugin.py
+++ b/scripts/lib/python/cve/plugin/eml_cve_nvd_plugin.py
@@ -466,6 +466,10 @@ class EmlNVDPlugin(EmlCvePlugin):
             for cve in data["vulnerabilities"]:
                 self._update_db(conn, cve)
 
+            if per_page == 0:
+                # no more data
+                break
+
             index += per_page
             if index >= total:
                 break


### PR DESCRIPTION
We used to check index value to break loop or not, but this check doesn't work recent API behavior change by NVD API. Thereby, it goes loop forever.

```
2026-05-25 01:53:13,390:DEBUG: CVE CVE-2026-25608 has no configurations
2026-05-25 01:53:15,390:DEBUG: Updating entries
2026-05-25 01:53:15,390:DEBUG: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2026-05-21T17%3A13%3A34.869206&lastModEndDate=2026-05-25T01%3A53%3A06.385307&startIndex=476
2026-05-25 01:53:28,326:DEBUG: Got 0 entries
2026-05-25 01:53:30,326:DEBUG: Updating entries
2026-05-25 01:53:30,326:DEBUG: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2026-05-21T17%3A13%3A34.869206&lastModEndDate=2026-05-25T01%3A53%3A06.385307&startIndex=476
2026-05-25 01:53:37,705:DEBUG: Got 0 entries
2026-05-25 01:53:39,705:DEBUG: Updating entries
2026-05-25 01:53:39,705:DEBUG: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2026-05-21T17%3A13%3A34.869206&lastModEndDate=2026-05-25T01%3A53%3A06.385307&startIndex=476
2026-05-25 01:53:40,745:DEBUG: Got 0 entries
2026-05-25 01:53:42,745:DEBUG: Updating entries
2026-05-25 01:53:42,746:DEBUG: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2026-05-21T17%3A13%3A34.869206&lastModEndDate=2026-05-25T01%3A53%3A06.385307&startIndex=476
2026-05-25 01:53:54,999:DEBUG: Got 0 entries
2026-05-25 01:53:56,999:DEBUG: Updating entries
2026-05-25 01:53:56,999:DEBUG: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2026-05-21T17%3A13%3A34.869206&lastModEndDate=2026-05-25T01%3A53%3A06.385307&startIndex=476
2026-05-25 01:54:08,073:DEBUG: Got 0 entries
```

This commit add to check resultsPerPage vaule. If this value is 0, there is no more data. so we can break the loop.
This logic should apply both nvd_cve.py for cve_check.py and eml_cve_nvd_plugin.py for cve_check_ng.py.

# Test

Before test, you need to build emlinux-image-base.

Run following commands. NOTICE: This command use pre-download feature.

for cve_check.py

```
cve_check.py \
--image emlinux-image-base \
--output-format text,json \
--nvd-api-key <your api key> \
--cve-db-predownload \
--verbose
```

for cve_check_ng.py

```
cve_check.py \
--image emlinux-image-base \
--output-format text,json \
--nvd-api-key <your api key> \
--cve-db-predownload \
--verbose
```

# Test result
Both cve check successfully break the loop when number of CVE is 0.

## cve_check.py

```
2026-05-25 02:08:27,700:DEBUG: CVE CVE-2026-9011 has no configurations
2026-05-25 02:08:27,700:DEBUG: Processing CVE CVE-2026-25606
2026-05-25 02:08:27,700:DEBUG: CVE CVE-2026-25606 has no configurations
2026-05-25 02:08:27,700:DEBUG: Processing CVE CVE-2026-25607
2026-05-25 02:08:27,700:DEBUG: CVE CVE-2026-25607 has no configurations
2026-05-25 02:08:27,700:DEBUG: Processing CVE CVE-2026-25608
2026-05-25 02:08:27,700:DEBUG: CVE CVE-2026-25608 has no configurations
2026-05-25 02:08:29,701:DEBUG: Updating entries
2026-05-25 02:08:29,701:DEBUG: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2026-05-21T17%3A13%3A34.869206&lastModEndDate=2026-05-25T02%3A08%3A12.482363&startIndex=476
2026-05-25 02:08:30,445:DEBUG: Got 0 entries
2026-05-25 02:08:30,445:INFO: Update last modified date
2026-05-25 02:08:30,452:INFO: Update debian CVE database
2026-05-25 02:08:30,452:INFO: Last database update is in 1day so skip Debian CVE database update
2026-05-25 02:08:30,452:INFO: Update KEV database
2026-05-25 02:08:30,452:INFO: Last database update is in 1day so skip Debian CVE database update
2026-05-25 02:08:30,452:INFO: Update cip-kernel-sec
2026-05-25 02:08:31,128:INFO: Checking CVEs ...
2026-05-25 02:09:27,295:INFO: CVE check finished. CVE check results are stored in /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64
```

## cve_check_ng.py

```
2026-05-25 02:06:53,893:DEBUG: CVE CVE-2026-25607 has no configurations
2026-05-25 02:06:53,893:DEBUG: Processing CVE CVE-2026-25608
2026-05-25 02:06:53,893:DEBUG: CVE CVE-2026-25608 has no configurations
2026-05-25 02:06:55,893:DEBUG: Updating entries
2026-05-25 02:06:55,894:DEBUG: Requesting https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2026-05-21T17%3A13%3A34.869206&lastModEndDate=2026-05-25T02%3A06%3A38.989127&startIndex=476
2026-05-25 02:06:57,907:DEBUG: Got 0 entries
2026-05-25 02:06:57,907:INFO: Update last modified date
2026-05-25 02:06:57,913:DEBUG: EmlNVDPlugin: run-check start
2026-05-25 02:07:19,358:DEBUG: EmlNVDPlugin: run-check finish
2026-05-25 02:07:19,564:INFO: Update KEV database
2026-05-25 02:07:19,564:INFO: Last database update is in 1day so skip Debian CVE database update
2026-05-25 02:07:19,893:INFO: Text report were written to /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64/cve_check_ng/text
2026-05-25 02:07:19,957:INFO: All in one text report was written to /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64/cve_check_ng/emlinux-image-base-emlinux-bookworm-qemu-amd64_cve
2026-05-25 02:07:20,162:INFO: Json report were written to /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64/cve_check_ng/json
2026-05-25 02:07:20,407:INFO: All in one json report was written to /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64/cve_check_ng/emlinux-image-base-emlinux-bookworm-qemu-amd64_cve.json
```

I also checked create database from scratch that succeeded as well.
