### PR TITLE
Update kernel to v5.10.268-cip77

### DIFF
--- a/conf/distro/emlinux-k510.conf
+++ b/conf/distro/emlinux-k510.conf
@@ -5,9 +5,9 @@ DISTRO_FEATURES_append = " kernel-510"
 DISTRO_FEATURES_NATIVESDK_append = " kernel-510"
 
 LINUX_GIT_BRANCH ?= "linux-5.10.y-cip"
-LINUX_GIT_SRCREV ?= "50209760a3646d8afaca26d50ca2834df369ade9"
-LINUX_CVE_VERSION ??= "5.10.263"
-LINUX_CIP_VERSION ?= "v5.10.263-cip76"
+LINUX_GIT_SRCREV ?= "2a254b6d597775ce6625a742cdfe7fffd699631c"
+LINUX_CVE_VERSION ??= "5.10.268"
+LINUX_CIP_VERSION ?= "v5.10.268-cip77"
 #
 # If you want to use latest revision of the kernel, append the following line
 # to local.conf


### PR DESCRIPTION
Update kernel to v5.10.268-cip77

This pull request update the kernel to the following cip versions:
v5.10.268-cip77 with hash tag 2a254b6d597775ce6625a742cdfe7fffd699631c
