### PR TITLE
cve-check: Fixed inconsistent kernel version names.

### DIFF
--- a/scripts/cve_check.py
+++ b/scripts/cve_check.py
@@ -518,7 +518,8 @@ def check_kernel_cves_by_cip_kernel_sec(uniq_installed_pkgs, cves, kernel_src_di
 
     kernel_cves = cves[kernel_name]
     pkgname = uniq_installed_pkgs[kernel_name]["package"]
-    kver = str(uniq_installed_pkgs[kernel_name]["version"]).split("+")[0]
+    pkg_full_version = str(uniq_installed_pkgs[kernel_name]["version"])
+    kver = pkg_full_version.split("+")[0]
 
     cip_kernel_sec_result = kernel_cve.run_cip_kernel_sec(kernel_src_dir, kver, cip_kernel_sec_dir)
 
@@ -526,7 +527,7 @@ def check_kernel_cves_by_cip_kernel_sec(uniq_installed_pkgs, cves, kernel_src_di
         cip_kernel_sec_cves = cip_kernel_sec_result[patched_status]
         for cve in cip_kernel_sec_cves:
             if not cve in kernel_cves:
-                cveinfo = recheck_kernel_cve(db_file, pkgname, kernel_name, kver, cve)
+                cveinfo = recheck_kernel_cve(db_file, pkgname, kernel_name, pkg_full_version, cve)
                 kernel_cves[cve] = cveinfo
 
             # Replace cve status by cip-kernel-sec result


### PR DESCRIPTION
In the check_kernel_cves_by_cip_kernel_sec, it removed PR value(e.g. +r0) from package version, then check kernel cves by cip-kernel-sec. If cve is only in cip-kernel-sec result, we add that data. However, in that case, current code uses kver instead of uniq_installed_pkgs[kernel_name]["version"]. Therefore, CVE report contains two kernel version the one have PR value and the other doesn't.

```
    kver = str(uniq_installed_pkgs[kernel_name]["version"]).split("+")[0] # Remove PR value here

    cip_kernel_sec_result = kernel_cve.run_cip_kernel_sec(kernel_src_dir, kver, cip_kernel_sec_dir)

    for patched_status in cip_kernel_sec_result:
        cip_kernel_sec_cves = cip_kernel_sec_result[patched_status]
        for cve in cip_kernel_sec_cves:
            if not cve in kernel_cves:
                cveinfo = recheck_kernel_cve(db_file, pkgname, kernel_name, kver, cve) # Add CVE data using kver which doesn't have PR value
                kernel_cves[cve] = cveinfo
```

To fix this problem, we should use versoin with PR value.

Current cve_check.py contains 2 versions.
```
$ grep "VERSION: "  /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-trixie-qemu-arm64/text/linux-cip  | sort | uniq
VERSION: 6.12.92-cip25
VERSION: 6.12.92-cip25+r0
```

This commit only show 1 version.

```
$ grep "VERSION: "  /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-trixie-qemu-arm64/text/linux-cip  | sort | uniq
VERSION: 6.12.92-cip25+r0
```

cve_check_ng.py doesn't have this issue.

```
$ grep "VERSION: "  /home/build/work/build/tmp/deploy/cve/emlinux-image-base-emlinux-trixie-qemu-arm64/cve_check_ng/text/linux-cip  | sort | uniq
VERSION: 6.12.92-cip25+r0
```