### PR TITLE
image-compact: require emlinux-image-common.inc instead of emlinux-image-prepare-sshd.inc

### DIFF
--- a/recipes-core/images/emlinux-image-compact.bb
+++ b/recipes-core/images/emlinux-image-compact.bb
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: MIT
 #
-require emlinux-image-prepare-sshd.inc
+require emlinux-image-common.inc
 
 FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/files/compact:"
 


### PR DESCRIPTION
Changes in emlinux-image-common.inc are currently not reflected in the compact image. Under the premise of only containing settings that are common between all images, this should be also used by the compact image.