### PR TITLE
docker: set .netrc UID to match the host user

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     configs:
       - source: host_netrc
         target: /home/build/.netrc
+        uid: $host_user_id
+        mode: 0600
 
 configs:
     host_netrc:


### PR DESCRIPTION
# Purpose of this PR

This fix sets the owner of `~/.netrc` created inside the container to match the host user.

# Testing

### How to test

**Check .netrc owner**
```
(host) $ cd meta-emlinux/docker
(host) $ id -u
(host) $ ./run.sh
(container) $ id
(container) $ ls -aln ~/.netrc 
```

**Try `wget` using the ~/.netrc:**
Add the following to ~/.netrc:
```
machine httpbin.org
login testuser
password testpass
```

Then, `wget` to test service 
```
(container) $ wget https://httpbin.org/basic-auth/testuser/testpass
```


### Result

#### Check .netrc owner

Without this patch:
```
(host) $ id -u
1002

(container) $ id
uid=1002(build) gid=1002(build) groups=1002(build)

(container) $ ls -aln ~/.netrc
-r--r--r-- 1 0 0 1 Sep  7 06:57 /home/build/.netrc
```

With this patch:
```
(host) $ id -u
1002

(container) $ id
uid=1002(build) gid=1002(build) groups=1002(build)

(container) $ ls -aln ~/.netrc
-rw------- 1 1002 1002 1 Sep  7 06:57 /home/build/.netrc
```
Confirmed that the owner of `~/.netrc` match the host user's UID.


#### Try `wget` using the ~/.netrc

Also, confirmed that `wget` using the .netrc succeeded:
```
$ wget https://httpbin.org/basic-auth/testuser/testpass
...
Proxy request sent, awaiting response... 200 OK
Length: 51 [application/json]
Saving to: ‘testpass.1’

testpass.1                           100%[===================================================================>]      51  --.-KB/s    in 0s      

2026-09-07 05:21:45 (16.1 MB/s) - ‘testpass.1’ saved [51/51]
```