### PR TITLE
Update kernel to v4.19.325-cip135

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "774e9597d38ad0d067a1d50e502503224b74f9f5"
+LINUX_GIT_SRCREV ?= "ba1643922563de1987b5cb0ed4a4b869ae1c3147"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip134"
+LINUX_CIP_VERSION ??= "v4.19.325-cip135"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip135

This pull request update the kernel to the following cip versions:
v4.19.325-cip135 with hash tag ba1643922563de1987b5cb0ed4a4b869ae1c3147
