### PR TITLE
Update kernel to v4.19.325-cip134

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "a0cf0e1623b28b1d20f9626f32809952b7a40f15"
+LINUX_GIT_SRCREV ?= "774e9597d38ad0d067a1d50e502503224b74f9f5"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip132"
+LINUX_CIP_VERSION ??= "v4.19.325-cip134"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip134

This pull request update the kernel to the following cip versions:
v4.19.325-cip134 with hash tag 774e9597d38ad0d067a1d50e502503224b74f9f5
