### PR TITLE
conf/distro: Set a RT_FRAGMENT variable

### DIFF
--- a/conf/distro/emlinux-common.inc
+++ b/conf/distro/emlinux-common.inc
@@ -45,3 +45,4 @@ SDK_PREINSTALL += " \
 
 SDK_INSTALL += "${@ "linux-headers-"+d.getVar('KERNEL_NAME') if d.getVar('KERNEL_NAME') else '' }"
 
+RT_FRAGMENT = "preempt-rt.cfg"


### PR DESCRIPTION
Setting a RT_FRAGMENT variable when the RT kernel feature is enabled has been mandatory since the following isar-cip-core commit was added.

https://gitlab.com/cip-project/cip-core/isar-cip-core/-/commit/0ef583915456e356671811c01fa57596015b71b0
