### PR TITLE
Improve or expression handling

### DIFF
--- a/conf/licenses/licenses.yml
+++ b/conf/licenses/licenses.yml
@@ -205,6 +205,12 @@ initramfs-tools-core:
   licenses: [
     GPL-2
   ]
+libisl23:
+  licenses: [
+    BSD-2-clause,
+    LGPL-2.1-or-later,
+    MIT,
+  ]
 klibc-utils:
   licenses: [
     GPL-2
@@ -928,6 +934,11 @@ locales:
 lrzsz:
   licenses: [
     GPL-2
+  ]
+ruby-narray:
+  licenses: [
+    GPL-2.0-or-later,
+    Ruby OR GPL-2.0-only,
   ]
 shared-mime-info:
   licenses: [

--- a/scripts/lib/python/sbom/licensing.py
+++ b/scripts/lib/python/sbom/licensing.py
@@ -52,6 +52,15 @@ def split_licesense_and_normalize(lic, license_mapping):
     elif " and-or " in lic:
         tmp = normalize_licenses(split_licenses(lic, " and-or "), license_mapping)
         lics.append("-and-or-".join(tmp))
+    elif " OR " in lic:
+        tmp = normalize_licenses(split_licenses(lic, " OR "), license_mapping)
+        l = f"({' OR '.join(tmp)})"
+        lics.append(l)
+    elif " or " in lic:
+        tmp = normalize_licenses(split_licenses(lic, " or "), license_mapping)
+        l = f"({' OR '.join(tmp)})"
+        lics.append(l)
+
     else:
         lics += normalize_licenses([lic], license_mapping)
 
@@ -68,12 +77,6 @@ def split_licenses_simple(licenses):
         elif " and " in lic:
             ret += lic.split(" and ")
             splited = True
-        elif " or " in lic:
-            ret += lic.split(" or ")
-            splited = True
-        elif " OR " in lic:
-            ret += lic.split(" OR ")
-            splited = True
         else:
             ret.append(lic)
 
@@ -82,7 +85,7 @@ def split_licenses_simple(licenses):
     
     return ret
 
-def normalize_for_spdx(licenses, license_mapping):
+def normalize_for_sbom(licenses, license_mapping):
     tmp = []
     normalized = []
 
@@ -91,13 +94,9 @@ def normalize_for_spdx(licenses, license_mapping):
         tmp += split_licesense_and_normalize(lic, license_mapping)
 
     for lic in tmp:
-        if " " in lic:
+        if not lic.startswith("(") and " " in lic:
             normalized.append(lic.replace(" ", "-"))
         else:
             normalized.append(lic)
 
     return list(set(normalized))
-
-def normalize_for_cyclonedx(licenses):
-    return split_licenses_simple(licenses)
-

--- a/scripts/lib/python/sbom/sbom_cyclonedx.py
+++ b/scripts/lib/python/sbom/sbom_cyclonedx.py
@@ -43,12 +43,15 @@ def debian_section_to_component_type(section):
     return ComponentType.APPLICATION 
 
 def make_license_info(factory, licenses, license_mapping):
-    ret = []
+    ret = None
 
-    uniq_licenses = licensing.normalize_for_cyclonedx(licenses)
+    uniq_licenses = licensing.normalize_for_sbom(licenses, license_mapping)
     for lic in uniq_licenses:
         tmp = factory["lc_factory"].make_with_name(lic)
-        ret.append(tmp)
+        if ret is None:
+            ret = tmp.name
+        else:
+            ret = f"{ret} AND {tmp.name}"
 
     return ret
 
@@ -78,12 +81,13 @@ def create_component(factory, distro, pkg, license_mapping):
     purl_info = create_package_url(distro, pkg)
     pkgname_hash = sbom_common.package_name_hash(pkg['package'], pkg['source'])
 
+    licenses_string = make_license_info(factory, pkg["licenses"], license_mapping)
     return Component(
         type = debian_section_to_component_type(pkg["section"]),
         name = pkg["package"],
         group = pkg["source"],
         version = pkg["version"],
-        licenses = make_license_info(factory, pkg["licenses"], license_mapping),
+        licenses = [LicenseExpression(value=licenses_string)],
         supplier = create_organization_entity(pkg),
         bom_ref = BomRef(f"{pkg['package']}@{pkg['version']}-{pkgname_hash}"),
         purl = purl_info,

--- a/scripts/lib/python/sbom/sbom_spdx.py
+++ b/scripts/lib/python/sbom/sbom_spdx.py
@@ -83,7 +83,7 @@ def create_license_string(pkg, license_mapping):
     licenses = []
     s = ""
 
-    licenses_tmp = licensing.normalize_for_spdx(create_uniq_list(pkg["licenses"]), license_mapping)
+    licenses_tmp = licensing.normalize_for_sbom(create_uniq_list(pkg["licenses"]), license_mapping)
 
     try:
         for lic in licenses_tmp:


### PR DESCRIPTION
# Purpose

This PR add licenses adn improve handling OR expression.

## commit: "sbom: Improve OR expression handling"

This commit improve OR expression handling.
It allowed to define license such as "LICENSE_A OR LICENSE_B" in licenses.yml.
Some package, for example, ruby-narray package contains dual license. 
In this case we need to define license as "Ruby OR GPL-2.0-only" but current code doesn't handle OR expression. 

To do this, CycloneDX format is bit changed.
Before this commit, licenses are defined as an array of license then we use expression tag (https://cyclonedx.org/docs/1.7/json/#metadata_tools_oneOf_i0_components_items_licenses_items_oneOf_i1)
    
Before:
    
 ```
                "licenses": [
                    {
                        "license": {
                            "name": "BSD-3-clause"
                        }
                    },
                    {
                        "license": {
                            "name": "Expat"
                        }
                    },
    
 ```
    
After:
    
```
                "licenses": [
                    {
                        "expression": "(Ruby OR GPL-2.0-only) AND GPL-2.0-or-later"
                    }
                ],
```
    
    This expression string is same as SPDX format.


## commit: "conf/licenses: Add licenses"

Added licenses for ruby-narray and libisl23 packages.

# Test

Add following lines in conf/local.conf.

```
IMAGE_PREINSTALL:append = " ruby-narray"
IMAGE_PREINSTALL:append = " libisl23"
```

Then build emlinux-image-base.

Finally, create sboms.

for spdx.

```
create_sbom.py \
    --image emlinux-image-base \
    --supplier "test" \
    --product EMLinux3 \
    --sbom-format spdx
```

for cyclonedx.

```
create_sbom.py \
    --image emlinux-image-base \
    --supplier "test" \
    --product EMLinux3 \
    --sbom-format spdx
```

# Test result

for spdx

```
>>> snip <<<
            "licenseConcluded": "GPL-2.0-or-later AND (Ruby OR GPL-2.0-only)",
            "licenseDeclared": "GPL-2.0-or-later AND (Ruby OR GPL-2.0-only)",
            "name": "ruby-narray",
            "primaryPackagePurpose": "APPLICATION",
>>> snip <<<
            "licenseConcluded": "LGPL-2.1-or-later AND MIT AND BSD-2-Clause",
            "licenseDeclared": "LGPL-2.1-or-later AND MIT AND BSD-2-Clause",
            "name": "libisl23",
```

for cyclonedx

```
>>> snip <<<
            "licenses": [
                {
                    "expression": "(Ruby OR GPL-2.0-only) AND GPL-2.0-or-later"
                }
            ],
            "name": "ruby-narray",
>>> snip <<<
            "licenses": [
                {
                    "expression": "BSD-2-clause AND MIT AND LGPL-2.1-or-later"
                }
            ],
            "name": "libisl23",
```