### PR TITLE
docker/docker-compose.yml: Use host's .netrc for BASIC auth

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,4 +23,10 @@ services:
     cap_add:
       - NET_ADMIN
     user: build
+    configs:
+      - source: host_netrc
+        target: /home/build/.netrc
 
+configs:
+    host_netrc:
+      content: "${HOST_NETRC:-}"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -27,7 +27,7 @@ cd ${script_dir}
 if [ "${mode}" = "build" ]; then
   ${docker_compose_cmd} build --no-cache emlinux2-build
 elif [ "${mode}" = "run" ]; then
-  ${docker_compose_cmd} run --rm emlinux2-build
+  HOST_NETRC=$( [ -f ~/.netrc ] && cat ~/.netrc || echo ' ') ${docker_compose_cmd} run --rm emlinux2-build
 elif [ "${mode}" = "clean" ]; then
   docker rmi -f "emlinux2-build-${host_user_name}"
 fi


### PR DESCRIPTION
Use existing host's .netrc to support BASIC auth.

I confirmed that:
- If host's ~/.netrc exists, ~/.netrc with same contents is created in the container
- If host's ~/.netrc is empty or contains special characters, ~/.netrc with same contents is created in the container
- If host's ~/.netrc does not exist, ~/.netrc contains a single space is created on the container
