### PR TITLE
conf/cve: Add CVE to ignore in EMLinux

### DIFF
--- a/conf/cve/cve_check_ignore.yml
+++ b/conf/cve/cve_check_ignore.yml
@@ -216,6 +216,9 @@ orc:
   all:
     - CVE-2018-8015
     - CVE-2025-47436
+pam:
+  all:
+    - CVE-2025-8941
 perl:
   all:
     - CVE-2004-2286


### PR DESCRIPTION
# Purpose
The following CVE can be ignored.  

* CVE-2025-8941
This is specific to RHEL.

# Test

Compare the above CVE status between before and after applying this update.

On the build host with debian 12 environment, run the following:
```
$ source setup-emlinux build
$ echo 'MACHINE = "qemu-arm64"' >> conf/local.conf
$ bitbake emlinux-image-base                      
$ cve_check.py --image-name emlinux-image-base --output-format text,json --cve-db-predownload
```

Before applying this update, the above CVE is reported as “Unpatched”.

```
$ grep -A1 "CVE: CVE-2025-8941" tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-emlinux-bookworm-qemu-arm64_cve 
CVE: CVE-2025-8941
CVE STATUS: Unpatched
```

After applying this update, the above CVE is reported as “Ignored”.

```
$ grep -A1 "CVE: CVE-2025-8941" tmp/deploy/cve/emlinux-image-base-emlinux-bookworm-qemu-arm64/emlinux-image-base-emlinux-bookworm-qemu-arm64_cve 
CVE: CVE-2025-8941
CVE STATUS: Ignored
```