### PR TITLE
Update kernel to v5.10.260-cip75

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "b56d51797ae30c19ebf7a70a94d700bc9af2b549"
-LINUX_CVE_VERSION ??= "5.10.258"
-LINUX_CIP_VERSION ?= "v5.10.258-cip74"
+LINUX_GIT_SRCREV ?= "b73e77b0c18cc1f30ddf28f058396899224a50a9"
+LINUX_CVE_VERSION ??= "5.10.260"
+LINUX_CIP_VERSION ?= "v5.10.260-cip75"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.260-cip75

This pull request update the kernel to the following cip versions:
v5.10.260-cip75 with hash tag b73e77b0c18cc1f30ddf28f058396899224a50a9
