### PR TITLE
Enable to select trixie distribution for docker image

### DIFF
--- a/docker/Dockerfile.trixie
+++ b/docker/Dockerfile.trixie
@@ -1,0 +1,82 @@
+FROM debian:trixie
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NOWARNINGS yes
+
+ARG uid
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+
+RUN apt-get update --fix-missing && apt-get -y upgrade --fix-missing
+
+RUN apt-get install --fix-missing -y \
+  binfmt-support \
+  bubblewrap \
+  debootstrap \
+  dosfstools \
+  dpkg-dev \
+  gettext-base \
+  git \
+  mtools \
+  parted \
+  python3 \
+  quilt \
+  qemu-system-x86 \
+  qemu-system-arm \
+  qemu-user-static \
+  seabios \
+  reprepro \
+  sudo \
+  git-buildpackage \
+  pristine-tar \
+  sbuild \
+  schroot \
+  zstd \
+  python3-setuptools \
+  python3-yaml \
+  python3-html5lib \
+  python3-pip \
+  vim \
+  screen \
+  socat \
+  patchelf \
+  sqlite3 \
+  umoci \
+  skopeo \
+  mmdebstrap \
+  locales
+
+RUN useradd -s /bin/bash -m build -u $uid
+RUN gpasswd -a build sbuild
+RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers
+RUN echo  "Defaults env_keep += \" http_proxy https_proxy no_proxy\"" | tee -a /etc/sudoers
+
+# Fix error "Please use a locale setting which supports utf-8."
+# See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+        echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+        dpkg-reconfigure --frontend=noninteractive locales 2>/dev/null && \
+        update-locale LANG=en_US.UTF-8
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+ADD gitproxy /usr/bin
+RUN chmod +x /usr/bin/gitproxy
+
+USER build
+WORKDIR /home/build
+
+RUN bash -c 'if test -n "$http_proxy"; then git config --global http.proxy "$http_proxy"; \
+                                            git config --global core.gitproxy "/usr/bin/gitproxy"; fi'
+RUN bash -c 'if test -n "$https_proxy"; then git config --global https.proxy "$https_proxy"; fi'
+RUN bash -c 'if test -n "$no_proxy"; then git config --global core.noproxy "$no_proxy"; fi'
+
+RUN pip install --user 'cyclonedx-python-lib>=7.3.2,<=7.5.1' --break-system-packages --no-warn-script-location
+RUN pip install --user jsonschema==4.21.1 --break-system-packages --no-warn-script-location
+RUN pip install --user spdx-tools==0.8.2 --break-system-packages --no-warn-script-location
+RUN pip install --user looseversion==1.3.0 --break-system-packages --no-warn-script-location
+
+RUN mkdir work
+WORKDIR /home/build/work

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,3 +28,29 @@ services:
     user: build
     command: /bin/sh -c "sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc && /bin/bash"
 
+  emlinux3-build-trixie:
+    image: "emlinux3-build-trixie-${host_user_name}"
+    build:
+      context: .
+      dockerfile: Dockerfile.trixie
+      args:
+        uid: $host_user_id
+        http_proxy: $http_proxy
+        https_proxy: $https_proxy
+        ftp_proxy: $ftp_proxy
+        no_proxy: $no_proxy
+    environment:
+      - http_proxy=$http_proxy
+      - https_proxy=$https_proxy
+      - ftp_proxy=$ftp_proxy
+      - no_proxy=$no_proxy
+    volumes:
+      - /dev/shm:/dev/shm:rw
+      - ../../../:/home/build/work:rw
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    privileged: true
+    cap_add:
+      - NET_ADMIN
+    user: build
+    command: /bin/sh -c "sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc && /bin/bash"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,56 +1,42 @@
 version: '3.8'
 
+x-build-args: &build-args
+  context: .
+  args:
+    uid: $host_user_id
+    http_proxy: $http_proxy
+    https_proxy: $https_proxy
+    ftp_proxy: $ftp_proxy
+    no_proxy: $no_proxy
+
+x-base-config: &base-config
+  environment:
+    - http_proxy=$http_proxy
+    - https_proxy=$https_proxy
+    - ftp_proxy=$ftp_proxy
+    - no_proxy=$no_proxy
+  volumes:
+    - /dev/shm:/dev/shm:rw
+    - ../../../:/home/build/work:rw
+  devices:
+    - /dev/net/tun:/dev/net/tun
+  privileged: true
+  cap_add:
+    - NET_ADMIN
+  user: build
+  command: /bin/sh -c "sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc && /bin/bash"
+
 services:
   emlinux3-build:
+    <<: *base-config
     image: "emlinux3-build-${host_user_name}"
     build:
-      context: .
+      <<: *build-args
       dockerfile: Dockerfile
-      args:
-        uid: $host_user_id
-        http_proxy: $http_proxy
-        https_proxy: $https_proxy
-        ftp_proxy: $ftp_proxy
-        no_proxy: $no_proxy
-    environment:
-      - http_proxy=$http_proxy
-      - https_proxy=$https_proxy
-      - ftp_proxy=$ftp_proxy
-      - no_proxy=$no_proxy
-    volumes:
-      - /dev/shm:/dev/shm:rw
-      - ../../../:/home/build/work:rw
-    devices:
-      - /dev/net/tun:/dev/net/tun
-    privileged: true
-    cap_add:
-      - NET_ADMIN
-    user: build
-    command: /bin/sh -c "sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc && /bin/bash"
 
   emlinux3-build-trixie:
+    <<: *base-config
     image: "emlinux3-build-trixie-${host_user_name}"
     build:
-      context: .
+      <<: *build-args
       dockerfile: Dockerfile.trixie
-      args:
-        uid: $host_user_id
-        http_proxy: $http_proxy
-        https_proxy: $https_proxy
-        ftp_proxy: $ftp_proxy
-        no_proxy: $no_proxy
-    environment:
-      - http_proxy=$http_proxy
-      - https_proxy=$https_proxy
-      - ftp_proxy=$ftp_proxy
-      - no_proxy=$no_proxy
-    volumes:
-      - /dev/shm:/dev/shm:rw
-      - ../../../:/home/build/work:rw
-    devices:
-      - /dev/net/tun:/dev/net/tun
-    privileged: true
-    cap_add:
-      - NET_ADMIN
-    user: build
-    command: /bin/sh -c "sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc && /bin/bash"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -14,9 +14,24 @@ if [ $? != 0 ]; then
 fi
 
 mode="run"
-if [ $# = 1 ]; then
-    mode="${1}"
-fi
+while [ $# -gt 0 ]; do
+  case "$1" in
+    run|build|clean)
+	mode="$1"
+	;;
+    "-t")
+	distro="-trixie"
+	;;
+    "-h")
+	echo "Usage: $0 [-t] [run|build|clean]"
+	echo "       -t:    Use trixie distribution (Default is bookworm)"
+	echo "       run:   Run new docker container"
+	echo "       build: Build docker image"
+	echo "       clean: Remove docker image"
+	exit
+  esac
+  shift
+done
 
 host_user_id=$(id -u)
 host_user_name=$(id -un)
@@ -25,9 +40,9 @@ export host_user_name="${host_user_name}"
 
 cd ${script_dir}
 if [ "${mode}" = "build" ]; then
-    ${docker_compose_cmd} build --no-cache emlinux3-build
+    ${docker_compose_cmd} build --no-cache emlinux3-build"${distro}"
 elif [ "${mode}" = "run" ]; then
-    ${docker_compose_cmd} run --rm emlinux3-build
+    ${docker_compose_cmd} run --rm emlinux3-build"${distro}"
 elif [ "${mode}" = "clean" ]; then
-    docker rmi -f "emlinux3-build-${host_user_name}"
+    docker rmi -f "emlinux3-build${distro}-${host_user_name}"
 fi


### PR DESCRIPTION
# Purpose
Modified run.sh to enable to select trixie distribution for docker image.

# Test
Comfirmed the following:
- No regression for existing functions
- Trixie distribution can be selected for docker image

# Test results
1. No regression for existing functions
```
$ ./run.sh
Image emlinux3-build-test Pulling
...(snip)...
Container docker-emlinux3-build-run-ddc87cde01f6 Created
build@cf8cb309cf77:~/work$ cat /etc/debian_version
12.14
build@cf8cb309cf77:~/work$ exit
$ ./run.sh run
build@48d4ce01d850:~/work$ cat /etc/debian_version
12.14
build@48d4ce01d850:~/work$ exit
$ ./run.sh build
[+] Building 142.7s (27/27) FINISHED
...(snip)...
 ✔ Image emlinux3-build-test Built
$ ./run.sh clean
Untagged: emlinux3-build-test:latest
Deleted: sha256:8bf616a082834ec2f875b18344ee8fd2f1f0d730ff8ce6d0f50a485ee52323ba
```

2. Trixie distribution can be selected for docker image
```
$ ./run.sh -t
Image emlinux3-build-trixie-test Pulling
...(snip)...
Container docker-emlinux3-build-trixie-run-0179d1fd1ab5 Created
build@0cd4b2cb7f37:~/work$ cat /etc/debian_version
13.5
build@0cd4b2cb7f37:~/work$ exit
$ ./run.sh -t run
build@3efaf6770dd3:~/work$ cat /etc/debian_version
13.5
build@3efaf6770dd3:~/work$ exit
$ ./run.sh -t build
[+] Building 151.8s (27/27) FINISHED
...(snip)...
 ✔ Image emlinux3-build-trixie-test Built
$ ./run.sh -t clean
Untagged: emlinux3-build-trixie-test:latest
Deleted: sha256:0ea8fb8281ceed02757bbc174e42d1363976b1027a606de5b327ad8d12df44ec
```