### PR TITLE
docker: Modify docker image selection option

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -19,16 +19,16 @@ while [ $# -gt 0 ]; do
     run|build|clean)
 	mode="$1"
 	;;
-    "-t")
-	distro="-trixie"
+    "--trixie")
+	distro="trixie"
 	;;
     "-h")
-	echo "Usage: $0 [-t] [run|build|clean]"
-	echo "       -t:    Use trixie distribution (Default is bookworm)"
-	echo "       run:   Run new docker container"
-	echo "       build: Build docker image"
-	echo "       clean: Remove docker image"
-	exit
+	echo "Usage: $0 [--trixie] [run|build|clean]"
+	echo "       --trixie: Use trixie distribution (Default is bookworm)"
+	echo "       run:      Run new docker container"
+	echo "       build:    Build docker image"
+	echo "       clean:    Remove docker image"
+	exit 1
   esac
   shift
 done
@@ -38,11 +38,17 @@ host_user_name=$(id -un)
 export host_user_id="${host_user_id}"
 export host_user_name="${host_user_name}"
 
+if [ -z "$distro" ]; then
+    dockerimage="emlinux3-build"
+else
+    dockerimage="emlinux3-build-${distro}"
+fi
+
 cd ${script_dir}
 if [ "${mode}" = "build" ]; then
-    ${docker_compose_cmd} build --no-cache emlinux3-build"${distro}"
+    ${docker_compose_cmd} build --no-cache "${dockerimage}"
 elif [ "${mode}" = "run" ]; then
-    ${docker_compose_cmd} run --rm emlinux3-build"${distro}"
+    ${docker_compose_cmd} run --rm "${dockerimage}"
 elif [ "${mode}" = "clean" ]; then
-    docker rmi -f "emlinux3-build${distro}-${host_user_name}"
+    docker rmi -f "${dockerimage}-${host_user_name}"
 fi


### PR DESCRIPTION
# Purpose
Modified trixie distribution selection option of run.sh from "-t" to "--trixie".

# Test
Comfirmed the following:
- No regression for existing functions
- Trixie distribution can be selected for docker image

## Test results
1. No regression for existing functions
```
$ ./run.sh
Image emlinux3-build-test Pulling 
...(snip)...
Container docker-emlinux3-build-run-65b778d98b9d Created 
build@9bfbfe137db7:~/work$ cat /etc/debian_version 
12.15
build@9bfbfe137db7:~/work$ exit
$ ./run.sh run
build@b85e3d7f4a7c:~/work$ cat /etc/debian_version
12.15
build@b85e3d7f4a7c:~/work$ exit
$ ./run.sh build
[+] Building 130.4s (27/27) FINISHED
...(snip)...
 ✔ Image emlinux3-build-test Built
$ ./run.sh clean
Untagged: emlinux3-build-test:latest
Deleted: sha256:266fa22a0bc156ecf45c7dcff05edb64926bd58973262b6ced03c26a1ee8d938
```

2. Trixie distribution can be selected for docker image
```
$ ./run.sh --trixie
Image emlinux3-build-trixie-test Pulling
...(snip)...
Container docker-emlinux3-build-trixie-run-90853840bd92 Created
build@46894bea8d42:~/work$ cat /etc/debian_version
13.6
build@46894bea8d42:~/work$ exit
$ ./run.sh --trixie run
build@5e31fce83b3f:~/work$ cat /etc/debian_version
13.6
build@5e31fce83b3f:~/work$ exit
$ ./run.sh --trixie build
[+] Building 152.4s (27/27) FINISHED
...(snip)...
 ✔ Image emlinux3-build-trixie-test Built
$ ./run.sh --trixie clean
Untagged: emlinux3-build-trixie-test:latest
Deleted: sha256:a836ea1c7a2ea4afc75d474ac6476d65132ad2de1c29d006fb9804211d62149f
```