### PR TITLE
classes/emlinux-compact: Fix task dependencies

### DIFF
--- a/classes/emlinux-compact.bbclass
+++ b/classes/emlinux-compact.bbclass
@@ -164,5 +164,5 @@ python do_make_emlinux_compact_rootfs() {
     bb.build.exec_func("replace_packages", d)
 }
 
-addtask make_emlinux_compact_rootfs before do_rootfs_finalize after do_generate_initramfs
+addtask make_emlinux_compact_rootfs before do_rootfs_finalize after do_rootfs_postprocess
 


### PR DESCRIPTION
# Purpose of pull request

Fix `emlinux-image-campact` build failures

Upstream ISAR commit ea319eb8 ("fix(rootfs): generate in-tree initrd as part of image install") moved do_generate_initramfs() from image.class to initramfs.bbclass.

This change broke the existing task dependencies for make_emlinux_compact_rootfs(), causing it to execute prematurely and resulting in build failures. Update the dependencies to ensure make_emlinux_compact_rootfs() runs in the correct order.

# Steps to Test

1. Add the following setting to `local.conf`:

```
MACHINE = "qemu-arm64"
```

2. build emlinux-image-compact image

```
$ bitbake emlinux-image-compact
```

# Test result

I confirmed that emlinux-image-compact builds successfully without errors.  
Specifically, I verified that the following error during do_make_emlinux_compact_rootfs is no longer output: 

```
Log data follows:
| DEBUG: Executing python function do_make_emlinux_compact_rootfs
| NOTE: Create compact image
| DEBUG: Executing shell function setup_make_compact_image
| mkdir: cannot create directory ‘/home/build/work/daily_build_emlinux3_compact_image_qemu_arm64_bookworm_latest_dev/build/build-temp/build/tmp/work/emlinux-bookworm-arm64/emlinux-image-compact-qemu-arm64/1.0-r0/rootfs/emlinux-work/’: No such file or directory
| WARNING: exit code 1 from a shell command.
| DEBUG: Python function do_make_emlinux_compact_rootfs finished
```