### PR TITLE
script: Allow CVE database update even though image is not build

### DIFF
--- a/scripts/cve_check_ng.py
+++ b/scripts/cve_check_ng.py
@@ -290,38 +290,45 @@ def main(args: dict):
         if not args.dpkg_status_file
         else args.dpkg_status_file
     )
-    if not os.path.exists(dpkg_status_file):
-        logger.error(f"File {dpkg_status_file} is not found")
-        exit(1)
 
     debian_codename = args.debian_codename
     if not debian_codename:
         debian_codename = bitbakeinfo["image_distro"].split("-")[1]
 
-    # Read dpkg file to get installed package information
-    installed_packages = PackageInfoHelper.parse_dpkg_status_file(
-        dpkg_status_file,
-        debian_codename,
-        target_source_package=args.target_source_package,
-    )
+    installed_packages = None
+    cve_product_list = None
 
-    # Check recipe's source code provenance
-    recipe_source_info = read_recipe_source_info(bitbakeinfo["deploy_image_dir"])
-    installed_packages.merge_recipe_source_info(recipe_source_info)
+    if args.update_cve_databese_only:
+        logger.info("Run on database update only mode.")
+    else:
+        if not os.path.exists(dpkg_status_file):
+            logger.error(f"File {dpkg_status_file} is not found.")
+            exit(1)
 
-    # Read cve product list
-    cve_product_list = CveProductList()
-    cve_product_list.create_product_list(
-        installed_packages, bitbakeinfo["emlinux_layer_dir"], args.extra_cve_product
-    )
+        # Read dpkg file to get installed package information
+        installed_packages = PackageInfoHelper.parse_dpkg_status_file(
+            dpkg_status_file,
+            debian_codename,
+            target_source_package=args.target_source_package,
+        )
 
-    # Read ignore list
-    ignore_list = create_ignore_list(
-        bitbakeinfo["emlinux_layer_dir"],
-        installed_packages,
-        debian_codename,
-        args.extra_cve_check_ignore,
-    )
+        # Check recipe's source code provenance
+        recipe_source_info = read_recipe_source_info(bitbakeinfo["deploy_image_dir"])
+        installed_packages.merge_recipe_source_info(recipe_source_info)
+
+        # Read cve product list
+        cve_product_list = CveProductList()
+        cve_product_list.create_product_list(
+            installed_packages, bitbakeinfo["emlinux_layer_dir"], args.extra_cve_product
+        )
+
+        # Read ignore list
+        ignore_list = create_ignore_list(
+            bitbakeinfo["emlinux_layer_dir"],
+            installed_packages,
+            debian_codename,
+            args.extra_cve_check_ignore,
+        )
 
     cve_data_dir = f"{bitbakeinfo['dl_dir']}/CVE"
     cl.create_directory(cve_data_dir)


### PR DESCRIPTION
This commit allow run CVE database update only mode even though image is not build.

# Test

## Test --update-cve-databese-only option works with out image
1. Confirm you don't build any image yet
2. Run cve_check_ng.py with --cve-db-predownload  and --update-cve-databese-only options


## Test cve check process regressions
1. Build emlinux-image-base
2. Remove build/downloads/CVE/nvd_cve_db_v2.db
3. Run cve_check_ng.py with --cve-db-predownload

# Test result

## Test --update-cve-databese-only option works with out image

We don't build any images yet.
```
build@c869bce503b2:~/work$ ls build/
conf
```

Download process was successfully finished.

```
build@c869bce503b2:~/work$ cve_check_ng.py \
--image emlinux-image-base \
--debian-codename bookworm \
--output-format text,json \
--nvd-api-key <you api key> \
--cve-db-predownload \
--update-cve-databese-only \
--verbose 
2026-06-11 01:51:08,828:INFO: |------------------------------|
2026-06-11 01:51:08,828:INFO: | This is experimental version |
2026-06-11 01:51:08,828:INFO: |------------------------------|
2026-06-11 01:51:18,571:INFO: Run on database update only mode.
2026-06-11 01:51:19,114:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_debian_plugin.py
2026-06-11 01:51:19,115:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_cip_kernel_plugin.py
2026-06-11 01:51:19,116:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_nvd_plugin.py
2026-06-11 01:51:19,117:DEBUG: run EmlDebianPlugin
2026-06-11 01:51:19,117:INFO: Update debian CVE database
2026-06-11 01:51:24,089:DEBUG: run EmlCIPKernelPlugin
2026-06-11 01:51:24,089:INFO: Update cip-kernel-sec CVE database
2026-06-11 01:51:24,089:INFO: clone/update cip-kernel-sec
2026-06-11 01:51:36,936:DEBUG: run EmlNVDPlugin
2026-06-11 01:51:36,937:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db_v2.db.tmp
2026-06-11 01:51:36,943:INFO: Predownload CVE database file.
2026-06-11 01:51:36,943:INFO: Download CVE database file from http://127.0.0.1:20080/nvd_cve_db_v2.db.
2026-06-11 01:51:37,466:INFO: Download CVE database file was succeeded.
2026-06-11 01:51:37,588:INFO: Last database update is in 1 day skip NVD database update
2026-06-11 01:51:37,588:INFO: Updating database finished.
```

## Test cve check process regressions

cve check process was successfully finished.

```
build@c869bce503b2:~/work$ rm build/downloads/CVE/nvd_cve_db_v2.db 
build@c869bce503b2:~/work$ cve_check_ng.py \
--image emlinux-image-base \
--debian-codename bookworm \
--output-format text,json \
--nvd-api-key 3790b688-cd75-4d6d-8714-bce59599d7d4 \
--cve-db-predownload \
--verbose 
2026-06-11 02:06:18,763:INFO: |------------------------------|
2026-06-11 02:06:18,763:INFO: | This is experimental version |
2026-06-11 02:06:18,763:INFO: |------------------------------|
2026-06-11 02:06:26,576:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_debian_plugin.py
2026-06-11 02:06:26,577:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_cip_kernel_plugin.py
2026-06-11 02:06:26,578:DEBUG: loading /home/build/work/build/../repos/meta-emlinux/scripts/lib/python/cve/plugin/eml_cve_nvd_plugin.py
2026-06-11 02:06:26,580:DEBUG: run EmlDebianPlugin
2026-06-11 02:06:26,580:INFO: Update debian CVE database
2026-06-11 02:06:26,580:INFO: Last database update is in 1day so skip Debian CVE database update
2026-06-11 02:06:26,580:DEBUG: EmlDebianPlugin: run-check start
2026-06-11 02:06:27,235:DEBUG: run EmlCIPKernelPlugin
2026-06-11 02:06:27,235:INFO: check update
2026-06-11 02:06:27,238:DEBUG: time diff: 0:14:51.238247
2026-06-11 02:06:27,238:INFO: cip-kernel-sec has been updated in 86400 second. skip update.
2026-06-11 02:06:27,238:DEBUG: EmlCIPKernelPlugin: run-check start
2026-06-11 02:06:27,238:DEBUG: Linux kernel package is linux-cip
2026-06-11 02:07:00,987:DEBUG: run EmlNVDPlugin
2026-06-11 02:07:00,987:DEBUG: Initialize nvd cve database /home/build/work/build/downloads/CVE/nvd_cve_db_v2.db.tmp
2026-06-11 02:07:00,992:INFO: Predownload CVE database file.
2026-06-11 02:07:00,992:INFO: Download CVE database file from http://127.0.0.1:20080/nvd_cve_db_v2.db.
2026-06-11 02:07:01,635:INFO: Download CVE database file was succeeded.
2026-06-11 02:07:01,789:INFO: Last database update is in 1 day skip NVD database update
2026-06-11 02:07:01,789:DEBUG: EmlNVDPlugin: run-check start
2026-06-11 02:07:21,585:DEBUG: EmlNVDPlugin: run-check finish
2026-06-11 02:07:21,792:INFO: Update KEV database
2026-06-11 02:07:21,792:INFO: Last database update is in 1day so skip Debian CVE database update
2026-06-11 02:07:22,133:INFO: Text report were written to /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64/cve_check_ng/text
2026-06-11 02:07:22,202:INFO: All in one text report was written to /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64/cve_check_ng/emlinux-image-base-emlinux-bookworm-qemu-amd64_cve
2026-06-11 02:07:22,416:INFO: Json report were written to /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64/cve_check_ng/json
2026-06-11 02:07:22,675:INFO: All in one json report was written to /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-amd64/cve_check_ng/emlinux-image-base-emlinux-bookworm-qemu-amd64_cve.json

```