### PR TITLE
Update kernel to v4.19.325-cip136

### DIFF
--- a/conf/distro/emlinux.conf
+++ b/conf/distro/emlinux.conf
@@ -3,9 +3,9 @@ require include/emlinux.inc
 DISTRO = "emlinux"
 
 LINUX_GIT_BRANCH ?= "linux-4.19.y-cip"
-LINUX_GIT_SRCREV ?= "ba1643922563de1987b5cb0ed4a4b869ae1c3147"
+LINUX_GIT_SRCREV ?= "596368289cc36e634b7c43a93e9e81b117692845"
 LINUX_CVE_VERSION ??= "4.19.325"
-LINUX_CIP_VERSION ??= "v4.19.325-cip135"
+LINUX_CIP_VERSION ??= "v4.19.325-cip136"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v4.19.325-cip136

This pull request update the kernel to the following cip versions:
v4.19.325-cip136 with hash tag 596368289cc36e634b7c43a93e9e81b117692845
