### PR TITLE
scripts/setup-emlinux: Remove DEBIAN_ELTS_SECURITY_UPDATE_MIRROR variable

### DIFF
--- a/scripts/setup-emlinux
+++ b/scripts/setup-emlinux
@@ -79,8 +79,6 @@ if [ -z "$TEMPLATECONF" ] && [ "${EML_BUILDDIR_SETUP_DONE}" = "false" ]; then
     echo "DEBIAN_MIRROR=\"http://archive.debian.org/debian/pool\"" >> conf/local.conf
     # Add debian security updates repository
     echo "DEBIAN_SECURITY_UPDATE_MIRROR=\"http://archive.debian.org/debian-security/pool/updates\"" >> conf/local.conf
-    # Add ELTS updates repository
-    echo "DEBIAN_ELTS_SECURITY_UPDATE_MIRROR=\"http://deb.freexian.com/extended-lts/pool\"" >> conf/local.conf
 
     if [ -d "${EML_HOOKS}" ]; then
 	for hook in $(\ls ${EML_HOOKS}); do


### PR DESCRIPTION
# purpose

We define this repository URL in other layer.

# test

Define DEBIAN_ELTS_SECURITY_UPDATE_MIRROR variable in other layer.
Then, add following lines in conf/local.conf

```
MACHINE = "qemuarm64"
INHERIT += "cve-check debian-cve-check kernel-cve-check"
CVE_DB_PREDOWNLOAD="1"
```

Finally, build core-image-weton

# test result

Building core-image-weston was succeeded.

```
Image CVE report stored in: /home/build/work/build/tmp-glibc/deploy/images/qemuarm64/core-image-weston-qemuarm64-20260612053456.rootfs.cve
NOTE: Tasks Summary: Attempted 5707 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 113 WARNING messages shown.
build@807ad0b990ee:~/work/build$ 
```

Image files were created as usual.

```
build@807ad0b990ee:~/work/build$ ls tmp-glibc/deploy/images/qemuarm64/
core-image-weston-qemuarm64-20260612053456.qemuboot.conf    core-image-weston-qemuarm64.cve            Image
core-image-weston-qemuarm64-20260612053456.rootfs.cve       core-image-weston-qemuarm64.ext4           Image--4.19-r0-qemuarm64-20260612053456.bin
core-image-weston-qemuarm64-20260612053456.rootfs.ext4      core-image-weston-qemuarm64.manifest       Image-qemuarm64.bin
core-image-weston-qemuarm64-20260612053456.rootfs.manifest  core-image-weston-qemuarm64.qemuboot.conf  modules--4.19-r0-qemuarm64-20260612053456.tgz
core-image-weston-qemuarm64-20260612053456.rootfs.tar.bz2   core-image-weston-qemuarm64.tar.bz2        modules-qemuarm64.tgz
core-image-weston-qemuarm64-20260612053456.testdata.json    core-image-weston-qemuarm64.testdata.json
```

cve-check results were stored in the cve directory.

```
build@807ad0b990ee:~/work/build$ ls  tmp-glibc/deploy/cve/
acl                     dbus               gcc-source-8.3.0   libice                libxfixes                  nettle                     socat
acpica-native           dbus-glib          gdk-pixbuf         libice-native         libxfixes-native           ninja-native               sqlite3
alsa-lib                dbus-glib-native   gdk-pixbuf-native  libidn2               libxfont2                  nspr-native                sqlite3-native
alsa-lib-native         dbus-native        gettext-native     libinput              libxi                      nss-native                 syslinux-native
apt                     dbus-test          glib-2.0           libjpeg-turbo         libxi-native               ofono                      systemd
apt-native              dpkg               glib-2.0-native    libjpeg-turbo-native  libxkbcommon               openssl                    systemd-conf
at-spi2-atk             dpkg-native        glibc              libnl                 libxml2                    openssl-native             sysvinit
at-spi2-atk-native      dropbear           gmp                libpcre               libxml2-native             pango                      tar
avahi                   e2fsprogs          gmp-native         libpcre2              libxml-parser-perl-native  pango-native               tcl
base-files              e2fsprogs-native   gnutls             libpcre-native        libxrandr                  patchelf-native            tcl-native
base-passwd             ed-native          grep               libpng                libxrandr-native           perl                       tcp-wrappers
bash                    elfutils           groff-native       libpng-native         libxrender                 perl-native                unzip
bash-completion         elfutils-native    gtk+3              librsvg-native        libxrender-native          pigz-native                util-linux
binutils                expat              gtk+3-native       libsamplerate0        libxslt-native             pixman                     util-linux-native
binutils-cross-aarch64  expat-native       harfbuzz           libsdl2-native        libxt                      pixman-native              vte
binutils-native         expect             harfbuzz-native    libsndfile1           libxtst                    procps                     wayland
bison                   expect-native      icu                libtirpc              libxtst-native             python3                    wayland-native
bison-native            file-native        icu-native         libtirpc-native       libxxf86vm                 python3-mako-native        wpa-supplicant
bluez5                  findutils          initscripts        libtool               linux-base                 python3-native             xkbcomp
busybox                 flac               iproute2           libtool-cross         lz4                        python3-setuptools-native  xkeyboard-config
bzip2                   flex               iptables           libtool-native        lzo                        qemu-native                xrandr
bzip2-native            flex-native        ipxe-native        libvorbis             lzo-native                 qemu-system-native         xserver-xorg
cairo                   fontconfig         kbd                libx11                m4                         quota                      xtrans
cairo-native            fontconfig-native  libarchive-native  libx11-native         m4-native                  re2c-native                xtrans-native
cdrtools-native         freetype           libcap             libxcb                mdadm                      readline                   xz
cmake-native            freetype-native    libcroco-native    libxcb-native         mesa                       readline-native            xz-native
coreutils               fribidi            libffi             libxcursor            mpfr                       rgb                        zip
cross-localedef-native  fribidi-native     libffi-native      libxcursor-native     mpfr-native                rpcbind                    zlib
curl                    gawk               libgcc             libxdmcp              mtools-native              rpm-native                 zlib-native
curl-native             gcc                libgcc-initial     libxdmcp-native       nasm-native                sed
db                      gcc-cross-aarch64  libgcrypt          libxext               ncurses                    shadow
db-native               gcc-runtime        libical            libxext-native        ncurses-native             shadow-native
```
