### PR TITLE
docker: Add packages to used by ca-certificates_debian.bb

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,8 @@ RUN apt-get install --fix-missing -y \
   python-is-python3 \
   python3-yaml \
   python3-html5lib \
-  python3-requests
+  python3-requests \
+  python3-cryptography
 
 RUN useradd -s /bin/bash -m build -u $uid
 RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers


### PR DESCRIPTION
# Purpose of pull request

Add package installation of python3-cryptography module used by meta-debian's ca-certificates_debian.bb.

# Test

## How to test

1. Build and run the Docker container

   ```
   $ ./repos/meta-emlinux/docker/run.sh build
   $ ./repos/meta-emlinux/docker/run.sh
   ```

2. Check installed cryptography module

   Start the Python 3 interpreter.
   ```
   $ python3
   ```

   Check cryptography module.
   ```
   >>> help('cryptography')
   ```

## Test result

The cryptography module is installed.
```
>>> help('cryptography')
Help on package cryptography:

NAME
    cryptography

DESCRIPTION
    # This file is dual licensed under the terms of the Apache License, Version
    # 2.0, and the BSD License. See the LICENSE file in the root of this repository
    # for complete details.

PACKAGE CONTENTS
    __about__
    exceptions
    fernet
    hazmat (package)
    utils
    x509 (package)

DATA
    __all__ = ['__title__', '__summary__', '__uri__', '__version__', '__au...
    __copyright__ = 'Copyright 2013-2019 The cryptography developers'
    __email__ = 'cryptography-dev@python.org'
    __license__ = 'BSD or Apache License, Version 2.0'
    __summary__ = 'cryptography is a package which provides cryptographic ...
    __title__ = 'cryptography'
    __uri__ = 'https://github.com/pyca/cryptography'

VERSION
    2.8

AUTHOR
    The cryptography developers

FILE
    /usr/lib/python3/dist-packages/cryptography/__init__.py
```