### PR TITLE
images: Disable ISAR SBOM creation

### DIFF
--- a/recipes-core/images/emlinux-image-common.inc
+++ b/recipes-core/images/emlinux-image-common.inc
@@ -3,4 +3,5 @@
 #
 # SPDX-License-Identifier: MIT
 #
+ROOTFS_FEATURES:remove = "generate-sbom"
 require emlinux-image-prepare-sshd.inc


### PR DESCRIPTION
Remove generate-sbom from ROOTFS_FEATURES to prevent SBOM files in the image directory being generated